### PR TITLE
feat(locations): DM sheet + edit toggle for LocationDetailView

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -305,6 +305,8 @@
 
 - [x] **Recipe visibility toggle on Workshop list** — added `PlayerVisibilityToggle` directly to each recipe row's action cluster (next to Edit + Delete) so the DM can flip a recipe's per-player visibility without entering the editor. Uses the existing `useUpdateRecipe` mutation; row click is `@click.stop`-guarded so clicking the toggle's popover doesn't navigate to the detail page.
 
+- [x] **LocationDetailView — view/edit split** (irongollem/grimoire#168) — DM-side location detail now renders a read-only sheet by default (sigil + type badge + tags + Tiptap description + map + sub-locations + People in the Area + Encounters Here + Currently Here + store inventory for store/tavern/inn types) with an **Edit** button that appends `?edit=true` to flip into the existing `LocationEditor`. Editor gains a **Cancel** button that strips the flag (preserves other query params like `?parent=` for nested creates). Sub-location links, NPC cards, encounter cards, and party-member chips are now clickable navigation — no more picker-only access to the location's network. Matches the NPC / Monster / Item / Spell split convention.
+
 ---
 
 ## AI Features

--- a/src/components/locations/LocationEditor.vue
+++ b/src/components/locations/LocationEditor.vue
@@ -45,6 +45,14 @@
         @update:visible-to="playerVisibleTo = $event"
       />
       <button
+        v-if="!isNew"
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-muted-foreground/50 transition-colors"
+        @click="onCancel"
+      >
+        Cancel
+      </button>
+      <button
         type="button"
         :disabled="saving || !name.trim()"
         class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity disabled:opacity-50"
@@ -595,7 +603,7 @@
 import { useConfirm } from "@/composables/useConfirm";
 const { confirm } = useConfirm();
 import { ref, computed, watch } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import {
   Save,
   Trash2,
@@ -643,6 +651,14 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+
+// Drop the `?edit=true` flag so Cancel takes the DM back to the sheet view,
+// preserving any other query params (e.g. ?parent=xxx for nested creates).
+const route = useRoute();
+function onCancel() {
+  const { edit: _edit, ...rest } = route.query;
+  router.push({ query: rest });
+}
 const isNew = computed(() => !props.location);
 
 // ── All locations (for parent picker) ─────────────────────────────────────────

--- a/src/components/locations/LocationSheet.vue
+++ b/src/components/locations/LocationSheet.vue
@@ -1,0 +1,327 @@
+<template>
+  <div class="flex flex-col gap-5">
+    <!-- Breadcrumb — same pattern as the editor so DMs keep their bearings
+         when switching between view and edit modes. -->
+    <div
+      v-if="ancestors.length"
+      class="flex flex-wrap items-center gap-1 text-xs font-fell text-muted-foreground"
+    >
+      <RouterLink to="/locations" class="hover:text-foreground transition-colors">Locations</RouterLink>
+      <template v-for="anc in ancestors" :key="anc.id">
+        <span class="opacity-40">/</span>
+        <RouterLink :to="`/locations/${anc.id}`" class="hover:text-foreground transition-colors">{{ anc.name }}</RouterLink>
+      </template>
+      <span class="opacity-40">/</span>
+      <span class="text-foreground">{{ location.name }}</span>
+    </div>
+
+    <!-- Action bar — Edit + Delete. Edit flips the view wrapper's ?edit=true
+         query; delete is DM-dangerous so kept right-aligned separately. -->
+    <div class="flex flex-wrap items-center justify-end gap-2">
+      <span
+        v-if="location.location_type"
+        class="font-cinzel text-[10px] tracking-wider bg-muted text-muted-foreground rounded px-2 py-0.5 capitalize"
+      >{{ LOCATION_TYPE_LABELS[location.location_type] }}</span>
+      <button
+        type="button"
+        :disabled="isDeleting"
+        class="inline-flex items-center gap-1.5 rounded-md border border-destructive px-3 py-2 font-cinzel text-xs font-semibold text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+        @click="onDelete"
+      >
+        <Trash2 class="h-3.5 w-3.5" />
+        Delete
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
+        @click="router.push({ query: { ...route.query, edit: 'true' } })"
+      >
+        <Pencil class="h-3.5 w-3.5" />
+        Edit
+      </button>
+    </div>
+
+    <!-- Identity: sigil + name + tags.
+         Mobile stacks (sigil above name block), desktop is side-by-side. -->
+    <div class="flex flex-col gap-4 md:flex-row md:gap-6">
+      <div v-if="location.image_url" class="w-full max-w-48 mx-auto md:mx-0 md:w-48 md:shrink-0">
+        <FocalImage
+          :src="location.image_url"
+          :alt="location.name"
+          format="portrait"
+          class="w-full rounded-lg border border-border overflow-hidden"
+        />
+      </div>
+      <div class="flex-1 flex flex-col gap-3 min-w-0">
+        <div class="flex flex-col gap-1">
+          <h1 class="font-cinzel text-2xl font-bold text-foreground leading-tight">{{ location.name }}</h1>
+          <p v-if="location.location_type" class="font-fell text-sm text-muted-foreground italic">
+            {{ LOCATION_TYPE_LABELS[location.location_type] }}
+          </p>
+        </div>
+        <div v-if="location.tags?.length" class="flex flex-wrap gap-1.5">
+          <span
+            v-for="tag in location.tags"
+            :key="tag"
+            class="font-cinzel text-[10px] tracking-wider bg-muted/60 text-muted-foreground rounded px-2 py-0.5"
+          >{{ tag }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Description — DM-facing Tiptap content. -->
+    <section v-if="hasDescription" class="flex flex-col gap-2">
+      <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">Description</h2>
+      <RichTextViewer :content="location.description" />
+    </section>
+
+    <!-- Map -->
+    <section v-if="location.map_url" class="flex flex-col gap-2">
+      <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">Map</h2>
+      <LocationMap
+        :map-url="location.map_url"
+        :pins="location.map_pins ?? []"
+        :children="mapPinnableChildren"
+        mode="view"
+        :show-hidden-pins="true"
+        @pin-click="onPinClick"
+      />
+    </section>
+
+    <!-- Sub-locations — read-only list linking into each child. -->
+    <section v-if="children?.length" class="flex flex-col gap-2">
+      <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">
+        Sub-locations
+        <span class="font-fell font-normal text-muted-foreground">({{ children.length }})</span>
+      </h2>
+      <div class="flex flex-wrap gap-2">
+        <RouterLink
+          v-for="child in children"
+          :key="child.id"
+          :to="`/locations/${child.id}`"
+          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1.5 hover:border-primary/50 transition-colors"
+        >
+          <span
+            class="h-2 w-2 rounded-full shrink-0"
+            :style="{ backgroundColor: LOCATION_TYPE_COLORS[child.location_type] }"
+          />
+          <span class="font-cinzel text-xs text-foreground truncate max-w-40">{{ child.name }}</span>
+        </RouterLink>
+      </div>
+    </section>
+
+    <!-- Store inventory — self-contained editable component. Useful enough
+         to keep in view mode so a DM running a shop scene doesn't need to
+         enter full-edit just to restock. -->
+    <section v-if="isStoreType" class="flex flex-col gap-2">
+      <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">Store</h2>
+      <StoreInventory :location-id="location.id" :owner-npc-id="location.npc_owner_id ?? null" />
+    </section>
+
+    <!-- People in the Area — NPCs whose location is this or any descendant. -->
+    <section v-if="locationNpcs?.length" class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">
+          People in the Area
+          <span class="font-fell font-normal text-muted-foreground">({{ locationNpcs.length }})</span>
+        </h2>
+        <button
+          v-if="locationNpcs.length > 3"
+          type="button"
+          class="font-cinzel text-[10px] text-muted-foreground hover:text-foreground tracking-wider transition-colors"
+          @click="npcsExpanded = !npcsExpanded"
+        >
+          {{ npcsExpanded ? "Show less" : `Show all ${locationNpcs.length}` }}
+        </button>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <RouterLink
+          v-for="npc in npcsExpanded ? locationNpcs : locationNpcs.slice(0, 3)"
+          :key="npc.id"
+          :to="`/npcs/${npc.id}`"
+          class="group flex items-center gap-3 rounded-lg border border-border bg-card hover:border-primary/50 transition-colors p-3 overflow-hidden"
+        >
+          <div class="flex-1 min-w-0">
+            <p class="font-cinzel text-sm font-semibold text-foreground truncate">{{ npc.name }}</p>
+            <p
+              v-if="npc.occupation || npc.race"
+              class="font-fell text-xs text-muted-foreground italic truncate"
+            >{{ [npc.race, npc.occupation].filter(Boolean).join(" · ") }}</p>
+            <p
+              v-if="npc.location_id && npc.location_id !== location.id"
+              class="font-cinzel text-[10px] text-muted-foreground/60 tracking-wide truncate mt-0.5"
+            >{{ allLocations?.find((l) => l.id === npc.location_id)?.name ?? "" }}</p>
+          </div>
+          <ChevronRight class="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
+        </RouterLink>
+      </div>
+    </section>
+
+    <!-- Encounters Here -->
+    <section v-if="locationEncounters?.length" class="flex flex-col gap-2">
+      <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">
+        Encounters Here
+        <span class="font-fell font-normal text-muted-foreground">({{ locationEncounters.length }})</span>
+      </h2>
+      <div class="flex flex-col gap-2">
+        <RouterLink
+          v-for="enc in locationEncounters"
+          :key="enc.id"
+          :to="`/encounters/${enc.id}`"
+          class="group flex items-center gap-3 rounded-lg border border-border bg-card hover:border-primary/50 transition-colors px-4 py-3"
+        >
+          <span class="flex-1 font-cinzel text-sm font-semibold text-foreground truncate">{{ enc.name }}</span>
+          <span
+            v-if="enc.is_finished"
+            class="font-cinzel text-[10px] text-muted-foreground tracking-wider"
+          >Done</span>
+          <ChevronRight class="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
+        </RouterLink>
+      </div>
+    </section>
+
+    <!-- Currently Here — party members with current_location_id = this id.
+         Read-only in view mode; moving members happens in edit mode. -->
+    <section v-if="membersHere.length" class="flex flex-col gap-2">
+      <h2 class="font-cinzel text-sm font-bold tracking-wide text-foreground">
+        Currently Here
+        <span class="font-fell font-normal text-muted-foreground">({{ membersHere.length }})</span>
+      </h2>
+      <div class="flex flex-wrap gap-2">
+        <RouterLink
+          v-for="m in membersHere"
+          :key="m.id"
+          :to="`/party/${m.id}`"
+          class="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 hover:border-primary/50 transition-colors"
+        >
+          <span class="font-cinzel text-xs font-semibold text-foreground">{{ m.name }}</span>
+          <span
+            v-if="m.class"
+            class="font-fell text-[10px] text-muted-foreground italic"
+          >{{ m.class }}</span>
+        </RouterLink>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useRoute, useRouter, RouterLink } from "vue-router";
+import { Pencil, Trash2, ChevronRight } from "lucide-vue-next";
+import { useConfirm } from "@/composables/useConfirm";
+import {
+  useLocations,
+  useAllLocations,
+  useDeleteLocation,
+  getPinnableDescendants,
+} from "@/composables/useLocations";
+import { useNpcsByLocations } from "@/composables/useNpcs";
+import { useEncountersByLocation } from "@/composables/useEncounters";
+import { useParty } from "@/composables/useParty";
+import {
+  LOCATION_TYPE_LABELS,
+  LOCATION_TYPE_COLORS,
+  STORE_LOCATION_TYPES,
+} from "@/types/location.types";
+import type { Location } from "@/types/location.types";
+import FocalImage from "@/components/common/FocalImage.vue";
+import RichTextViewer from "@/components/common/RichTextViewer.vue";
+import LocationMap from "@/components/locations/LocationMap.vue";
+import StoreInventory from "@/components/locations/StoreInventory.vue";
+
+const props = defineProps<{ location: Location }>();
+const route   = useRoute();
+const router  = useRouter();
+const { confirm } = useConfirm();
+
+// ── Ancestor chain, same as editor ──────────────────────────────────────────
+const { data: allLocations } = useAllLocations();
+const ancestors = computed(() => {
+  const parent = props.location.parent_id;
+  if (!parent || !allLocations.value?.length) return [];
+  const chain: Location[] = [];
+  let current = allLocations.value.find((l) => l.id === parent);
+  while (current && chain.length < 10) {
+    chain.unshift(current);
+    current = current.parent_id
+      ? allLocations.value!.find((l) => l.id === current!.parent_id)
+      : undefined;
+  }
+  return chain;
+});
+
+// ── Children + pinnable descendants (for the map viewer) ────────────────────
+const { data: children } = useLocations(props.location.id);
+const mapPinnableChildren = computed(() => {
+  if (!allLocations.value?.length) return [];
+  return getPinnableDescendants(props.location.id, allLocations.value);
+});
+
+// ── NPCs + Encounters + Party members ───────────────────────────────────────
+function collectDescendantIds(id: string, allLocs: Location[]): string[] {
+  const result: string[] = [id];
+  for (const loc of allLocs) {
+    if (loc.parent_id === id) result.push(...collectDescendantIds(loc.id, allLocs));
+  }
+  return result;
+}
+
+const npcLocationIds = computed(() => {
+  if (!allLocations.value?.length) return [props.location.id];
+  return collectDescendantIds(props.location.id, allLocations.value);
+});
+
+const { data: locationNpcs } = useNpcsByLocations(npcLocationIds);
+const { data: locationEncounters } = useEncountersByLocation(props.location.id);
+const npcsExpanded = ref(false);
+
+const { data: allPartyMembers } = useParty();
+const membersHere = computed(() =>
+  (allPartyMembers.value ?? []).filter(
+    (m) => m.current_location_id === props.location.id,
+  ),
+);
+
+// ── Misc ────────────────────────────────────────────────────────────────────
+const hasDescription = computed(() => {
+  const d = props.location.description;
+  if (!d) return false;
+  // Tiptap empty doc looks like `{"type":"doc","content":[{"type":"paragraph"}]}`
+  // so render only when there's actual text content.
+  try {
+    const doc = JSON.parse(d);
+    const texts: string[] = [];
+    function walk(n: { text?: string; content?: unknown[] }) {
+      if (n.text) texts.push(n.text);
+      (n.content as typeof n[] | undefined)?.forEach(walk);
+    }
+    walk(doc);
+    return texts.join("").trim().length > 0;
+  } catch {
+    return String(d).trim().length > 0;
+  }
+});
+
+const isStoreType = computed(() => STORE_LOCATION_TYPES.has(props.location.location_type));
+
+// ── Delete ──────────────────────────────────────────────────────────────────
+const { mutateAsync: deleteLocation } = useDeleteLocation();
+const isDeleting = ref(false);
+
+async function onDelete() {
+  if (!(await confirm(`Delete "${props.location.name}"? This cannot be undone.`))) return;
+  isDeleting.value = true;
+  try {
+    router.push("/locations");
+    await deleteLocation(props.location.id);
+  } finally {
+    isDeleting.value = false;
+  }
+}
+
+// Pin click in view mode → navigate to the child location.
+function onPinClick(childId: string) {
+  router.push(`/locations/${childId}`);
+}
+</script>

--- a/src/views/locations/LocationDetailView.vue
+++ b/src/views/locations/LocationDetailView.vue
@@ -7,12 +7,21 @@
       <LoadingSpinner />
     </div>
 
+    <!-- New locations always go straight into the editor — no sheet to show
+         until the row exists. Existing locations render the sheet by default
+         and flip into the editor when `?edit=true` is present, matching the
+         NPC / Monster / Item / Spell convention (#168). -->
     <LocationEditor
-      v-else
+      v-else-if="isNew || isEditing"
       :key="id || 'new'"
       :location="isNew ? null : (location ?? null)"
       :parent-id="parentId ?? null"
       :initial-name="initialName"
+    />
+    <LocationSheet
+      v-else-if="location"
+      :key="location.id"
+      :location="location"
     />
   </PageHeader>
 </template>
@@ -24,10 +33,12 @@ import { useLocation } from "@/composables/useLocations";
 import PageHeader from "@/components/common/PageHeader.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import LocationEditor from "@/components/locations/LocationEditor.vue";
+import LocationSheet from "@/components/locations/LocationSheet.vue";
 import { LOCATION_TYPE_LABELS } from "@/types/location.types";
 
 const route      = useRoute();
 const isNew      = computed(() => route.name === "location-new");
+const isEditing  = computed(() => route.query.edit === "true");
 const id         = computed(() => (isNew.value ? "" : (route.params.id as string)));
 const parentId   = computed(() => (route.query.parent as string | undefined));
 const initialName = computed(() => (route.query.name as string | undefined));


### PR DESCRIPTION
## Summary

First item off the #168 audit list. `LocationDetailView` was the most glaring form-only DM screen — you had to stare at a 945-line editor just to read your own location. Detail now defaults to a read-only **LocationSheet** with an **Edit** button that flips into the existing `LocationEditor` via `?edit=true` (same convention as NPC / Monster / Item / Spell).

## New — `LocationSheet.vue`

Renders DM-friendly read-only content in roughly this order:

- **Ancestor breadcrumb** (reused from editor)
- **Identity block** — prominent sigil via `FocalImage`, name, type badge, tag pills
- **Description** — `RichTextViewer`; section hidden when the Tiptap doc is empty
- **Map** — `LocationMap` in view mode; pin clicks navigate to the child location
- **Sub-locations** — clickable chips (no more picker-only access to the hierarchy)
- **People in the Area** — NPCs at this location or any descendant, expand/collapse past 3
- **Encounters Here** — linked cards
- **Currently Here** — party members matched by `current_location_id`
- **Store inventory** (store / tavern / inn only) — embedded inline; `StoreInventory` already self-manages its CRUD so a DM restocking a shop doesn't need full edit mode

**Delete** lives on the sheet so destructive actions stay one click away but clearly separated from Edit.

## `LocationDetailView`

Thin router wrapper that picks sheet vs editor:

- `location-new` route **or** `?edit=true` query → `LocationEditor`
- Otherwise → `LocationSheet`

## `LocationEditor`

- New **Cancel** button (edit-existing only) that strips `?edit=true` from the query so the DM lands back on the sheet. Any other query params (e.g. `?parent=xxx` for nested creates) are preserved.
- Save / Delete navigation is unchanged — both still go to `/locations` per the post-mutation convention in `CLAUDE.md`.

## Intentionally not touched here

- **Player side** — players currently only see a mini-thumb sigil on the map pin, not the location art itself. Landing as a separate small PR after this (you flagged it yesterday).
- Other #168 items (`QuestDetailView`, `FactionDetailView`, `EncounterDetailView`, `PartyMemberView`, Dungeon Craft views, Codex views, lighter views) — separate PRs; each follows the same mechanical refactor.

## Test plan

- [x] `npm run build` passes (verified locally — vue-tsc clean)
- [x] `/locations/<id>` renders the sheet with sigil, type badge, tags, description, map, children, NPCs, encounters, party members, store inventory where applicable
- [x] **Edit** button navigates to `/locations/<id>?edit=true` and renders the editor
- [x] **Cancel** in the editor returns to the sheet (query stripped, not a new history entry — browser back still works)
- [x] **Save** in the editor still navigates to `/locations` (list) as before
- [x] **Delete** on the sheet and inside the editor both go to `/locations`
- [x] Creating a new location (`/locations/new`) still goes straight into the editor — no sheet phase
- [x] Nested create (`/locations/new?parent=<id>`) still respects the parent param through Save / Cancel
- [ ] Clicking a map pin in view mode navigates to the child location
- [x] Clicking an NPC / encounter / party-member card navigates to the respective detail

https://claude.ai/code/session_01Gw1QE9FcNgguNH2ucp4xSx