### PR TITLE
feat(workshop): visibility toggle on list rows + Claude Code session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SessionStart hook — installs Node dependencies so `npm run build`, `npm run
+# lint`, and `npm run dev` are ready when the Claude Code session begins.
+#
+# Grimoire is Vue + Vite + Supabase; the repo is all JS/TS — no Python, no
+# Rust, no Go. `npm install` is the only setup step needed for a working
+# agent environment. Supabase CLI operations (`supabase db push`, function
+# deploys) happen on the user's machine, not here, so the CLI isn't
+# provisioned from this hook.
+#
+# Remote-only: we short-circuit on local runs so maintainers don't get a
+# surprise `npm install` every session.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+echo "[session-start] installing npm dependencies…"
+# `npm install` (not `npm ci`) so the container cache can incrementally reuse
+# node_modules across sessions. Idempotent — no-op when the lockfile is
+# already satisfied.
+npm install --no-audit --no-fund --loglevel=error
+echo "[session-start] done"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -301,6 +301,8 @@
 - [x] **Crafting open to non-proficient players** — disciplines no longer fully locked; players without tool proficiency can still attempt (no proficiency bonus), with "NO PROF" badge on tab; standard workspace bonus and poor-ingredient penalty modifiers added to all attempt dialogs
 - [x] **Recipe player visibility** — replaced dedicated GrantRecipeDialog with unified PlayerVisibilityToggle component; recipes now use `shared_with_players` + `player_visible_to` columns matching NPC/quest/location pattern
 
+- [x] **Recipe visibility toggle on Workshop list** — added `PlayerVisibilityToggle` directly to each recipe row's action cluster (next to Edit + Delete) so the DM can flip a recipe's per-player visibility without entering the editor. Uses the existing `useUpdateRecipe` mutation; row click is `@click.stop`-guarded so clicking the toggle's popover doesn't navigate to the detail page.
+
 ---
 
 ## AI Features

--- a/src/views/crafting/CraftingView.vue
+++ b/src/views/crafting/CraftingView.vue
@@ -121,7 +121,11 @@
           </div>
 
           <!-- Actions -->
-          <div class="flex items-center gap-1 shrink-0">
+          <div class="flex items-center gap-1 shrink-0" @click.stop>
+            <PlayerVisibilityToggle
+              :visible-to="recipe.player_visible_to"
+              @update:visible-to="onVisibilityChange(recipe, $event)"
+            />
             <button
               class="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
               title="Edit recipe"
@@ -149,8 +153,9 @@ import { computed, ref } from "vue";
 import { Award, Download, LayoutList, Loader2, Pencil, Plus, Trash2, Wrench } from "lucide-vue-next";
 import ListPageLayout from "@/components/common/ListPageLayout.vue";
 import ListActionButton from "@/components/common/ListActionButton.vue";
+import PlayerVisibilityToggle from "@/components/common/PlayerVisibilityToggle.vue";
 import { CRAFTING_DISCIPLINES, getDiscipline } from "@/lib/crafting-disciplines";
-import { useCraftingRecipes, useDeleteRecipe, useImportStarterRecipes } from "@/composables/useCrafting";
+import { useCraftingRecipes, useDeleteRecipe, useImportStarterRecipes, useUpdateRecipe } from "@/composables/useCrafting";
 import { useConfirm } from "@/composables/useConfirm";
 import { useUiStore } from "@/stores/ui";
 import type { CraftingRecipe } from "@/types/crafting.types";
@@ -163,7 +168,15 @@ const activeDiscipline = computed(() =>
 
 const { data: recipes, isLoading } = useCraftingRecipes();
 const { mutateAsync: deleteRecipe } = useDeleteRecipe();
+const { mutateAsync: updateRecipe } = useUpdateRecipe();
 const { confirm } = useConfirm();
+
+// Persist a visibility change from the list row. The toggle is wrapped in
+// `@click.stop` above so clicking inside the popover doesn't navigate to
+// the editor.
+async function onVisibilityChange(recipe: CraftingRecipe, visibleTo: string[]) {
+  await updateRecipe({ id: recipe.id, update: { player_visible_to: visibleTo } });
+}
 
 const importMutation = useImportStarterRecipes();
 const importStatus = ref<"idle" | "done" | "uptodate">("idle");


### PR DESCRIPTION
## Summary

Two small adds in one PR:

### Workshop: visibility toggle on the list row

Recipe cards in `/crafting` only exposed Edit + Delete on the row action cluster — flipping a recipe's per-player visibility required entering the editor. Added `PlayerVisibilityToggle` inline alongside the existing actions, wired to the existing `useUpdateRecipe` mutation. Row click is `@click.stop`-guarded so interacting with the toggle's popover doesn't navigate to the detail page.

### `.claude/hooks/session-start.sh` — SessionStart hook

Runs `npm install` when a Claude Code on the web session boots, so `npm run build` / `npm run lint` / `npm run dev` are ready from the first prompt. Uses `npm install --no-audit --no-fund --loglevel=error` (not `npm ci`) so the container can incrementally reuse `node_modules` across sessions. Short-circuits on local runs via `$CLAUDE_CODE_REMOTE` so maintainers don't get a surprise `npm install` each session.

Registered via the SessionStart entry in `.claude/settings.json` — existing Stop (TS check) + PostToolUse (migration warning) hooks kept untouched.

## Validation results

1. ✅ **Session hook execution** — ran `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` locally, printed `[session-start] installing npm dependencies… added 1 package in 4s [session-start] done`, exit 0
2. ✅ **Linter execution** — `npx oxlint --config oxlint.json src/views/crafting/CraftingView.vue` → `Found 0 warnings and 0 errors`
3. ➖ **Test execution** — no tests to run (package.json has no `test` script; the project relies on vue-tsc + build as its CI signal)

## Hook execution mode: synchronous

- **Pros**: Guarantees `node_modules` is installed before the session starts, preventing a race where Claude tries to run `npm run build` / `lint` before they're ready.
- **Cons**: Your remote session will only start once `npm install` finishes (~4–30s depending on cache state).

If you'd rather have the session boot faster at the cost of that race, I can flip the hook to async mode in a follow-up.

Once this merges into main, all future Claude Code on the web sessions on this repo will use the hook automatically.

## Test plan

- [ ] On `/crafting`, each recipe row now shows an eye/eye-off toggle between the recipe info and the Edit button
- [ ] Clicking the toggle opens the popover without navigating to the detail page
- [ ] Picking "All players" or individual players from the popover persists after reload
- [ ] Starting a new Claude Code on the web session on this repo runs `npm install` before the first prompt

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx