### PR TITLE
feat(common): migrate remaining 11 list views to ListPageLayout

### DIFF
--- a/src/components/common/ListActionButton.vue
+++ b/src/components/common/ListActionButton.vue
@@ -17,8 +17,8 @@
     :type="rootTag === 'button' ? 'button' : undefined"
     :disabled="rootTag === 'button' ? disabled : undefined"
     :class="buttonClass"
-    :title="label"
-    :aria-label="label"
+    :title="tooltip ?? label"
+    :aria-label="tooltip ?? label"
     @click="onClick"
   >
     <component
@@ -62,6 +62,12 @@ const props = withDefaults(
      * where the icon alone is ambiguous.
      */
     collapseOnMobile?: boolean;
+    /**
+     * Override for the `title` / `aria-label`. Use when the visible label
+     * describes state ("Kanban") but the tooltip should describe action
+     * ("Switch to list view"). Defaults to `label`.
+     */
+    tooltip?: string;
   }>(),
   {
     variant: "secondary",

--- a/src/components/common/ListActionButton.vue
+++ b/src/components/common/ListActionButton.vue
@@ -29,9 +29,11 @@
     />
     <!--
       Label rendered via v-if/v-else so the class string is a static literal
-      Tailwind picks up verbatim. `max-sm:hidden` resolves to a single
-      media-query-wrapped rule with no cascading between `.hidden` and
-      `.sm:inline`.
+      Tailwind picks up verbatim. Previously used a computed `labelClass`
+      returning "hidden sm:inline"; at least one browser was failing to
+      collapse the label at runtime. `max-sm:hidden` is a single utility
+      that resolves to one media-query-wrapped rule — no cascading / order
+      dependency between `hidden` and `sm:inline`.
     -->
     <span v-if="shouldCollapse" class="max-sm:hidden">{{ label }}</span>
     <span v-else>{{ label }}</span>
@@ -126,5 +128,4 @@ const shouldCollapse = computed(() => {
   // label space stops action rows from overflowing on narrow screens.
   return true;
 });
-
 </script>

--- a/src/components/common/ListFilterSelect.vue
+++ b/src/components/common/ListFilterSelect.vue
@@ -2,7 +2,7 @@
   <!--
     Native <select> wrapper for filter rows. Keeps the OS-provided picker
     (which works well on mobile) but normalizes the dark-app styling that
-    was duplicated across many list views.
+    was duplicated across 7 list views.
 
     Consumers pass <option> elements through the default slot so both the
     "empty" placeholder value (often "" or "all") and the order of options
@@ -12,7 +12,9 @@
     :value="modelValue"
     class="bg-card border border-border rounded-md px-2 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring shrink-0"
     :aria-label="ariaLabel"
-    @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
+    @change="
+      emit('update:modelValue', ($event.target as HTMLSelectElement).value)
+    "
   >
     <slot />
   </select>

--- a/src/components/common/ListPageLayout.vue
+++ b/src/components/common/ListPageLayout.vue
@@ -40,9 +40,8 @@
         <!--
           Title + description hidden on <md. AppTopBar renders the page
           title on mobile, so repeating a big h1 here duplicates the label
-          and eats ~70px of vertical space right above the action row.
-          Desktop is unchanged — `md:block md:flex-1 md:min-w-0` makes
-          the wrapper a proper flex item at ≥md.
+          and eats ~70px of vertical space right above the action row that
+          users would rather spend on the list itself.
         -->
         <div class="hidden md:block md:min-w-0 md:flex-1">
           <h1

--- a/src/components/layout/AppMobileNav.vue
+++ b/src/components/layout/AppMobileNav.vue
@@ -22,9 +22,11 @@
         </button>
       </div>
 
-      <!-- Navigation -->
+      <!-- Navigation — `desktopOnly` groups (e.g. "Publish") are filtered
+           out because their tools target letter/A4 output that's unusable
+           on a phone. The desktop sidebar still shows them. -->
       <nav class="flex-1 overflow-y-auto px-2 py-4">
-        <template v-for="group in NAV_GROUPS" :key="group.label">
+        <template v-for="group in mobileNavGroups" :key="group.label">
           <p
             class="px-2 pt-4 pb-1 font-cinzel text-[10px] font-bold tracking-widest text-muted-foreground/60 uppercase first:pt-0"
           >
@@ -77,6 +79,8 @@ const router = useRouter();
 
 const userEmail = computed(() => auth.userEmail ?? "");
 const userInitial = computed(() => userEmail.value.charAt(0).toUpperCase() || "?");
+
+const mobileNavGroups = computed(() => NAV_GROUPS.filter((g) => !g.desktopOnly));
 
 async function handleSignOut() {
   ui.toggleMobileNav();

--- a/src/composables/usePullToRefresh.ts
+++ b/src/composables/usePullToRefresh.ts
@@ -1,7 +1,8 @@
 import { onMounted, onUnmounted, ref } from "vue";
 
-const THRESHOLD = 72;   // px of pull needed to trigger reload
-const MAX_PULL  = 96;   // max visual travel of the indicator
+const THRESHOLD     = 72;   // px of pull needed to trigger reload
+const MAX_PULL      = 96;   // max visual travel of the indicator
+const TOP_ZONE      = 64;   // touch must start within this many px of the top of the screen
 
 // Walk up the DOM to find the first element that actually scrolls.
 function scrollableAncestor(el: Element | null): Element {
@@ -18,20 +19,25 @@ export function usePullToRefresh() {
   const readyToReload = ref(false);
 
   let startY    = 0;
+  let eligible  = false;   // true only when touch started in the top zone at scrollTop 0
   let pulling   = false;
   let container: Element | null = null;
 
   function onTouchStart(e: TouchEvent) {
+    const touchY = e.touches[0].clientY;
     container = scrollableAncestor(e.target as Element);
-    if (container.scrollTop > 2) return;          // not at the top — ignore
-    startY  = e.touches[0].clientY;
+    // Only arm pull-to-refresh when the finger starts at the very top of the screen
+    // AND the scrollable container is already at the top.
+    eligible = touchY <= TOP_ZONE && container.scrollTop <= 2;
+    if (!eligible) return;
+    startY  = touchY;
     pulling = false;
     pullPx.value = 0;
     readyToReload.value = false;
   }
 
   function onTouchMove(e: TouchEvent) {
-    if (!container || container.scrollTop > 2) return;
+    if (!eligible || !container || container.scrollTop > 2) return;
     const delta = e.touches[0].clientY - startY;
     if (delta <= 4) return;
 
@@ -50,6 +56,7 @@ export function usePullToRefresh() {
       window.location.reload();
       return;
     }
+    eligible = false;
     pulling = false;
     pullPx.value = 0;
     readyToReload.value = false;

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -35,6 +35,12 @@ export interface NavItem {
 export interface NavGroup {
   label: string;
   items: NavItem[];
+  /**
+   * Hide this group on mobile (<md). Use for tools that target letter/A4
+   * output (Scriptorium, Card Forge, The Mint) where the editing surface
+   * is impractical on a phone-sized viewport.
+   */
+  desktopOnly?: boolean;
 }
 
 export const NAV_GROUPS: NavGroup[] = [
@@ -173,6 +179,7 @@ export const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "Publish",
+    desktopOnly: true, // A4/letter-output tools — unusable on phone-sized viewports
     items: [
       {
         label: "Scriptorium",

--- a/src/views/HallOfHeroesView.vue
+++ b/src/views/HallOfHeroesView.vue
@@ -1,50 +1,31 @@
 <template>
-  <PageHeader title="Hall of Heroes" description="Iconic characters importable into any campaign">
-    <template #actions>
-      <template v-if="isAppAdmin">
-        <button
-          type="button"
-          :disabled="populateMutation.isPending.value"
-          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 disabled:opacity-50 transition-colors"
-          @click="handlePopulate"
-        >
-          <Sparkles class="h-3.5 w-3.5" />
-          {{ populateLabel }}
-        </button>
-        <RouterLink
-          to="/hall-of-heroes/new"
-          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold tracking-wider text-primary-foreground hover:opacity-90 transition-opacity"
-        >
-          <Plus class="h-3.5 w-3.5" />
-          New Hero
-        </RouterLink>
-      </template>
+  <ListPageLayout title="Hall of Heroes" description="Iconic characters importable into any campaign">
+    <template v-if="isAppAdmin" #actions>
+      <ListActionButton
+        :icon="Sparkles"
+        :label="populateLabel"
+        :disabled="populateMutation.isPending.value"
+        @click="handlePopulate"
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Hero"
+        variant="primary"
+        to="/hall-of-heroes/new"
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex gap-2 flex-wrap">
-        <input
-          v-model="search"
-          type="search"
-          placeholder="Search heroes…"
-          class="h-8 flex-1 min-w-40 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-        />
-        <select
-          v-model="settingFilter"
-          class="h-8 rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="hasActiveFilters"
+        @clear="clearFilters"
+      >
+        <ListSearchInput v-model="search" placeholder="Search heroes…" />
+        <ListFilterSelect v-model="settingFilter" aria-label="Setting filter">
           <option value="all">All Settings</option>
           <option v-for="s in SETTINGS" :key="s.value" :value="s.value">{{ s.label }}</option>
-        </select>
-        <button
-          v-if="hasActiveFilters"
-          type="button"
-          class="h-8 rounded-md border border-border px-3 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
-          @click="clearFilters"
-        >
-          Clear
-        </button>
-      </div>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <div v-if="isLoading" class="flex justify-center py-16">
@@ -76,7 +57,6 @@
         :key="hero.id"
         class="group relative flex flex-col overflow-hidden rounded-lg border border-border bg-card transition-shadow hover:shadow-md"
       >
-        <!-- Portrait + Info (clickable) -->
         <RouterLink :to="`/hall-of-heroes/${hero.id}`" class="flex flex-1 flex-col">
           <div class="relative h-36 shrink-0 overflow-hidden bg-muted">
             <FocalImage
@@ -94,14 +74,12 @@
               {{ hero.name.charAt(0) }}
             </div>
 
-            <!-- Setting badge -->
             <span
               class="absolute top-2 left-2 rounded-full bg-black/60 px-2 py-0.5 font-cinzel text-[10px] font-semibold tracking-wider text-white uppercase backdrop-blur-sm"
             >
               {{ settingLabel(hero.setting) }}
             </span>
 
-            <!-- Campaign-match indicator -->
             <span
               v-if="campaignSetting && hero.setting === campaignSetting"
               class="absolute top-2 right-2 rounded-full bg-primary/80 px-1.5 py-0.5 font-cinzel text-[9px] font-semibold tracking-wider text-primary-foreground uppercase backdrop-blur-sm"
@@ -127,7 +105,6 @@
           </div>
         </RouterLink>
 
-        <!-- Actions -->
         <div class="flex items-center gap-2 border-t border-border px-3 py-2">
           <button
             type="button"
@@ -160,10 +137,12 @@
       </div>
     </div>
 
-    <p v-if="filtered.length" class="mt-4 text-center font-fell text-xs text-muted-foreground">
-      {{ filtered.length }} of {{ heroes?.length ?? 0 }} heroes
-    </p>
-  </PageHeader>
+    <template v-if="filtered.length" #footer>
+      <p class="text-center font-fell text-xs text-muted-foreground">
+        {{ filtered.length }} of {{ heroes?.length ?? 0 }} heroes
+      </p>
+    </template>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
@@ -174,7 +153,11 @@ import { useHallOfHeroes, useDeleteHero, useImportHero, usePopulateAllSettingHer
 import { useAuthStore } from "@/stores/auth";
 import { useCampaignStore } from "@/stores/campaign";
 import { useUiStore } from "@/stores/ui";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
 import FocalImage from "@/components/common/FocalImage.vue";
@@ -255,7 +238,6 @@ const filtered = computed(() => {
     list = list.filter((h) => h.setting === settingFilter.value);
   }
 
-  // Sort: campaign-setting matches first, then alphabetical
   const cs = campaignSetting.value;
   if (cs) {
     list = [...list].sort((a, b) => {

--- a/src/views/crafting/CraftingView.vue
+++ b/src/views/crafting/CraftingView.vue
@@ -1,31 +1,27 @@
 <template>
-  <PageHeader
+  <ListPageLayout
     title="Workshop"
     description="Create recipes and share them with your players"
   >
     <template #actions>
-      <button
+      <ListActionButton
+        :icon="importMutation.isPending.value ? Loader2 : Download"
+        :label="importStatusLabel"
         :disabled="importMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md bg-muted border border-border px-4 py-2 font-cinzel text-xs font-semibold text-muted-foreground tracking-wider hover:text-foreground hover:border-border/80 disabled:opacity-50 transition-colors"
-        :title="importStatusLabel"
         @click="handleImport"
-      >
-        <Download class="h-3.5 w-3.5" />
-        {{ importStatusLabel }}
-      </button>
-      <button
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-        @click="$router.push('/crafting/new')"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Recipe
-      </button>
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Recipe"
+        variant="primary"
+        to="/crafting/new"
+      />
     </template>
 
-    <!-- Discipline tabs -->
-    <div class="flex flex-wrap gap-1 mb-6 rounded-md border border-border p-1 bg-muted w-fit">
+    <!-- Discipline tabs (body content) -->
+    <div class="flex flex-wrap gap-1 mb-6 rounded-md border border-border p-1 bg-muted w-fit max-w-full overflow-x-auto">
       <button
-        class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-cinzel tracking-wide transition-colors"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-cinzel tracking-wide transition-colors shrink-0"
         :class="ui.workshopActiveTab === 'all'
           ? 'bg-card text-foreground shadow-sm'
           : 'text-muted-foreground hover:text-foreground'"
@@ -37,7 +33,7 @@
       <button
         v-for="d in CRAFTING_DISCIPLINES"
         :key="d.id"
-        class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-cinzel tracking-wide transition-colors"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-cinzel tracking-wide transition-colors shrink-0"
         :class="ui.workshopActiveTab === d.id
           ? 'bg-card text-foreground shadow-sm'
           : 'text-muted-foreground hover:text-foreground'"
@@ -118,14 +114,15 @@
         </div>
       </div>
     </div>
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
-import { Download, LayoutList, Pencil, Plus, Trash2 } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Download, LayoutList, Loader2, Pencil, Plus, Trash2 } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
 import { CRAFTING_DISCIPLINES, getDiscipline } from "@/lib/crafting-disciplines";
 import { useCraftingRecipes, useDeleteRecipe, useImportStarterRecipes } from "@/composables/useCrafting";
 import { useConfirm } from "@/composables/useConfirm";

--- a/src/views/crafting/CraftingView.vue
+++ b/src/views/crafting/CraftingView.vue
@@ -65,31 +65,57 @@
       </div>
 
       <div v-else class="grid gap-3">
+        <!--
+          Recipe card restructured so it can't grow wider than its
+          container. Previously the name + tag pills sat in a single flex
+          row with no wrap: enough tags (discipline + PROF + TOOLS)
+          pushed the whole card past the viewport on mobile.
+
+          New layout: name on its own line (truncates), tags wrap onto a
+          second line, meta (DC + time) on a third. On mobile the tag
+          labels collapse to their icons via `max-sm:hidden` so a recipe
+          with all three tags still fits on one row below the name.
+        -->
         <div
           v-for="recipe in disciplineRecipes"
           :key="recipe.id"
-          class="rounded-lg border border-border bg-card px-4 py-3 flex items-center gap-3 hover:border-border/80 transition-colors"
+          class="rounded-lg border border-border bg-card px-4 py-3 flex items-start gap-3 hover:border-border/80 transition-colors"
         >
-          <!-- Left: name + meta -->
+          <!-- Left: name + tags + meta -->
           <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
-              <p class="font-cinzel text-sm font-bold text-foreground truncate">{{ recipe.name }}</p>
+            <p class="font-cinzel text-sm font-bold text-foreground truncate">{{ recipe.name }}</p>
+
+            <div
+              v-if="!activeDiscipline || recipe.requires_proficiency || recipe.requires_tools"
+              class="flex flex-wrap items-center gap-1.5 mt-1"
+            >
               <span
                 v-if="!activeDiscipline"
-                class="shrink-0 font-cinzel text-[10px] tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
-              >{{ getDiscipline(recipe.discipline).label }}</span>
+                class="inline-flex items-center gap-1 shrink-0 font-cinzel text-[10px] tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
+                :title="getDiscipline(recipe.discipline).label"
+              >
+                <component :is="getDiscipline(recipe.discipline).icon" class="h-3 w-3" />
+                <span class="max-sm:hidden">{{ getDiscipline(recipe.discipline).label }}</span>
+              </span>
               <span
                 v-if="recipe.requires_proficiency"
-                class="shrink-0 font-cinzel text-[10px] tracking-wider px-1.5 py-0.5 rounded border border-destructive/40 text-destructive bg-destructive/10"
+                class="inline-flex items-center gap-1 shrink-0 font-cinzel text-[10px] tracking-wider px-1.5 py-0.5 rounded border border-destructive/40 text-destructive bg-destructive/10"
                 title="Requires tool proficiency"
-              >PROF</span>
+              >
+                <Award class="h-3 w-3" />
+                <span class="max-sm:hidden">PROF</span>
+              </span>
               <span
                 v-if="recipe.requires_tools"
-                class="shrink-0 font-cinzel text-[10px] tracking-wider px-1.5 py-0.5 rounded border border-destructive/40 text-destructive bg-destructive/10"
+                class="inline-flex items-center gap-1 shrink-0 font-cinzel text-[10px] tracking-wider px-1.5 py-0.5 rounded border border-destructive/40 text-destructive bg-destructive/10"
                 title="Requires physical tools"
-              >TOOLS</span>
+              >
+                <Wrench class="h-3 w-3" />
+                <span class="max-sm:hidden">TOOLS</span>
+              </span>
             </div>
-            <p class="font-fell text-xs text-muted-foreground">
+
+            <p class="font-fell text-xs text-muted-foreground mt-1">
               DC {{ recipe.dc }} · {{ recipe.crafting_time }} {{ recipe.crafting_time !== 1 ? recipe.crafting_time_unit : recipe.crafting_time_unit.replace(/s$/, '') }}
             </p>
           </div>
@@ -120,7 +146,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
-import { Download, LayoutList, Loader2, Pencil, Plus, Trash2 } from "lucide-vue-next";
+import { Award, Download, LayoutList, Loader2, Pencil, Plus, Trash2, Wrench } from "lucide-vue-next";
 import ListPageLayout from "@/components/common/ListPageLayout.vue";
 import ListActionButton from "@/components/common/ListActionButton.vue";
 import { CRAFTING_DISCIPLINES, getDiscipline } from "@/lib/crafting-disciplines";

--- a/src/views/encounters/EncountersView.vue
+++ b/src/views/encounters/EncountersView.vue
@@ -1,62 +1,56 @@
 <template>
-  <PageHeader title="Encounters" description="Build and run combat encounters">
+  <ListPageLayout title="Encounters" description="Build and run combat encounters">
     <template #actions>
-      <RouterLink
+      <ListActionButton
+        :icon="Plus"
+        label="New Encounter"
+        variant="primary"
         to="/encounters/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        New Encounter
-      </RouterLink>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex items-center gap-2">
-        <div class="relative flex-1 min-w-48">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="ui.encountersSearch"
-            type="text"
-            placeholder="Search encounters…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-        <select
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="ui.encountersHasActiveFilters"
+        @clear="ui.resetEncountersFilters()"
+      >
+        <ListSearchInput v-model="ui.encountersSearch" placeholder="Search encounters…" />
+        <ListFilterSelect
           v-model="ui.encountersFilterQuestId"
-          class="bg-card border border-border rounded-md px-2 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          aria-label="Quest filter"
         >
           <option value="all">All quests</option>
           <option value="unassigned">Unassigned</option>
           <option v-for="q in quests" :key="q.id" :value="q.id">{{ q.title }}</option>
-        </select>
-        <button
-          type="button"
-          class="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-md border font-cinzel text-xs tracking-wider transition-colors"
-          :class="ui.encountersHideFinished
-            ? 'border-primary/40 bg-primary/10 text-primary'
-            : 'border-border text-muted-foreground hover:text-foreground'"
+        </ListFilterSelect>
+        <!--
+          Active/All toggle — the CheckCheck icon alone is ambiguous between
+          the two states, so the visible label carries the "Active" / "All"
+          information. Tooltip describes the action the next tap would take.
+          Primary variant when filtering-to-active so it reads as "on".
+        -->
+        <ListActionButton
+          :icon="CheckCheck"
+          :label="ui.encountersHideFinished ? 'Active' : 'All'"
+          :collapse-on-mobile="false"
+          :tooltip="ui.encountersHideFinished ? 'Show all encounters' : 'Hide finished encounters'"
+          :variant="ui.encountersHideFinished ? 'primary' : 'ghost'"
           @click="ui.encountersHideFinished = !ui.encountersHideFinished"
-        >
-          <CheckCheck class="h-3.5 w-3.5" />
-          {{ ui.encountersHideFinished ? 'Active only' : 'All' }}
-        </button>
-        <button
-          v-if="ui.encountersHasActiveFilters"
-          type="button"
-          class="shrink-0 px-2.5 py-1.5 rounded-md border border-border bg-card font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
-          @click="ui.resetEncountersFilters()"
-        >
-          Clear
-        </button>
-      </div>
+        />
+      </ListFilterBar>
     </template>
 
     <EncounterList />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
-import { Search, CheckCheck } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Plus, CheckCheck } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import EncounterList from "@/components/encounters/EncounterList.vue";
 import { useUiStore } from "@/stores/ui";
 import { useAllQuests } from "@/composables/useQuests";

--- a/src/views/factions/FactionListView.vue
+++ b/src/views/factions/FactionListView.vue
@@ -1,53 +1,32 @@
 <template>
-  <PageHeader title="Factions" description="Guilds, cults, governments, and other organisations">
+  <ListPageLayout title="Factions" description="Guilds, cults, governments, and other organisations">
     <template #actions>
-      <button
+      <ListActionButton
         v-if="hasSetting"
-        type="button"
+        :icon="Sparkles"
+        :label="populateStatusLabel"
         :disabled="populateMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 disabled:opacity-50 transition-colors"
-        :title="populateStatusLabel"
         @click="handlePopulate"
-      >
-        <Sparkles class="h-3.5 w-3.5" />
-        {{ populateStatusLabel }}
-      </button>
-      <RouterLink
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Faction"
+        variant="primary"
         to="/factions/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Faction
-      </RouterLink>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex flex-wrap items-center gap-2">
-        <div class="relative flex-1 min-w-40">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="ui.factionsSearch"
-            type="text"
-            placeholder="Filter factions…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-        <select
-          v-model="ui.factionsFilterType"
-          class="bg-card border border-border rounded-md px-2 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="ui.factionsHasActiveFilters"
+        @clear="ui.resetFactionsFilters()"
+      >
+        <ListSearchInput v-model="ui.factionsSearch" placeholder="Filter factions…" />
+        <ListFilterSelect v-model="ui.factionsFilterType" aria-label="Faction type filter">
           <option value="">All types</option>
           <option v-for="t in FACTION_TYPES" :key="t" :value="t">{{ t }}</option>
-        </select>
-        <button
-          v-if="ui.factionsHasActiveFilters"
-          type="button"
-          class="px-2.5 py-1.5 rounded-md border border-border bg-card font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
-          @click="ui.resetFactionsFilters()"
-        >
-          Clear
-        </button>
-      </div>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <div v-if="isLoading" class="flex justify-center py-16">
@@ -68,7 +47,6 @@
           :to="`/factions/${faction.id}`"
           class="group flex items-center gap-3 rounded-lg border border-border bg-card hover:border-primary/50 transition-colors p-4"
         >
-          <!-- Emblem / placeholder -->
           <div class="shrink-0 h-12 w-12 rounded-lg border border-border bg-muted overflow-hidden flex items-center justify-center">
             <img v-if="faction.emblem_url" :src="faction.emblem_url" alt="" class="w-full h-full object-cover" />
             <Shield v-else class="h-5 w-5 text-muted-foreground/40" />
@@ -95,18 +73,22 @@
         </RouterLink>
       </div>
     </template>
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { Plus, Shield, ChevronRight, Eye, Search, Sparkles } from "lucide-vue-next";
+import { Plus, Shield, ChevronRight, Eye, Sparkles } from "lucide-vue-next";
 import { useAllFactions, usePopulateFactions } from "@/composables/useFactions";
 import { FACTION_TYPES } from "@/types/faction.types";
 import { useUiStore } from "@/stores/ui";
 import { useCampaignStore } from "@/stores/campaign";
 import { getSetting } from "@/settings/index";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
 

--- a/src/views/items/ItemsView.vue
+++ b/src/views/items/ItemsView.vue
@@ -1,84 +1,58 @@
 <template>
-  <PageHeader title="Vault" description="Your mundane equipment and magic items">
+  <ListPageLayout title="Vault" description="Your mundane equipment and magic items">
     <template #actions>
-      <button
-        type="button"
+      <ListActionButton
+        :icon="importMutation.isPending.value ? Loader2 : Download"
+        :label="importStatusLabel"
         :disabled="importMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
         @click="handleImport"
-      >
-        <Loader2 v-if="importMutation.isPending.value" class="size-3.5 animate-spin shrink-0" />
-        <Download v-else class="size-3.5 shrink-0" />
-        {{ importStatusLabel }}
-      </button>
-      <button
-        type="button"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
+      />
+      <ListActionButton
+        :icon="Sparkles"
+        label="Generate"
         @click="ui.itemGeneratorOpen = true"
-      >
-        <Sparkles class="size-3.5 shrink-0" />
-        Generate
-      </button>
-      <RouterLink
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Item"
+        variant="primary"
         to="/vault/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        + New Item
-      </RouterLink>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex items-center gap-2 flex-wrap">
-        <div class="relative flex-1 min-w-40">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="search"
-            type="text"
-            placeholder="Search items…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-        <select
-          v-model="typeFilter"
-          class="bg-card border border-border rounded-md px-2 py-1.5 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="hasActiveFilters"
+        @clear="clearFilters"
+      >
+        <ListSearchInput v-model="search" placeholder="Search items…" />
+        <ListFilterSelect v-model="typeFilter" aria-label="Item type filter">
           <option value="">All types</option>
           <option v-for="t in ITEM_TYPES" :key="t" :value="t">{{ ITEM_TYPE_LABELS[t] }}</option>
-        </select>
-        <select
-          v-model="rarityFilter"
-          class="bg-card border border-border rounded-md px-2 py-1.5 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+        </ListFilterSelect>
+        <ListFilterSelect v-model="rarityFilter" aria-label="Rarity filter">
           <option value="">All rarities</option>
           <option v-for="r in ITEM_RARITIES" :key="r" :value="r">{{ ITEM_RARITY_LABELS[r] }}</option>
-        </select>
-        <select
-          v-if="sources?.length"
-          v-model="sourceFilter"
-          class="bg-card border border-border rounded-md px-2 py-1.5 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+        </ListFilterSelect>
+        <ListFilterSelect v-if="sources?.length" v-model="sourceFilter" aria-label="Source filter">
           <option value="">All sources</option>
           <option v-for="s in sources" :key="s.slug" :value="s.slug">{{ itemSourceLabel(s.slug, s.title) }}</option>
-        </select>
-        <button
-          v-if="hasActiveFilters"
-          type="button"
-          class="px-2.5 py-1.5 rounded-md border border-border bg-card font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
-          @click="clearFilters"
-        >
-          Clear
-        </button>
-      </div>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <ItemList :search="search" :type-filter="typeFilter" :rarity-filter="rarityFilter" :source-filter="sourceFilter" />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { Loader2, Download, Search, Sparkles } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Plus, Loader2, Download, Sparkles } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import ItemList from "@/components/items/ItemList.vue";
 import { useImportSrdItems, useItemSources } from "@/composables/useItems";
 import { ITEM_TYPES, ITEM_TYPE_LABELS, ITEM_RARITIES, ITEM_RARITY_LABELS, itemSourceLabel } from "@/types/item.types";

--- a/src/views/locations/LocationsView.vue
+++ b/src/views/locations/LocationsView.vue
@@ -1,66 +1,50 @@
 <template>
-  <PageHeader
+  <ListPageLayout
     title="Atlas"
     description="Continents, cities, dungeons, and every place in between"
   >
     <template #actions>
-      <button
-        type="button"
+      <ListActionButton
+        :icon="planarMutation.isPending.value ? Loader2 : Globe"
+        :label="planarStatusLabel"
         :disabled="planarMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
         @click="handlePopulatePlanes"
-      >
-        <Loader2 v-if="planarMutation.isPending.value" class="size-3.5 animate-spin shrink-0" />
-        <Globe v-else class="size-3.5 shrink-0" />
-        {{ planarStatusLabel }}
-      </button>
-      <button
-        type="button"
+      />
+      <ListActionButton
+        :icon="populateMutation.isPending.value ? Loader2 : MapPin"
+        :label="populateStatusLabel"
         :disabled="populateMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
         @click="handlePopulate"
-      >
-        <Loader2 v-if="populateMutation.isPending.value" class="size-3.5 animate-spin shrink-0" />
-        <MapPin v-else class="size-3.5 shrink-0" />
-        {{ populateStatusLabel }}
-      </button>
-      <RouterLink
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Location"
+        variant="primary"
         to="/locations/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Location
-      </RouterLink>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex items-center gap-2">
-        <div class="relative flex-1 min-w-48">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="search"
-            type="text"
-            placeholder="Search locations…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-        <select
-          v-model="typeFilter"
-          class="bg-card border border-border rounded-md px-2 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+    <template #filters>
+      <ListFilterBar>
+        <ListSearchInput v-model="search" placeholder="Search locations…" />
+        <ListFilterSelect v-model="typeFilter" aria-label="Location type filter">
           <option v-for="opt in TYPE_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
-        </select>
-      </div>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <LocationList :search="search" :type-filter="typeFilter" />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { Plus, Loader2, MapPin, Globe, Search } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Plus, Loader2, MapPin, Globe } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LocationList from "@/components/locations/LocationList.vue";
 import { usePopulateLocations, usePopulatePlanarLocations } from "@/composables/useLocations";
 import { LOCATION_TYPE_LABELS } from "@/types/location.types";

--- a/src/views/npcs/NpcWebView.vue
+++ b/src/views/npcs/NpcWebView.vue
@@ -87,7 +87,7 @@
         :edges="graphEdges"
         :configs="graphConfigs"
         :event-handlers="eventHandlers"
-        class="w-full h-full select-none"
+        class="w-full h-full select-none touch-none"
       />
 
       <!-- Link mode hint -->

--- a/src/views/puzzles/PuzzlesView.vue
+++ b/src/views/puzzles/PuzzlesView.vue
@@ -1,29 +1,36 @@
 <template>
-  <PageHeader title="Enigmarium" description="Puzzle rooms, riddles & dungeon conundrums">
+  <ListPageLayout title="Enigmarium" description="Puzzle rooms, riddles & dungeon conundrums">
     <template #actions>
-      <button
-        type="button"
+      <ListActionButton
+        :icon="populateMutation.isPending.value ? Loader2 : BookOpen"
+        :label="populateStatusLabel"
         :disabled="populateMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
         @click="handlePopulate"
-      >
-        <Loader2 v-if="populateMutation.isPending.value" class="size-3.5 animate-spin shrink-0" />
-        <BookOpen v-else class="size-3.5 shrink-0" />
-        {{ populateStatusLabel }}
-      </button>
-      <button
-        class="inline-flex items-center gap-1.5 font-cinzel text-xs font-semibold px-3 py-1.5 rounded-md border border-border bg-card text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
+      />
+      <ListActionButton
+        :icon="Sparkles"
+        label="Generate"
         @click="ui.puzzleGeneratorOpen = true"
-      >
-        <Sparkles class="size-3.5 shrink-0" />
-        Generate
-      </button>
-      <button
-        class="font-cinzel text-xs font-semibold px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+      />
+      <ListActionButton
+        label="New Puzzle"
+        variant="primary"
         @click="router.push('/puzzles/new')"
-      >
-        New Puzzle
-      </button>
+      />
+    </template>
+
+    <template v-if="puzzles?.length" #filters>
+      <ListFilterBar>
+        <ListSearchInput v-model="search" placeholder="Search puzzles…" />
+        <ListFilterSelect v-model="typeFilter" aria-label="Puzzle type filter">
+          <option value="">All Types</option>
+          <option v-for="t in PUZZLE_TYPES" :key="t" :value="t">{{ t }}</option>
+        </ListFilterSelect>
+        <ListFilterSelect v-model="difficultyFilter" aria-label="Difficulty filter">
+          <option value="">All Difficulties</option>
+          <option v-for="d in PUZZLE_DIFFICULTIES" :key="d" :value="d">{{ d }}</option>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <div v-if="isLoading" class="flex justify-center py-16">
@@ -31,35 +38,10 @@
     </div>
 
     <template v-else-if="puzzles?.length">
-      <!-- Filters -->
-      <div class="flex flex-wrap items-center gap-2 mb-4">
-        <input
-          v-model="search"
-          type="search"
-          placeholder="Search puzzles…"
-          class="flex-1 min-w-40 bg-card border border-border rounded-md px-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        />
-        <select
-          v-model="typeFilter"
-          class="bg-card border border-border rounded-md px-3 py-1.5 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <option value="">All Types</option>
-          <option v-for="t in PUZZLE_TYPES" :key="t" :value="t">{{ t }}</option>
-        </select>
-        <select
-          v-model="difficultyFilter"
-          class="bg-card border border-border rounded-md px-3 py-1.5 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <option value="">All Difficulties</option>
-          <option v-for="d in PUZZLE_DIFFICULTIES" :key="d" :value="d">{{ d }}</option>
-        </select>
-      </div>
-
       <p v-if="!filtered.length" class="text-center font-fell text-sm text-muted-foreground italic py-8">
         No puzzles match your filter.
       </p>
 
-      <!-- Grid -->
       <div v-else class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
         <RouterLink
           v-for="puzzle in filtered"
@@ -67,7 +49,6 @@
           :to="`/puzzles/${puzzle.id}`"
           class="flex flex-col rounded-lg border border-border bg-card overflow-hidden hover:border-primary/50 transition-colors group"
         >
-          <!-- Image / placeholder -->
           <div class="relative aspect-square bg-muted overflow-hidden shrink-0">
             <FocalImage
               v-if="puzzle.image_url"
@@ -80,19 +61,16 @@
             <div v-else class="w-full h-full flex items-center justify-center text-muted-foreground/20">
               <PuzzleIcon class="h-10 w-10" />
             </div>
-            <!-- Type badge -->
             <span
               class="absolute top-2 left-2 font-cinzel text-[9px] px-1.5 py-0.5 rounded tracking-wider text-white font-bold"
               :style="{ backgroundColor: PUZZLE_TYPE_COLORS[puzzle.puzzle_type] + 'DD' }"
             >{{ puzzle.puzzle_type }}</span>
-            <!-- Difficulty badge -->
             <span
               class="absolute bottom-2 right-2 font-cinzel text-[9px] px-1.5 py-0.5 rounded tracking-wider text-white font-bold"
               :style="{ backgroundColor: PUZZLE_DIFFICULTY_COLORS[puzzle.difficulty] + 'DD' }"
             >{{ puzzle.difficulty }}</span>
           </div>
 
-          <!-- Info -->
           <div class="p-2.5 flex flex-col gap-0.5">
             <h3 class="font-cinzel text-sm font-bold text-foreground leading-tight truncate">{{ puzzle.name }}</h3>
             <div class="flex items-center gap-2">
@@ -116,7 +94,7 @@
       action-label="New Puzzle"
       @action="router.push('/puzzles/new')"
     />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
@@ -126,7 +104,11 @@ import { Puzzle as PuzzleIcon, Loader2, BookOpen, Sparkles } from "lucide-vue-ne
 import { usePuzzles, usePopulatePuzzles } from "@/composables/usePuzzles";
 import { PUZZLE_TYPES, PUZZLE_DIFFICULTIES, PUZZLE_TYPE_COLORS, PUZZLE_DIFFICULTY_COLORS } from "@/types/puzzle.types";
 import { useUiStore } from "@/stores/ui";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import FocalImage from "@/components/common/FocalImage.vue";
 import EmptyState from "@/components/common/EmptyState.vue";

--- a/src/views/quests/QuestsView.vue
+++ b/src/views/quests/QuestsView.vue
@@ -1,54 +1,46 @@
 <template>
-  <PageHeader title="Quest Log" description="Track active quests, side jobs, and completed adventures">
+  <ListPageLayout title="Quest Log" description="Track active quests, side jobs, and completed adventures">
     <template #actions>
-      <RouterLink
+      <ListActionButton
+        :icon="Plus"
+        label="New Quest"
+        variant="primary"
         to="/quests/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Quest
-      </RouterLink>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex items-center gap-2">
-        <div class="relative flex-1">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="ui.questsSearch"
-            type="text"
-            placeholder="Search quests…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-        <button
-          type="button"
-          :title="ui.questsIsKanban ? 'Switch to list view' : 'Switch to kanban view'"
-          class="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border bg-card text-muted-foreground hover:text-foreground transition-colors"
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="ui.questsHasActiveFilters"
+        @clear="ui.resetQuestsFilters()"
+      >
+        <ListSearchInput v-model="ui.questsSearch" placeholder="Search quests…" />
+        <!--
+          View-toggle — reuses ListActionButton for consistent styling. Label
+          stays visible on mobile because it complements the icon (without
+          it the icon alone is ambiguous between Kanban/List).
+        -->
+        <ListActionButton
+          :icon="ui.questsIsKanban ? Columns2 : LayoutList"
+          :label="ui.questsIsKanban ? 'Kanban' : 'List'"
+          :collapse-on-mobile="false"
+          variant="ghost"
+          :tooltip="ui.questsIsKanban ? 'Switch to list view' : 'Switch to kanban view'"
           @click="ui.questsIsKanban = !ui.questsIsKanban"
-        >
-          <Columns2 v-if="ui.questsIsKanban" class="h-3.5 w-3.5" />
-          <LayoutList v-else class="h-3.5 w-3.5" />
-          <span class="font-cinzel text-[10px] font-semibold tracking-wider">{{ ui.questsIsKanban ? 'Kanban' : 'List' }}</span>
-        </button>
-        <button
-          v-if="ui.questsHasActiveFilters"
-          type="button"
-          class="shrink-0 px-2.5 py-1.5 rounded-md border border-border bg-card font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
-          @click="ui.resetQuestsFilters()"
-        >
-          Clear
-        </button>
-      </div>
+        />
+      </ListFilterBar>
     </template>
 
     <QuestList />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
-import { Plus, Search, Columns2, LayoutList } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Plus, Columns2, LayoutList } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import QuestList from "@/components/quests/QuestList.vue";
 import { useUiStore } from "@/stores/ui";
 

--- a/src/views/rules/RulesView.vue
+++ b/src/views/rules/RulesView.vue
@@ -1,22 +1,24 @@
 <template>
-  <PageHeader title="Rules Reliquary" description="DM screen, SRD compendium & custom rule systems">
+  <ListPageLayout title="Rules Reliquary" description="DM screen, SRD compendium & custom rule systems">
     <template #actions>
-      <RouterLink
+      <ListActionButton
         v-if="activeTab === 'custom'"
+        :icon="Plus"
+        label="New Rule"
+        variant="primary"
         to="/rules/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Rule
-      </RouterLink>
+      />
     </template>
 
-    <!-- Tab bar -->
-    <div class="flex gap-1 mb-6 border-b border-border">
+    <!--
+      Tab bar lives in the body because it's not a single-choice filter —
+      each tab renders entirely different content. Scrolls with the body.
+    -->
+    <div class="flex gap-1 mb-6 border-b border-border overflow-x-auto">
       <button
         v-for="tab in TABS"
         :key="tab.id"
-        class="flex items-center gap-1.5 px-4 py-2.5 font-cinzel text-xs font-semibold tracking-wider border-b-2 -mb-px transition-colors"
+        class="flex items-center gap-1.5 px-4 py-2.5 font-cinzel text-xs font-semibold tracking-wider border-b-2 -mb-px transition-colors shrink-0"
         :class="activeTab === tab.id
           ? 'border-primary text-primary'
           : 'border-transparent text-muted-foreground hover:text-foreground'"
@@ -30,13 +32,14 @@
     <ScreenTab v-if="activeTab === 'screen'" />
     <CompendiumTab v-else-if="activeTab === 'compendium'" />
     <CustomRulesTab v-else-if="activeTab === 'custom'" />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 import { Plus, Monitor, BookOpen, Scroll } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
 import ScreenTab from "@/components/rules/ScreenTab.vue";
 import CompendiumTab from "@/components/rules/CompendiumTab.vue";
 import CustomRulesTab from "@/components/rules/CustomRulesTab.vue";

--- a/src/views/scriptorium/ScriptoriumView.vue
+++ b/src/views/scriptorium/ScriptoriumView.vue
@@ -1,21 +1,21 @@
 <template>
-  <PageHeader title="Scriptorium" description="Craft spell scrolls, stat blocks, and campaign documents">
+  <ListPageLayout title="Scriptorium" description="Craft spell scrolls, stat blocks, and campaign documents">
     <template #actions>
-      <RouterLink
+      <ListActionButton
+        :icon="Plus"
+        label="New Document"
+        variant="primary"
         to="/scriptorium/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Document
-      </RouterLink>
+      />
     </template>
 
     <ScriptoriumDocumentList />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { Plus } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
 import ScriptoriumDocumentList from "@/components/scriptorium/ScriptoriumDocumentList.vue";
 </script>

--- a/src/views/soundboard/SoundboardView.vue
+++ b/src/views/soundboard/SoundboardView.vue
@@ -1,40 +1,22 @@
 <template>
-  <PageHeader title="Soundboard" description="Ambient sounds & music for your sessions">
+  <ListPageLayout title="Soundboard" description="Ambient sounds & music for your sessions">
     <template #actions>
-      <button
-        class="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gold-500/20 border border-gold-500/40 text-xs font-cinzel text-gold-300 hover:bg-gold-500/30 transition-colors"
+      <ListActionButton
+        :icon="Plus"
+        label="Add Sound"
+        variant="primary"
         @click="showForm = !showForm"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        Add Sound
-      </button>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex flex-wrap items-center gap-3">
-        <!-- Search -->
-        <div class="relative">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
-          <input
-            v-model="ui.soundboardSearchQuery"
-            type="text"
-            placeholder="Search sounds…"
-            class="pl-8 pr-3 py-1.5 rounded-md border border-border bg-background text-sm font-fell text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-gold-500 w-48"
-          />
-        </div>
-
-        <!-- Category filter -->
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="ui.soundboardHasActiveFilters"
+        @clear="ui.resetSoundboardFilters()"
+      >
+        <ListSearchInput v-model="ui.soundboardSearchQuery" placeholder="Search sounds…" />
         <SoundCategoryFilter v-model="ui.soundboardFilterCategory" />
-
-        <!-- Clear -->
-        <button
-          v-if="ui.soundboardHasActiveFilters"
-          class="font-fell text-xs text-muted-foreground hover:text-foreground transition-colors"
-          @click="ui.resetSoundboardFilters()"
-        >
-          Clear
-        </button>
-      </div>
+      </ListFilterBar>
     </template>
 
     <!-- Add form (inline) -->
@@ -72,17 +54,20 @@
         @delete="handleDelete"
       />
     </div>
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { Plus, Search } from "lucide-vue-next";
+import { Plus } from "lucide-vue-next";
 import { useSounds, useDeleteSound } from "@/composables/useSounds";
 import { useSoundboardStore } from "@/stores/soundboard";
 import { useUiStore } from "@/stores/ui";
 import type { Sound } from "@/types/sound.types";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
 import SoundCard from "@/components/soundboard/SoundCard.vue";

--- a/src/views/species/SpeciesView.vue
+++ b/src/views/species/SpeciesView.vue
@@ -1,70 +1,45 @@
 <template>
-  <PageHeader title="Species" description="Playable species & subspecies compendium">
+  <ListPageLayout title="Species" description="Playable species & subspecies compendium">
     <template #actions>
-      <div class="flex gap-2">
-        <button
-          class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 font-cinzel text-xs font-semibold text-foreground tracking-wider hover:bg-accent hover:text-accent-foreground transition-colors"
-          @click="ui.speciesOpen5ePanelOpen = true"
-        >
-          <Download class="h-3.5 w-3.5" />
-          Import Open5e
-        </button>
-        <RouterLink
-          to="/species/new"
-          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-        >
-          <Plus class="h-3.5 w-3.5" />
-          New Species
-        </RouterLink>
-      </div>
+      <ListActionButton
+        :icon="Download"
+        label="Import Open5e"
+        @click="ui.speciesOpen5ePanelOpen = true"
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Species"
+        variant="primary"
+        to="/species/new"
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex flex-wrap items-center gap-2">
-        <!-- Search -->
-        <div class="relative flex-1 min-w-48">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="ui.speciesSearch"
-            type="text"
-            placeholder="Search species…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-
-        <!-- Size filter -->
-        <div class="flex rounded-md border border-border overflow-hidden text-xs font-cinzel font-semibold tracking-wider">
-          <button
-            v-for="s in SIZE_OPTIONS"
-            :key="s.value"
-            class="px-2.5 py-1.5 transition-colors"
-            :class="ui.speciesFilterSize === s.value ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground hover:text-foreground'"
-            @click="ui.speciesFilterSize = s.value"
-          >
-            {{ s.label }}
-          </button>
-        </div>
-
-        <!-- Clear -->
-        <button
-          v-if="ui.speciesHasActiveFilters"
-          type="button"
-          class="px-2.5 py-1.5 rounded-md border border-border bg-card font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
-          @click="ui.resetSpeciesFilters()"
-        >
-          Clear
-        </button>
-      </div>
+    <template #filters>
+      <ListFilterBar
+        :has-active-filters="ui.speciesHasActiveFilters"
+        @clear="ui.resetSpeciesFilters()"
+      >
+        <ListSearchInput v-model="ui.speciesSearch" placeholder="Search species…" />
+        <ListFilterGroup
+          v-model="ui.speciesFilterSize"
+          :options="SIZE_OPTIONS"
+          aria-label="Species size filter"
+        />
+      </ListFilterBar>
     </template>
 
     <SpeciesList />
     <SpeciesOpen5ePanel />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
-import { Plus, Search, Download } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Plus, Download } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterGroup from "@/components/common/ListFilterGroup.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import SpeciesList from "@/components/species/SpeciesList.vue";
 import SpeciesOpen5ePanel from "@/components/species/SpeciesOpen5ePanel.vue";
 import { useUiStore } from "@/stores/ui";
@@ -77,5 +52,5 @@ const SIZE_OPTIONS = [
   { value: "small", label: "Small" },
   { value: "medium", label: "Medium" },
   { value: "large", label: "Large" },
-];
+] as const;
 </script>

--- a/src/views/spells/SpellsView.vue
+++ b/src/views/spells/SpellsView.vue
@@ -1,11 +1,14 @@
 <template>
-  <PageHeader title="Spellbook" description="Your custom spell compendium">
+  <ListPageLayout title="Spellbook" description="Your custom spell compendium">
     <template #actions>
-      <!-- Source picker popover -->
-      <div ref="sourcePickerRef" class="relative">
+      <!--
+        Source picker popover — custom UI, not a simple button. Kept inline
+        because its anchored popover doesn't fit ListActionButton's model.
+      -->
+      <div ref="sourcePickerRef" class="relative shrink-0">
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors"
+          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors shrink-0"
           :title="selectedSources.length === 0 ? 'All sources selected' : `${selectedSources.length} source(s) selected`"
           @click="showSourcePicker = !showSourcePicker"
         >
@@ -49,76 +52,45 @@
           </div>
         </div>
       </div>
-      <button
-        type="button"
+
+      <ListActionButton
+        :icon="importMutation.isPending.value ? Loader2 : Download"
+        :label="importStatusLabel"
         :disabled="importMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
         @click="handleImport"
-      >
-        <Loader2 v-if="importMutation.isPending.value" class="size-3.5 animate-spin shrink-0" />
-        <Download v-else class="size-3.5 shrink-0" />
-        {{ importStatusLabel }}
-      </button>
-      <RouterLink
+      />
+      <ListActionButton
+        :icon="Plus"
+        label="New Spell"
+        variant="primary"
         to="/spells/new"
-        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        New Spell
-      </RouterLink>
+      />
     </template>
 
-    <template #sticky>
-      <div class="flex flex-wrap items-center gap-2">
-        <!-- Search -->
-        <div class="relative flex-1 min-w-48">
-          <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            v-model="searchInput"
-            type="text"
-            placeholder="Search by name…"
-            class="w-full bg-card border border-border rounded-md pl-8 pr-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-        </div>
-        <!-- Level -->
-        <div class="flex rounded-md border border-border overflow-hidden text-xs font-cinzel font-semibold tracking-wider">
-          <button
-            v-for="lvl in LEVEL_FILTERS"
-            :key="lvl.value"
-            class="px-2.5 py-1.5 transition-colors"
-            :class="levelFilter === lvl.value ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground hover:text-foreground'"
-            @click="setLevelFilter(lvl.value)"
-          >
-            {{ lvl.label }}
-          </button>
-        </div>
-        <!-- School -->
-        <select
-          v-model="schoolFilter"
-          class="bg-card border border-border rounded-md px-3 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+    <template #filters>
+      <ListFilterBar>
+        <ListSearchInput v-model="searchInput" placeholder="Search by name…" />
+        <ListFilterGroup
+          :model-value="levelFilter"
+          :options="LEVEL_FILTERS"
+          aria-label="Spell level filter"
+          @update:model-value="setLevelFilter"
+        />
+        <ListFilterSelect v-model="schoolFilter" aria-label="School filter">
           <option value="">All Schools</option>
           <option v-for="s in SPELL_SCHOOLS" :key="s" :value="s" class="capitalize">{{ s }}</option>
-        </select>
-        <!-- Class -->
-        <select
-          v-model="classFilter"
-          class="bg-card border border-border rounded-md px-3 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+        </ListFilterSelect>
+        <ListFilterSelect v-model="classFilter" aria-label="Class filter">
           <option value="">All Classes</option>
           <option v-for="c in SPELL_CLASSES" :key="c" :value="c">{{ c }}</option>
-        </select>
-        <!-- Source -->
-        <select
-          v-model="sourceFilter"
-          class="bg-card border border-border rounded-md px-3 py-1.5 font-cinzel text-xs font-semibold text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+        </ListFilterSelect>
+        <ListFilterSelect v-model="sourceFilter" aria-label="Source filter">
           <option value="">All Sources</option>
           <option v-for="s in sources" :key="s.slug" :value="s.slug">
             {{ spellSourceLabel(s.slug, s.title) }}
           </option>
-        </select>
-      </div>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <SpellList
@@ -130,14 +102,20 @@
       :page="page"
       @update:page="page = $event"
     />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { ref, watch } from "vue";
+import { computed } from "vue";
 import { refDebounced, useLocalStorage, onClickOutside } from "@vueuse/core";
-import { Plus, Loader2, Download, Search, Settings2 } from "lucide-vue-next";
-import PageHeader from "@/components/common/PageHeader.vue";
+import { Plus, Loader2, Download, Settings2 } from "lucide-vue-next";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterGroup from "@/components/common/ListFilterGroup.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import SpellList from "@/components/spells/SpellList.vue";
 import { useImportSrdSpells, useSpellSources, useOpen5eDocuments } from "@/composables/useSpells";
 import { SPELL_SCHOOLS, SPELL_CLASSES, spellSourceLabel } from "@/types/spell.types";
@@ -149,7 +127,7 @@ const LEVEL_FILTERS = [
   { value: "1", label: "1" }, { value: "2", label: "2" }, { value: "3", label: "3" },
   { value: "4", label: "4" }, { value: "5", label: "5" }, { value: "6", label: "6" },
   { value: "7", label: "7" }, { value: "8", label: "8" }, { value: "9", label: "9" },
-];
+] as const;
 
 const searchInput = ref("");
 const search = refDebounced(searchInput, 400);

--- a/src/views/traps/TrapsView.vue
+++ b/src/views/traps/TrapsView.vue
@@ -1,22 +1,31 @@
 <template>
-  <PageHeader title="Traproom" description="Traps, hazards & dungeon dangers">
+  <ListPageLayout title="Traproom" description="Traps, hazards & dungeon dangers">
     <template #actions>
-      <button
-        type="button"
+      <ListActionButton
+        :icon="populateMutation.isPending.value ? Loader2 : BookOpen"
+        :label="populateStatusLabel"
         :disabled="populateMutation.isPending.value"
-        class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
         @click="handlePopulate"
-      >
-        <Loader2 v-if="populateMutation.isPending.value" class="size-3.5 animate-spin shrink-0" />
-        <BookOpen v-else class="size-3.5 shrink-0" />
-        {{ populateStatusLabel }}
-      </button>
-      <button
-        class="font-cinzel text-xs font-semibold px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+      />
+      <ListActionButton
+        label="New Trap"
+        variant="primary"
         @click="router.push('/traps/new')"
-      >
-        New Trap
-      </button>
+      />
+    </template>
+
+    <!--
+      Filters moved into the sticky slot so they don't scroll away with the
+      grid. Previously they lived inside the default slot above the grid.
+    -->
+    <template v-if="traps?.length" #filters>
+      <ListFilterBar>
+        <ListSearchInput v-model="search" placeholder="Search traps…" />
+        <ListFilterSelect v-model="typeFilter" aria-label="Trap type filter">
+          <option value="">All Types</option>
+          <option v-for="t in TRAP_TYPES" :key="t" :value="t">{{ t }}</option>
+        </ListFilterSelect>
+      </ListFilterBar>
     </template>
 
     <div v-if="isLoading" class="flex justify-center py-16">
@@ -24,28 +33,10 @@
     </div>
 
     <template v-else-if="traps?.length">
-      <!-- Filters -->
-      <div class="flex flex-wrap items-center gap-2 mb-4">
-        <input
-          v-model="search"
-          type="search"
-          placeholder="Search traps…"
-          class="flex-1 min-w-40 bg-card border border-border rounded-md px-3 py-1.5 font-fell text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        />
-        <select
-          v-model="typeFilter"
-          class="bg-card border border-border rounded-md px-3 py-1.5 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <option value="">All Types</option>
-          <option v-for="t in TRAP_TYPES" :key="t" :value="t">{{ t }}</option>
-        </select>
-      </div>
-
       <p v-if="!filtered.length" class="text-center font-fell text-sm text-muted-foreground italic py-8">
         No traps match your filter.
       </p>
 
-      <!-- Grid -->
       <div v-else class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
         <RouterLink
           v-for="trap in filtered"
@@ -53,7 +44,6 @@
           :to="`/traps/${trap.id}`"
           class="flex flex-col rounded-lg border border-border bg-card overflow-hidden hover:border-primary/50 transition-colors group"
         >
-          <!-- Image / placeholder -->
           <div class="relative aspect-square bg-muted overflow-hidden shrink-0">
             <FocalImage
               v-if="trap.image_url"
@@ -66,14 +56,12 @@
             <div v-else class="w-full h-full flex items-center justify-center text-muted-foreground/20">
               <CrosshairIcon class="h-10 w-10" />
             </div>
-            <!-- Type badge -->
             <span
               class="absolute top-2 left-2 font-cinzel text-[9px] px-1.5 py-0.5 rounded tracking-wider text-white font-bold"
               :style="{ backgroundColor: TRAP_TYPE_COLORS[trap.trap_type] + 'DD' }"
             >{{ trap.trap_type }}</span>
           </div>
 
-          <!-- Info -->
           <div class="p-2.5 flex flex-col gap-0.5">
             <h3 class="font-cinzel text-sm font-bold text-foreground leading-tight truncate">{{ trap.name }}</h3>
             <div class="flex items-center gap-2">
@@ -97,7 +85,7 @@
       action-label="New Trap"
       @action="router.push('/traps/new')"
     />
-  </PageHeader>
+  </ListPageLayout>
 </template>
 
 <script setup lang="ts">
@@ -106,7 +94,11 @@ import { RouterLink, useRouter } from "vue-router";
 import { Crosshair as CrosshairIcon, Loader2, BookOpen } from "lucide-vue-next";
 import { useTraps, usePopulateTraps } from "@/composables/useTraps";
 import { TRAP_TYPES, TRAP_TYPE_COLORS } from "@/types/trap.types";
-import PageHeader from "@/components/common/PageHeader.vue";
+import ListPageLayout from "@/components/common/ListPageLayout.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import ListFilterBar from "@/components/common/ListFilterBar.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import FocalImage from "@/components/common/FocalImage.vue";
 import EmptyState from "@/components/common/EmptyState.vue";


### PR DESCRIPTION
Stacked on [#136](https://github.com/irongollem/grimoire/pull/136). Will auto-retarget as PRs below it merge.

**Finalizes the list-page layout refactor.** Every view listed in the #132 audit now uses the shared layout.

## New primitive

### `ListFilterSelect.vue`
Native `<select>` with the dark-app styling duplicated across 7 views. Uses a default slot for options so callers keep full control over:
- The empty-value convention (some use `""`, some use `"all"`)
- Option ordering and labels

Keeps the OS-provided mobile picker behavior (which works well), just normalizes the chrome.

## `ListActionButton` — small addition

Added optional `tooltip` prop. Needed for toggle buttons where the visible label describes state ("Kanban") but the tooltip should describe the action ("Switch to list view"). Defaults to `label`.

## Migrated views

| View | Notes |
|---|---|
| Scriptorium | Trivial — single primary action |
| Locations | 3 actions, search + type select |
| Traps | Filters moved from body to sticky `#filters` slot |
| Puzzles | Filters moved from body to sticky `#filters` slot |
| Factions | Already sticky; straight swap |
| Species | Size filter uses `ListFilterGroup` (pill set) |
| Items | 3 actions, 3 `ListFilterSelect`s |
| Spells | Custom source-picker popover kept inline (its anchored popover doesn't fit the button model); rest migrated |
| Hall of Heroes | Uses the new `#footer` slot for the "N of M heroes" count |
| Quests | View-toggle button uses `ListActionButton` with `tooltip` prop |
| Rules | Tabs stay in body (each tab = different content, not a single-choice filter). Tab bar gains `overflow-x-auto` so it scrolls on narrow screens |

## Behavior changes (intentional)

- **Traps + Puzzles**: filters previously sat in the default slot *above* the grid, so they scrolled away with the list. Now they're in the sticky `#filters` slot — they stay visible while scrolling, matching every other list view.

## Known limitations (out of scope for this PR)

- **Traps + Puzzles still use local `ref()` for filter state.** CLAUDE.md requires `useUiStore` for filter state; these two pre-existing violations weren't fixed here because it's a state-persistence change, not a layout refactor. Separate PR.
- **`PageHeader.vue` is still around.** Used by non-list pages (detail views, settings panels). No deprecation in this PR; if you want it removed once verified, I'll do a sweep.

## Final stack state

| PR | Scope | Targets |
|---|---|---|
| [#134](https://github.com/irongollem/grimoire/pull/134) | Mobile first-pass + infrastructure | `main` |
| [#135](https://github.com/irongollem/grimoire/pull/135) | `ListPageLayout` + `ListActionButton`, migrate Notes & Monsters | #134 |
| [#136](https://github.com/irongollem/grimoire/pull/136) | Filter primitives, migrate NPCs & Monsters | #135 |
| #137 (this) | Migrate remaining 11 views | #136 |

**Stack totals**: 7 common primitives created, 14 list views migrated, PageHeader skeleton duplicated 14 times is now 1 component with documented slots.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — 0 warnings, 0 errors
- [ ] Smoke-test each migrated view — header/filters/list render as before, at desktop + 375px
- [ ] Traps/Puzzles — verify filters stay sticky (new behavior) and filter → grid filtering still works
- [ ] Hall of Heroes — footer count renders and updates with filter changes
- [ ] Quests — view-toggle button flips icon+label correctly, tooltip updates
- [ ] Rules — tab bar scrolls horizontally on narrow screens

Refs #132

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx