### PR TITLE
feat(npc): surface Relations in view-mode sheet

### DIFF
--- a/src/components/npcs/NpcTabContent.vue
+++ b/src/components/npcs/NpcTabContent.vue
@@ -54,6 +54,16 @@
       <NpcInventorySection :npc-id="npc.id" :npc-name="npc.name" />
     </div>
 
+    <!-- Relations tab -->
+    <!-- Surfacing NpcRelationsSection here so DMs can see (and tweak)
+         relations from the view mode sheet — previously relations were only
+         visible after clicking into the edit form. See #168. The component
+         handles its own CRUD so embedding it here doesn't require flipping
+         the sheet into "edit mode". -->
+    <div v-else-if="activeTab === 'relations'">
+      <NpcRelationsSection :npc-id="npc.id" />
+    </div>
+
     <!-- Combat tab -->
     <div v-else-if="activeTab === 'combat'" class="space-y-4">
       <template v-if="npc.stat_block">
@@ -75,6 +85,7 @@ import StatBlockPanel from "@/components/common/StatBlockPanel.vue";
 import TraitList from "@/components/common/TraitList.vue";
 import SpellcastingList from "@/components/common/SpellcastingList.vue";
 import NpcInventorySection from "@/components/npcs/NpcInventorySection.vue";
+import NpcRelationsSection from "@/components/npcs/NpcRelationsSection.vue";
 import type { Npc } from "@/types/npc.types";
 
 defineProps<{ npc: Npc }>();
@@ -82,6 +93,7 @@ defineProps<{ npc: Npc }>();
 const TABS = [
   { key: 'lore',      label: 'Lore' },
   { key: 'inventory', label: 'Inventory' },
+  { key: 'relations', label: 'Relations' },
   { key: 'combat',    label: 'Combat' },
 ] as const;
 type TabKey = typeof TABS[number]['key'];


### PR DESCRIPTION
## Summary

First concrete fix from the audit tracked in #168. NPC Relations were only visible inside the edit form (`NpcDetail.vue:227`) — DMs had to flip the sheet into edit mode just to see who an NPC is connected to.

Added a **Relations** tab to `NpcTabContent` between Inventory and Combat that renders `NpcRelationsSection` with the same `npcId` prop.

The section handles its own CRUD so embedding it in view mode doesn't require flipping to edit — DMs can add/remove relations directly from the sheet. The edit form keeps its copy too so the existing flow is unchanged; both instances read from the same Supabase table and stay in sync via realtime.

## Related

- Issue #168 tracks the broader audit: several DM detail views (`LocationDetailView`, `QuestDetailView`, `FactionDetailView`, `TrapDetailView`, `DungeonFeatureDetailView`) still render only the edit form with no view mode. Each can land as its own PR.

## Test plan

- [ ] Open any NPC detail page without `?edit=true` → sheet renders with the new **Relations** tab between Inventory and Combat
- [ ] Switching to the Relations tab lists any relations that were there before this PR (they've been in the DB all along — this just surfaces them)
- [ ] Adding / removing a relation from the sheet persists and re-renders
- [ ] Flipping to edit mode still shows the same relations section at its old position (both instances read the same data)

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx