### PR TITLE
feat(rules): sync Open5e v1 sections, retire stale v2 rulesets

### DIFF
--- a/supabase/functions/sync-srd-rules/index.ts
+++ b/supabase/functions/sync-srd-rules/index.ts
@@ -1,43 +1,86 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-// v2 rulesets API — each ruleset embeds its rules as a nested array
-const OPEN5E_RULESETS_BASE = "https://api.open5e.com/v2/rulesets/";
+// Open5e v1 `/v1/sections/` — 2014 SRD 5.1 prose sections.
+//
+// Earlier this function pulled from v2 `/v2/rulesets/` (the 2024 / 5.5e
+// SRD), but the rest of the app (monsters, backgrounds, conditions,
+// spells, items …) all consumes v1 endpoints, so the Compendium content
+// was the odd one out. To keep the edition consistent across the whole
+// app, this function now syncs v1 sections only and explicitly cleans up
+// the old `doc_slug='srd-2024'` rows on each run so the table doesn't
+// carry stale 5.5e content.
+//
+// When we eventually add explicit v2 / 5.5e support across the rest of
+// the app, this function should grow back the v2 rulesets fetch (or
+// move v2 to its own function) — see #142.
+//
+// Sections are a flat list with a free-text `parent` name. We slugify
+// each section's name to look up parents and build the tree client-side.
+
+const OPEN5E_SECTIONS_BASE = "https://api.open5e.com/v1/sections/";
+const DOC_SLUG = "srd-5.1";
+const STALE_DOC_SLUGS = ["srd-2024"]; // Removed on each run.
 const BATCH = 100;
 
-interface EmbeddedRule {
-  url: string;
+interface Open5eV1Section {
+  slug: string;
   name: string;
   desc: string;
+  parent: string;  // Free-text parent name, e.g. "Combat", "" for root
 }
 
-interface Open5eV2Ruleset {
-  key: string;     // e.g. "srd-2024_combat"
-  name: string;    // e.g. "Combat"
-  desc: string;
-  rules: EmbeddedRule[];
-}
-
-interface Open5eListResponse {
+interface Open5eListResponse<T> {
   count: number;
   next: string | null;
-  results: Open5eV2Ruleset[];
+  results: T[];
 }
 
-function slugFromUrl(url: string): string {
-  return url.replace(/\?.*$/, "").replace(/\/$/, "").split("/").pop() ?? url;
+interface Row {
+  slug: string;
+  name: string;
+  content: string;
+  parent_slug: string | null;
+  doc_slug: string;
 }
 
-async function fetchAllRulesets(): Promise<Open5eV2Ruleset[]> {
-  const results: Open5eV2Ruleset[] = [];
-  let url: string | null = `${OPEN5E_RULESETS_BASE}?limit=100&format=json`;
+async function fetchAll<T>(baseUrl: string): Promise<T[]> {
+  const results: T[] = [];
+  let url: string | null = `${baseUrl}?limit=100&format=json`;
   while (url) {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`open5e fetch failed: ${res.status} ${url}`);
-    const json: Open5eListResponse = await res.json();
+    const json: Open5eListResponse<T> = await res.json();
     results.push(...json.results);
     url = json.next;
   }
   return results;
+}
+
+/**
+ * Build tree-ready rows from the flat sections list:
+ *   1. Prefix every slug with `srd5_` so the namespace stays clean and
+ *      so old v2 rows (which used `srd-2024_*` keys) couldn't accidentally
+ *      collide on a re-import.
+ *   2. Look up each row's parent by lowercased name.
+ *   3. If a section's parent isn't in the result set, it becomes a
+ *      top-level node (`parent_slug: null`).
+ */
+function buildRows(sections: Open5eV1Section[]): Row[] {
+  const PREFIX = "srd5_";
+  const namesToSlugs = new Map<string, string>(
+    sections.map((s) => [s.name.toLowerCase(), `${PREFIX}${s.slug}`]),
+  );
+  return sections.map((s) => {
+    const parentName = (s.parent ?? "").toLowerCase().trim();
+    const parentSlug = parentName ? (namesToSlugs.get(parentName) ?? null) : null;
+    return {
+      slug:        `${PREFIX}${s.slug}`,
+      name:        s.name,
+      content:     s.desc ?? "",
+      parent_slug: parentSlug,
+      doc_slug:    DOC_SLUG,
+    };
+  });
 }
 
 Deno.serve(async (_req) => {
@@ -47,39 +90,18 @@ Deno.serve(async (_req) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
 
-    const rulesets = await fetchAllRulesets();
+    const sections = await fetchAll<Open5eV1Section>(OPEN5E_SECTIONS_BASE);
+    const rows: Row[] = buildRows(sections);
 
-    const rows: Array<{
-      slug: string;
-      name: string;
-      content: string;
-      parent_slug: string | null;
-      doc_slug: string;
-    }> = [];
+    // Remove stale rows from the previous v2 sync before upserting fresh
+    // v1 data. Idempotent: if no v2 rows exist (already migrated) the
+    // delete is a no-op.
+    const { error: deleteError, count: deletedCount } = await supabase
+      .from("srd_rules")
+      .delete({ count: "exact" })
+      .in("doc_slug", STALE_DOC_SLUGS);
+    if (deleteError) throw deleteError;
 
-    for (const rs of rulesets) {
-      // Parent row — the ruleset itself
-      rows.push({
-        slug:        rs.key,
-        name:        rs.name,
-        content:     rs.desc ?? "",
-        parent_slug: null,
-        doc_slug:    "srd-2024",
-      });
-
-      // Child rows — the individual rules embedded in the ruleset
-      for (const rule of rs.rules ?? []) {
-        rows.push({
-          slug:        slugFromUrl(rule.url),
-          name:        rule.name,
-          content:     rule.desc ?? "",
-          parent_slug: rs.key,
-          doc_slug:    "srd-2024",
-        });
-      }
-    }
-
-    // Upsert in batches
     let upserted = 0;
     for (let i = 0; i < rows.length; i += BATCH) {
       const { error } = await supabase
@@ -90,7 +112,13 @@ Deno.serve(async (_req) => {
     }
 
     return new Response(
-      JSON.stringify({ ok: true, synced: upserted, total: rows.length }),
+      JSON.stringify({
+        ok: true,
+        synced: upserted,
+        deleted_stale: deletedCount ?? 0,
+        doc_slug: DOC_SLUG,
+        sections_fetched: sections.length,
+      }),
       { headers: { "Content-Type": "application/json" } },
     );
   } catch (err) {


### PR DESCRIPTION
Closes the `v1/sections/` bullet on #142 and brings the Compendium edition in line with the rest of the app.

## What and why

The Reliquary Compendium was pulling from Open5e's **v2** `/v2/rulesets/` (2024 SRD / 5.5e) since it shipped — but every other Open5e endpoint we consume (spells / monsters / items / conditions / backgrounds / races) is on **v1** (2014 SRD 5.1). The Compendium was an island of 2024 rules in an otherwise-2014 app, with no campaign-level switch telling DMs which edition they were on.

Per the new tracking issue **#146** the right long-term move is a campaign-level ruleset switch (2014 ↔ 2024) with full v2 support across the app — but Open5e's v2 coverage is still patchy (no v2 backgrounds / conditions / feats / planes yet), so committing to 2024 today is premature. This PR brings the Compendium in line by switching the sync to v1 sections only.

When v2 coverage is complete enough that #146 can ship, the v2 fetch comes back as a version-aware path.

## Edge function changes

- Fetch from `https://api.open5e.com/v1/sections/` instead of `/v2/rulesets/`
- Tag rows `doc_slug: "srd-5.1"` (was `"srd-2024"`)
- Slug-prefix every section with `srd5_` to keep the namespace clean and avoid any future v2-vs-v1 collision
- Sections have free-text `parent` names in the v1 API; the function builds a `name → slug` lookup so children resolve to the right `parent_slug`
- **Cleanup**: every run starts with a `DELETE FROM srd_rules WHERE doc_slug IN ('srd-2024')` so previous v2 rows don't linger as orphans

Function response shape:
```json
{ "ok": true, "synced": 45, "deleted_stale": 317, "doc_slug": "srd-5.1", "sections_fetched": 45 }
```

## UI

**Zero changes to CompendiumTab.** With a single `doc_slug` in the table, the existing tree just shows v1 sections instead of v2 rulesets — no edition badge needed yet. That comes back when #146 lands and the table holds both editions side by side.

## Deploy

After merging:

```bash
supabase functions deploy sync-srd-rules
# then trigger it (Supabase dashboard → Edge Functions → Invoke, or curl)
```

The first run will delete the existing 317 v2 rule rows and replace them with the ~45 v1 section rows. **This is a destructive change to the Compendium contents** — DMs who relied on the 2024 rulings being there will see 2014 prose instead until v2 support lands. That's the intentional trade-off for cross-app consistency; #146 captures the path back.

## Test plan

- [x] Function compiles cleanly under deno's TS checker
- [x] `npm run build` — passes (no client changes touch the build)
- [x] `npm run lint` — 0 warnings, 0 errors
- [ ] Deploy + invoke — verify response payload includes `synced` count > 0 and `deleted_stale` matches the prior v2 row count
- [ ] Open `/rules` Compendium tab — verify v1 sections (Combat, Equipment, Magic, etc.) appear in the tree
- [ ] Verify no orphaned v2 rows in `srd_rules` (`select count(*) from srd_rules where doc_slug = 'srd-2024'` → 0)
- [ ] Search still works in the Compendium

Refs #142, #146

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx