### PR TITLE
feat(ui): custom tooltip engine — auto-upgrades every native title

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -248,6 +248,78 @@
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+   Custom tooltip popover (see src/lib/tooltip.ts). One element appended to
+   <body> by the engine; styled here so it lives alongside the rest of the
+   app chrome. `opacity` transition gives a soft fade; `visibility` is
+   toggled via `is-visible` so the popover doesn't intercept pointer events
+   while hidden.
+───────────────────────────────────────────────────────────────────────────── */
+.tw-tooltip {
+  position: fixed;
+  z-index: 100;
+  max-width: min(20rem, calc(100vw - 1rem));
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  font-family: var(--font-fell, "Crimson Pro", Georgia, serif);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease-out, visibility 120ms;
+  white-space: normal;
+  word-wrap: break-word;
+}
+.tw-tooltip.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+.tw-tooltip-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+/* Arrow placement encoded via data-attr so the engine can flip it without
+   touching CSS. `placement="top"` = popover sits below target, arrow points up. */
+.tw-tooltip-arrow[data-placement="top"] {
+  top: -5px;
+  border-width: 0 5px 5px 5px;
+  border-color: transparent transparent var(--border) transparent;
+}
+.tw-tooltip-arrow[data-placement="top"]::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: -4px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 4px 4px 4px;
+  border-color: transparent transparent var(--popover) transparent;
+}
+.tw-tooltip-arrow[data-placement="bottom"] {
+  bottom: -5px;
+  border-width: 5px 5px 0 5px;
+  border-color: var(--border) transparent transparent transparent;
+}
+.tw-tooltip-arrow[data-placement="bottom"]::after {
+  content: "";
+  position: absolute;
+  bottom: 1px;
+  left: -4px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 4px 4px 0 4px;
+  border-color: var(--popover) transparent transparent transparent;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
    Safe-area utilities — register as Tailwind v4 utilities so they compose with
    variants (`sm:pb-safe`) and arbitrary modifiers where needed. The numeric
    helpers add a fixed amount *on top of* the inset, which is the common case

--- a/src/directives/tooltip.ts
+++ b/src/directives/tooltip.ts
@@ -1,0 +1,26 @@
+import type { Directive } from "vue";
+import { setTooltipText } from "@/lib/tooltip";
+
+/**
+ * `v-tooltip="text"` — sets the tooltip text on an element without
+ * relying on the `title` attribute promotion path. Useful when the text
+ * comes from a computed value and you'd rather not see the native tooltip
+ * flicker on first paint before the engine's MutationObserver picks it up.
+ *
+ * Usage:
+ *   <button v-tooltip="`Switch to ${otherView}`">…</button>
+ *   <Icon v-tooltip="t.label" />
+ */
+export const tooltip: Directive<HTMLElement, string | undefined | null> = {
+  mounted(el, binding) {
+    setTooltipText(el, binding.value);
+  },
+  updated(el, binding) {
+    if (binding.value !== binding.oldValue) {
+      setTooltipText(el, binding.value);
+    }
+  },
+  beforeUnmount(el) {
+    setTooltipText(el, null);
+  },
+};

--- a/src/lib/tooltip.ts
+++ b/src/lib/tooltip.ts
@@ -1,0 +1,268 @@
+/**
+ * Global tooltip engine.
+ *
+ * Replaces native `title` tooltips with a single styled, multi-line popover
+ * shared across the whole app. Components don't need to import or wire
+ * anything — once `installTooltipEngine()` is called at boot, every element
+ * with a `title` attribute (or `data-tooltip` set by the `v-tooltip`
+ * directive) automatically gets the upgraded experience on hover, focus,
+ * and touch long-press.
+ *
+ * Why a singleton DOM listener instead of per-component wrappers:
+ * - Zero migration cost — existing `title="..."` attributes Just Work.
+ * - One element in the DOM, one event listener, no per-component overhead.
+ * - Trivial to add features (placement, colour, html content) in one place.
+ *
+ * Why we promote `title` → `data-tooltip` instead of leaving `title` alone:
+ * the browser's own native tooltip would still fire after our delay, leading
+ * to two tooltips. `MutationObserver` + the `v-tooltip` directive both move
+ * the text to `data-tooltip` and remove `title` so only ours shows. The
+ * original text is preserved on `aria-label` for screen readers.
+ */
+
+const HOVER_DELAY = 300;        // ms before showing on hover
+const HIDE_FADE_MS = 120;       // visual fade-out
+const LONG_PRESS_DELAY = 500;   // touch long-press
+const VIEWPORT_MARGIN = 8;      // min gap from viewport edge
+
+let popoverEl: HTMLDivElement | null = null;
+let arrowEl: HTMLDivElement | null = null;
+let activeEl: HTMLElement | null = null;
+let showTimer: number | null = null;
+let hideTimer: number | null = null;
+let pressTimer: number | null = null;
+let installed = false;
+
+/** Find the nearest ancestor (including self) that carries tooltip text. */
+function nearestTooltipElement(start: HTMLElement | null): HTMLElement | null {
+  let cur: HTMLElement | null = start;
+  while (cur) {
+    if (cur.dataset?.tooltip) return cur;
+    if (cur.hasAttribute("title")) return cur;
+    cur = cur.parentElement;
+  }
+  return null;
+}
+
+function getTooltipText(el: HTMLElement): string {
+  return el.dataset.tooltip ?? el.getAttribute("title") ?? "";
+}
+
+/** Promote `title` → `data-tooltip` so the native tooltip stays silent.
+ *  Preserve the text on `aria-label` (if not already set) for a11y. */
+function promoteTitle(el: HTMLElement) {
+  const title = el.getAttribute("title");
+  if (!title) return;
+  el.dataset.tooltip = title;
+  el.removeAttribute("title");
+  if (!el.hasAttribute("aria-label") && !el.hasAttribute("aria-labelledby")) {
+    el.setAttribute("aria-label", title);
+  }
+}
+
+function ensurePopover(): HTMLDivElement {
+  if (popoverEl) return popoverEl;
+  popoverEl = document.createElement("div");
+  popoverEl.setAttribute("role", "tooltip");
+  popoverEl.className = "tw-tooltip";
+  arrowEl = document.createElement("div");
+  arrowEl.className = "tw-tooltip-arrow";
+  popoverEl.appendChild(arrowEl);
+  document.body.appendChild(popoverEl);
+  return popoverEl;
+}
+
+/** Place the popover relative to `target`, with viewport-aware flipping. */
+function position(target: HTMLElement, popover: HTMLDivElement) {
+  const r = target.getBoundingClientRect();
+  const pop = popover.getBoundingClientRect();
+
+  // Prefer below; flip above if it would clip.
+  let placeAbove = false;
+  if (r.bottom + pop.height + 12 > window.innerHeight - VIEWPORT_MARGIN) {
+    placeAbove = true;
+  }
+
+  const top = placeAbove
+    ? Math.max(VIEWPORT_MARGIN, r.top - pop.height - 8)
+    : Math.min(window.innerHeight - pop.height - VIEWPORT_MARGIN, r.bottom + 8);
+
+  // Centre horizontally, clamp to viewport.
+  const idealLeft = r.left + r.width / 2 - pop.width / 2;
+  const left = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(window.innerWidth - pop.width - VIEWPORT_MARGIN, idealLeft),
+  );
+
+  popover.style.top = `${top}px`;
+  popover.style.left = `${left}px`;
+
+  if (arrowEl) {
+    // Arrow points TOWARDS the target, so it sits on the side facing the target.
+    arrowEl.dataset.placement = placeAbove ? "bottom" : "top";
+    const arrowLeft = Math.max(8, Math.min(pop.width - 8, r.left + r.width / 2 - left));
+    arrowEl.style.left = `${arrowLeft}px`;
+  }
+}
+
+function show(target: HTMLElement, text: string) {
+  const popover = ensurePopover();
+  popover.textContent = "";
+  // Render multi-line text — split on \n so chip tooltips like
+  // "Cond — click to remove\n\nFull rules…" come through legibly.
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0) popover.appendChild(document.createElement("br"));
+    popover.appendChild(document.createTextNode(lines[i]));
+  }
+  if (arrowEl) popover.appendChild(arrowEl);
+  popover.classList.add("is-visible");
+  // Position after the popover has natural dimensions.
+  popover.style.top = "0px";
+  popover.style.left = "0px";
+  requestAnimationFrame(() => position(target, popover));
+  activeEl = target;
+}
+
+function hide(immediate = false) {
+  if (showTimer) { clearTimeout(showTimer); showTimer = null; }
+  if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
+  activeEl = null;
+  if (!popoverEl) return;
+  if (immediate) {
+    popoverEl.classList.remove("is-visible");
+    return;
+  }
+  if (hideTimer) clearTimeout(hideTimer);
+  hideTimer = window.setTimeout(() => {
+    popoverEl?.classList.remove("is-visible");
+  }, 0);
+}
+
+function scheduleShow(target: HTMLElement) {
+  if (showTimer) clearTimeout(showTimer);
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+  const text = getTooltipText(target);
+  if (!text) return;
+  showTimer = window.setTimeout(() => show(target, text), HOVER_DELAY);
+}
+
+function onMouseOver(e: MouseEvent) {
+  const target = nearestTooltipElement(e.target as HTMLElement | null);
+  if (!target) { hide(); return; }
+  if (target === activeEl) return;
+  scheduleShow(target);
+}
+
+function onMouseOut(e: MouseEvent) {
+  const related = e.relatedTarget as HTMLElement | null;
+  // If we're moving into the popover itself, don't hide.
+  if (related && popoverEl?.contains(related)) return;
+  hide();
+}
+
+function onFocusIn(e: FocusEvent) {
+  const target = nearestTooltipElement(e.target as HTMLElement | null);
+  if (!target) return;
+  // Skip the hover delay for keyboard users.
+  if (showTimer) clearTimeout(showTimer);
+  show(target, getTooltipText(target));
+}
+
+function onFocusOut() { hide(); }
+
+function onScroll() { hide(true); }
+function onResize() { hide(true); }
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") hide(true);
+}
+
+// ── Touch long-press ─────────────────────────────────────────────────────────
+function onPointerDown(e: PointerEvent) {
+  if (e.pointerType !== "touch") return;
+  const target = nearestTooltipElement(e.target as HTMLElement | null);
+  if (!target) return;
+  pressTimer = window.setTimeout(() => {
+    show(target, getTooltipText(target));
+    // Subsequent tap dismisses.
+    document.addEventListener("pointerdown", () => hide(true), { once: true, capture: true });
+  }, LONG_PRESS_DELAY);
+}
+function onPointerCancel() {
+  if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
+}
+
+// ── MutationObserver: promote any new `title` attributes ──────────────────────
+function promoteAllTitles(root: ParentNode) {
+  // Skip form controls — `title` on input/select/textarea has accessibility
+  // weight (some screen readers expose it as the accessible name) and the
+  // browser's tooltip is generally fine for those. Easy to relax later.
+  const els = root.querySelectorAll<HTMLElement>(
+    "[title]:not(input):not(select):not(textarea)",
+  );
+  els.forEach(promoteTitle);
+}
+
+function startMutationObserver() {
+  const obs = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      if (m.type === "attributes" && m.attributeName === "title" && m.target instanceof HTMLElement) {
+        promoteTitle(m.target);
+      } else if (m.type === "childList") {
+        m.addedNodes.forEach((n) => {
+          if (n instanceof HTMLElement) promoteAllTitles(n);
+        });
+      }
+    }
+  });
+  obs.observe(document.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ["title"],
+  });
+  return obs;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export function installTooltipEngine() {
+  if (installed) return;
+  installed = true;
+
+  promoteAllTitles(document.body);
+  startMutationObserver();
+
+  document.addEventListener("mouseover", onMouseOver, true);
+  document.addEventListener("mouseout", onMouseOut, true);
+  document.addEventListener("focusin", onFocusIn, true);
+  document.addEventListener("focusout", onFocusOut, true);
+  document.addEventListener("pointerdown", onPointerDown, true);
+  document.addEventListener("pointercancel", onPointerCancel, true);
+  document.addEventListener("pointerup", onPointerCancel, true);
+  document.addEventListener("keydown", onKeyDown, true);
+  // Hide on scroll/resize because positions are stale and re-anchoring
+  // mid-scroll feels worse than just dismissing.
+  window.addEventListener("scroll", onScroll, { capture: true, passive: true });
+  window.addEventListener("resize", onResize);
+}
+
+/** Public for the directive — set the tooltip text on an element directly. */
+export function setTooltipText(el: HTMLElement, text: string | undefined | null) {
+  if (text === null || text === undefined || text === "") {
+    delete el.dataset.tooltip;
+    if (el.getAttribute("aria-label") === el.dataset.tooltip) {
+      el.removeAttribute("aria-label");
+    }
+    return;
+  }
+  el.dataset.tooltip = text;
+  if (!el.hasAttribute("aria-label") && !el.hasAttribute("aria-labelledby")) {
+    el.setAttribute("aria-label", text);
+  }
+  // Always remove `title` so the native tooltip stays silent.
+  el.removeAttribute("title");
+}
+
+void HIDE_FADE_MS;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ import App from "./App.vue";
 import "./assets/main.css";
 import { captureInstallPrompt } from "./composables/usePwaInstall";
 import { onWakeLockVisibilityChange } from "./composables/useWakeLock";
+import { installTooltipEngine } from "./lib/tooltip";
+import { tooltip as vTooltip } from "./directives/tooltip";
 
 window.addEventListener("beforeinstallprompt", captureInstallPrompt, { once: true });
 document.addEventListener("visibilitychange", onWakeLockVisibilityChange);
@@ -63,6 +65,14 @@ const app = createApp(App);
 app.use(createPinia());
 app.use(VueQueryPlugin, { queryClient });
 app.use(router);
+
+// Custom tooltip engine — replaces native `title` tooltips app-wide. Existing
+// `title="…"` attributes on every component are auto-promoted to the styled
+// popover; new code can also use the `v-tooltip="…"` directive registered
+// here for cases where the value is dynamic and we want to skip the native
+// tooltip flicker.
+app.directive("tooltip", vTooltip);
+installTooltipEngine();
 
 app.mount("#app");
 


### PR DESCRIPTION
Replaces browser-native `title` tooltips with a single styled, multi-line, viewport-aware popover shared across the whole app. Zero per-component changes — every existing `title="…"` (and `:title="…"`) is auto-promoted by the engine.

## Why a global engine

Native `title` tooltips have been a long-running annoyance:

- No styling / dark-theme support
- 500ms delay on most browsers, no multi-line on Safari
- Nothing on touch devices (long-press triggers OS context menu instead)
- Can't carry the gold/parchment palette

A `<Tooltip>` wrapper component would have meant rewriting **every** ListActionButton call site, every condition chip, every map pin button, every mobile nav icon — hundreds of touch points across the app. Instead, one document-level delegate sits at the root and intercepts pointer/focus events for the whole tree once.

## Pieces

### `src/lib/tooltip.ts` — engine

- `installTooltipEngine()` boots once from `main.ts`. Capturing listeners for hover / focus / pointer / scroll / resize / keydown.
- `MutationObserver` watches the body for new `title` attributes; promotes each one to `data-tooltip` (and copies to `aria-label` if absent) so the native browser tooltip stays silent and screen readers still get the text.
- Hover delay 300ms (OS convention). Focus shows immediately for keyboard. Touch long-press 500ms; next tap dismisses.
- ESC dismisses. Scroll/resize dismiss because re-anchoring mid-scroll feels worse than just closing.
- Multi-line — text split on `\n` and rendered as text nodes + `<br>`, so existing two-paragraph tooltips like `"Cond — click to remove\n\nFull rules…"` come through legibly.
- Viewport-aware placement: prefer below; flip above if it would clip; horizontal centering clamped to viewport.
- Form controls (`input`/`select`/`textarea`) excluded from auto-promotion — `title` on form controls has accessibility weight some screen readers expose as the accessible name. Easy to relax later.

### `src/directives/tooltip.ts` — opt-in directive

`v-tooltip="text"` for cases where the value is dynamic and we want to skip even the brief flicker between Vue setting `title` and the MutationObserver promoting it. Same engine path, just bypasses the title-promotion microtask.

### Styles

`.tw-tooltip` in `src/assets/main.css` — themed via `var(--popover)` / `var(--border)` / `var(--popover-foreground)`, z-100, fade transition. Arrow pseudo-element flips orientation via `data-placement` so the engine can swap top/bottom without touching CSS.

### `src/main.ts`

```ts
app.directive("tooltip", vTooltip);
installTooltipEngine();
```

Two lines after `app.use(router)`.

## What auto-upgrades on the moment this lands

Every `title=""` and `:title=""` already in the codebase:

- `ListActionButton` tooltips (Generate, Save, Delete, etc.)
- Condition chips (the SRD rules text shipped on `feat/open5e`)
- Atlas pin pill action buttons
- Map zoom controls
- Workshop recipe icon-only PROF / TOOLS tags
- Mobile navigation icons
- Edit-overlay buttons on list cards
- Hundreds of others

Nothing else needs touching.

## Cost

| | Lines |
|---|---|
| Engine | ~250 |
| Directive | ~25 |
| CSS | ~70 |
| Boot wiring | 4 |
| **Total** | **~350 lines added; 0 lines changed in any consumer** |

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] Built CSS contains all 7 `.tw-tooltip*` rules
- [ ] Hover any button with a `title` — popover appears below, themed, multi-line text wraps, fades on leave
- [ ] Hover at the bottom of the viewport — popover flips above the trigger
- [ ] Hover at the right edge — popover stays inside the viewport, arrow shifts to align with the trigger centre
- [ ] Tab-focus a button — popover shows immediately (no 300ms delay)
- [ ] Long-press a button on touch (DevTools mobile mode + pointer) — popover shows after ~500ms; tap elsewhere dismisses
- [ ] Press ESC while a popover is showing — dismisses
- [ ] Scroll while a popover is showing — dismisses
- [ ] No double-tooltip: native browser tooltip should never appear (verify by hovering for 2+ seconds — only ours should show)
- [ ] Screen reader announces tooltip text (the `aria-label` migration covers this)

## Out of scope (follow-ups)

- Placement modifiers (`v-tooltip:top` / `:right`) — easy to add as directive arguments when a real case turns up
- HTML / rich content support — text-only by design (XSS surface area kept small)
- Sticky-on-popover-hover — popover is `pointer-events: none` so you can't hover it. Trade-off: can't copy text out of a tooltip; gain: simple lifecycle.

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx