### PR TITLE
fix(list-primitives): reliable mobile label collapse, drop duplicate title

### DIFF
--- a/src/components/common/ListActionButton.vue
+++ b/src/components/common/ListActionButton.vue
@@ -27,7 +27,14 @@
       class="h-3.5 w-3.5 shrink-0"
       aria-hidden="true"
     />
-    <span :class="labelClass">{{ label }}</span>
+    <!--
+      Label rendered via v-if/v-else so the class string is a static literal
+      Tailwind picks up verbatim. `max-sm:hidden` resolves to a single
+      media-query-wrapped rule with no cascading between `.hidden` and
+      `.sm:inline`.
+    -->
+    <span v-if="shouldCollapse" class="max-sm:hidden">{{ label }}</span>
+    <span v-else>{{ label }}</span>
   </component>
 </template>
 
@@ -114,5 +121,4 @@ const shouldCollapse = computed(() => {
   return true;
 });
 
-const labelClass = computed(() => (shouldCollapse.value ? "hidden sm:inline" : "inline"));
 </script>

--- a/src/components/common/ListPageLayout.vue
+++ b/src/components/common/ListPageLayout.vue
@@ -37,7 +37,14 @@
     <div class="sticky top-0 z-20 bg-background px-4 pt-3 md:px-6 md:pt-6">
       <!-- Title + actions row -->
       <div class="flex items-start justify-between gap-3 md:gap-4">
-        <div class="min-w-0 flex-1">
+        <!--
+          Title + description hidden on <md. AppTopBar renders the page
+          title on mobile, so repeating a big h1 here duplicates the label
+          and eats ~70px of vertical space right above the action row.
+          Desktop is unchanged — `md:block md:flex-1 md:min-w-0` makes
+          the wrapper a proper flex item at ≥md.
+        -->
+        <div class="hidden md:block md:min-w-0 md:flex-1">
           <h1
             class="font-cinzel text-xl md:text-3xl font-bold text-foreground tracking-wide truncate"
           >
@@ -62,7 +69,7 @@
         -->
         <div
           v-if="hasActions || showDiceRoller"
-          class="flex items-center gap-2 shrink-0 -mr-4 pr-4 md:mr-0 md:pr-0 max-w-[70%] md:max-w-none overflow-x-auto md:overflow-visible list-actions-row"
+          class="flex items-center gap-2 shrink-0 -mr-4 pr-4 md:mr-0 md:pr-0 max-w-full md:max-w-none overflow-x-auto md:overflow-visible list-actions-row"
         >
           <slot name="actions" />
           <!--


### PR DESCRIPTION
Small focused follow-up for two mobile polish regressions reported after #136 landed on main. Sits directly on main, targets main, no dependencies on the remaining #137.

## Problems

1. **Primary action button label (+ New Monster) still rendered on mobile at 390px** despite `ListActionButton`'s default `collapseOnMobile` being `true`. The previous implementation built the class via a computed ref returning `"hidden sm:inline"` — relying on cascading between `.hidden` (always) and `.sm:inline` (inside `@media min-width: 40rem`). In Chrome/macOS device emulation at iPhone 12 Pro dimensions the label kept showing.

2. **Duplicate page title on mobile.** `AppTopBar` already renders the page title on mobile; `ListPageLayout`'s big h1 repeated it below, eating ~70px above the action row.

## Changes

### `ListActionButton.vue`
- Replaced computed `labelClass` with a v-if/v-else `<span>` pair using `max-sm:hidden` — a single utility resolving to `@media not all and (min-width: 40rem) { .max-sm\:hidden { display: none } }`. No cross-class specificity dance, and the class name is a literal in the template so Tailwind's scanner has zero ambiguity.

### `ListPageLayout.vue`
- Title + description wrapper is `hidden md:block md:min-w-0 md:flex-1` — hidden on `<md`, proper flex item at `≥md`. AppTopBar handles the title on mobile.
- Action row's `max-w-[70%]` relaxed to `max-w-full` on mobile since there's no title competing for horizontal space.

Desktop layout is completely unchanged.

## Visual

Bestiary at 390px:
- Before: `[BESTIARY small (TopBar)] [BESTIARY big (h1)] [⚡ GENERATE] [+ NEW MONSTER]` — title twice, action row overflowing
- After: `[BESTIARY (TopBar)] [⚡] [+]` — one title, action row fits

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] Compiled CSS verified to contain `@media not all and (min-width:40rem) { .max-sm\:hidden { display: none } }`
- [ ] Manual: Bestiary at 390px — no big h1, just icon-only Generate + New Monster buttons, Clear still collapses to X
- [ ] Manual: Bestiary at ≥768px — unchanged (full title, full action labels)
- [ ] Manual: Other list pages using ListPageLayout (Notes, Monsters) pick up the same behaviour

Refs #132

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx