### PR TITLE
feat: physical-dice mode + concentration enforcement

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
       <RouterView />
     </component>
     <ConfirmDialog />
+    <ManualRollPrompt />
   </template>
 
   <!-- Pull-to-refresh indicator (touch devices only) -->
@@ -29,6 +30,7 @@ import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import AuthLayout from "@/layouts/AuthLayout.vue";
 import PlayerLayout from "@/layouts/PlayerLayout.vue";
 import ConfirmDialog from "@/components/common/ConfirmDialog.vue";
+import ManualRollPrompt from "@/components/common/ManualRollPrompt.vue";
 import LoadingScreen from "@/components/auth/LoadingScreen.vue";
 import { useTheme } from "@/composables/useTheme";
 import { supabase } from "@/lib/supabase";

--- a/src/components/chat/CampaignChatPanel.vue
+++ b/src/components/chat/CampaignChatPanel.vue
@@ -60,6 +60,12 @@
               class="font-cinzel text-[10px] text-destructive tracking-wider"
               >NAT 1</span
             >
+            <span
+              v-if="(msg.metadata as RollMetadata).manual"
+              class="font-cinzel text-[10px] text-muted-foreground tracking-wider"
+              title="Entered from physical dice"
+              >MANUAL</span
+            >
           </div>
         </template>
 

--- a/src/components/common/ManualRollPrompt.vue
+++ b/src/components/common/ManualRollPrompt.vue
@@ -1,0 +1,201 @@
+<template>
+  <Teleport to="body">
+    <Transition name="dialog-fade">
+      <div
+        v-if="pending"
+        class="fixed inset-0 z-200 flex items-center justify-center p-4"
+        @mousedown.self="cancel"
+      >
+        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+
+        <div
+          class="relative w-full max-w-md rounded-xl border border-border bg-card shadow-2xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="manual-roll-title"
+        >
+          <div class="px-5 pt-5 pb-3">
+            <h2
+              id="manual-roll-title"
+              class="font-cinzel text-sm font-bold text-foreground tracking-wide"
+            >
+              Enter your dice roll
+            </h2>
+            <p class="mt-1 font-fell text-sm text-muted-foreground leading-snug">
+              {{ pending.label }} — roll your physical dice and enter the result{{
+                totalDice > 1 ? "s" : ""
+              }}.
+            </p>
+          </div>
+
+          <div class="px-5 pb-3 space-y-3">
+            <div
+              v-for="row in rows"
+              :key="row.sides"
+              class="flex items-center gap-2"
+            >
+              <span
+                class="w-14 shrink-0 font-cinzel text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+              >
+                d{{ row.sides }}
+              </span>
+              <div class="flex flex-wrap gap-1.5">
+                <input
+                  v-for="(_, i) in row.inputs"
+                  :key="i"
+                  v-model.number="row.inputs[i]"
+                  type="number"
+                  :min="1"
+                  :max="row.sides"
+                  :placeholder="'1–' + row.sides"
+                  class="w-16 rounded-md border border-border bg-background px-2 py-1 text-center font-mono text-sm focus:border-primary focus:outline-none"
+                />
+              </div>
+              <span
+                v-if="row.advLabel"
+                class="ml-1 font-cinzel text-[10px] uppercase tracking-wider text-muted-foreground"
+              >
+                {{ row.advLabel }}
+              </span>
+            </div>
+
+            <div v-if="pending.modifier !== 0" class="pt-1 text-xs text-muted-foreground font-fell">
+              Modifier: <span class="font-semibold text-foreground">{{
+                pending.modifier > 0 ? `+${pending.modifier}` : pending.modifier
+              }}</span>
+            </div>
+            <div class="text-xs text-muted-foreground font-fell">
+              Running total:
+              <span class="font-semibold text-foreground">{{ runningTotal }}</span>
+              <span v-if="!allFilled" class="italic"> (incomplete)</span>
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-2 px-5 pb-5 pt-2">
+            <button
+              type="button"
+              class="px-4 py-1.5 rounded-md border border-border font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors tracking-wider"
+              @click="cancel"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="px-4 py-1.5 rounded-md font-cinzel text-xs font-semibold tracking-wider transition-colors bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+              :disabled="!allFilled"
+              @click="submit"
+            >
+              Submit
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import type { DieSize } from "@/lib/dice";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
+
+const { pending, _resolveManual } = usePromptedRoll();
+
+interface Row {
+  sides: DieSize;
+  inputs: (number | null)[];
+  advLabel: string;
+}
+
+const rows = ref<Row[]>([]);
+
+watch(
+  pending,
+  (p) => {
+    if (!p) {
+      rows.value = [];
+      return;
+    }
+    const next: Row[] = [];
+    for (const sides of [4, 6, 8, 10, 12, 20, 100] as DieSize[]) {
+      const n = p.counts[sides] ?? 0;
+      if (n === 0) continue;
+      const isAdv = sides === 20 && n === 1 && p.mode !== "normal";
+      next.push({
+        sides,
+        inputs: Array.from({ length: isAdv ? 2 : n }, () => null),
+        advLabel: isAdv ? (p.mode === "advantage" ? "Advantage (keep higher)" : "Disadvantage (keep lower)") : "",
+      });
+    }
+    rows.value = next;
+  },
+  { immediate: true },
+);
+
+const totalDice = computed(() =>
+  rows.value.reduce((s, r) => s + r.inputs.length, 0),
+);
+
+function clamp(sides: DieSize, val: number | null): number | null {
+  if (val == null || Number.isNaN(val)) return null;
+  if (val < 1 || val > sides) return null;
+  return Math.floor(val);
+}
+
+const allFilled = computed(() =>
+  rows.value.every((r) =>
+    r.inputs.every((v) => clamp(r.sides, v) !== null),
+  ),
+);
+
+const runningTotal = computed(() => {
+  const p = pending.value;
+  if (!p) return 0;
+  let sum = p.modifier;
+  for (const r of rows.value) {
+    const vals = r.inputs.map((v) => clamp(r.sides, v)).filter((v): v is number => v !== null);
+    if (vals.length === 0) continue;
+    if (r.sides === 20 && (p.counts[20] ?? 0) === 1 && p.mode !== "normal" && vals.length === 2) {
+      sum += p.mode === "advantage" ? Math.max(vals[0], vals[1]) : Math.min(vals[0], vals[1]);
+    } else {
+      sum += vals.reduce((s, v) => s + v, 0);
+    }
+  }
+  return sum;
+});
+
+function submit() {
+  if (!allFilled.value) return;
+  const values: Partial<Record<DieSize, number[]>> = {};
+  for (const r of rows.value) {
+    values[r.sides] = r.inputs.map((v) => clamp(r.sides, v) as number);
+  }
+  _resolveManual(values as Record<DieSize, number[]>);
+}
+
+function cancel() {
+  _resolveManual(null);
+}
+</script>
+
+<style scoped>
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+.dialog-fade-enter-active .relative,
+.dialog-fade-leave-active .relative {
+  transition:
+    transform 0.15s ease,
+    opacity 0.15s ease;
+}
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+.dialog-fade-enter-from .relative,
+.dialog-fade-leave-to .relative {
+  transform: scale(0.95);
+  opacity: 0;
+}
+</style>

--- a/src/components/encounters/RunnerCombatantList.vue
+++ b/src/components/encounters/RunnerCombatantList.vue
@@ -128,6 +128,12 @@
         @click="store.toggleCondition(combatant.instance_id, cond)"
         :title="`${cond} — click to remove\n\n${getConditionDescription(cond)}`"
       >{{ cond }} ×</span>
+      <span
+        v-if="pcConcentration(combatant)"
+        class="conc-chip"
+        :title="`Concentrating on ${pcConcentration(combatant)} — click to drop`"
+        @click="dropCombatantConcentration(combatant)"
+      >✦ {{ pcConcentration(combatant) }} ×</span>
       <div class="relative" v-if="addingCondFor !== combatant.instance_id">
         <button class="add-cond-btn" @click="addingCondFor = combatant.instance_id">+</button>
       </div>
@@ -332,6 +338,8 @@ import { Eye, EyeOff } from "lucide-vue-next";
 import FocalImage from "@/components/common/FocalImage.vue";
 import { useEncounterRunStore } from "@/stores/encounterRun";
 import { useIsMobile } from "@/composables/useBreakpoint";
+import { useParty } from "@/composables/useParty";
+import { useConcentration } from "@/composables/useConcentration";
 import {
   CONDITIONS,
   getConditionDescription,
@@ -339,6 +347,7 @@ import {
   setExhaustionLevel,
   isExhaustion,
 } from "@/lib/conditions";
+import { CONCENTRATION_BREAKING_CONDITIONS } from "@/composables/useConcentration";
 import ExhaustionChip from "@/components/common/ExhaustionChip.vue";
 import type { RunCombatant, RevealState } from "@/types/encounter.types";
 
@@ -355,6 +364,8 @@ const emit = defineEmits<{
 }>();
 
 const store = useEncounterRunStore();
+const { data: partyList } = useParty();
+const { rollConcentrationSave, endConcentration } = useConcentration();
 const addingCondFor = ref<string | null>(null);
 const quickAmounts = ref<Record<string, number | null>>({});
 
@@ -440,12 +451,22 @@ function nonExhaustion(conditions: string[]): string[] {
  * 1; any subsequent level changes happen via the chip's pips. Other names
  * are stored as-is.
  */
-function onPickCondition(instanceId: string, value: string) {
+async function onPickCondition(instanceId: string, value: string) {
   if (!value) { addingCondFor.value = null; return; }
   if (value === "Exhaustion") {
     onExhaustionChange(instanceId, 1);
   } else {
     store.toggleCondition(instanceId, value);
+    // Concentration-breaking conditions end concentration on PCs automatically.
+    if (CONCENTRATION_BREAKING_CONDITIONS.includes(value)) {
+      const c = store.sortedCombatants.find((x) => x.instance_id === instanceId);
+      const member = c?.party_member_id
+        ? partyList.value?.find((m) => m.id === c.party_member_id) ?? null
+        : null;
+      if (member?.concentration) {
+        await endConcentration(member, { reason: value.toLowerCase() });
+      }
+    }
   }
   addingCondFor.value = null;
 }
@@ -455,6 +476,19 @@ function onExhaustionChange(instanceId: string, newLevel: number) {
   if (!combatant) return;
   const next = setExhaustionLevel(combatant.conditions, newLevel);
   store.setConditions(instanceId, next);
+}
+
+function pcConcentration(c: RunCombatant): string | null {
+  if (!c.party_member_id) return null;
+  const m = partyList.value?.find((p) => p.id === c.party_member_id);
+  return m?.concentration?.spellName ?? null;
+}
+
+async function dropCombatantConcentration(c: RunCombatant) {
+  if (!c.party_member_id) return;
+  const member = partyList.value?.find((m) => m.id === c.party_member_id);
+  if (!member?.concentration) return;
+  await endConcentration(member, { reason: "dropped" });
 }
 
 function combatantInitials(c: RunCombatant): string {
@@ -473,12 +507,28 @@ function revealBtnTitle(state: RevealState | undefined) {
   return "Hidden — click to show slot";
 }
 
-function quickDamage(instanceId: string) {
+async function quickDamage(instanceId: string) {
   const amt = quickAmounts.value[instanceId];
   if (!amt) return;
+  const c = store.sortedCombatants.find((x) => x.instance_id === instanceId);
+  const memberId = c?.party_member_id;
+  const memberBefore = memberId ? partyList.value?.find((m) => m.id === memberId) ?? null : null;
+  const hpBefore = c?.hp ?? 0;
+
   store.adjustHp(instanceId, -amt);
   showFlash(instanceId, -amt);
   quickAmounts.value[instanceId] = null;
+
+  // Concentration check for PCs only — monsters/NPCs don't currently have
+  // concentration state on party_members, so there's nothing to roll against.
+  if (memberBefore?.concentration && amt > 0) {
+    const newHp = Math.max(0, hpBefore - amt);
+    if (newHp === 0) {
+      await endConcentration(memberBefore, { reason: "dropped to 0 HP" });
+    } else {
+      await rollConcentrationSave(memberBefore, amt);
+    }
+  }
 }
 
 function quickHeal(instanceId: string) {
@@ -686,6 +736,10 @@ function quickTemp(instanceId: string) {
 
 .cond-badge {
   @apply inline-flex items-center px-1.5 py-0.5 rounded font-cinzel text-[9px] font-semibold bg-amber-500/20 text-amber-700 dark:text-amber-400 border border-amber-500/30 cursor-pointer hover:bg-destructive/20 hover:text-destructive transition-colors;
+}
+
+.conc-chip {
+  @apply inline-flex items-center px-1.5 py-0.5 rounded font-cinzel text-[9px] font-semibold bg-indigo-500/20 text-indigo-700 dark:text-indigo-300 border border-indigo-500/30 cursor-pointer hover:bg-destructive/20 hover:text-destructive transition-colors;
 }
 
 .add-cond-btn {

--- a/src/components/encounters/RunnerEntityDetail.vue
+++ b/src/components/encounters/RunnerEntityDetail.vue
@@ -711,7 +711,9 @@ import { useDiscoveredKeys } from "@/composables/useDiscoveredMonsters";
 import { useDmPinnedForms } from "@/composables/usePinnedForms";
 import { useCompanions } from "@/composables/useCompanions";
 import { parseExpression } from "@/lib/dice";
-import { rollDice, rollParsed } from "@/lib/roller";
+import { rollParsed } from "@/lib/roller";
+import type { DieSize, RollResult } from "@/lib/roller";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import type { Spell as SpellType } from "@/types/spell.types";
 import { getCasterType } from "@/types/spell.types";
 import { useClassByName } from "@/composables/useCustomClasses";
@@ -786,8 +788,20 @@ const rollResultClass = computed(() => {
   return "";
 });
 
-function performCheck(modifier: number, label: string) {
-  const r = rollDice({ 20: 1 }, modifier, rollMode.value);
+const { promptRoll } = usePromptedRoll();
+
+async function performCheck(modifier: number, label: string): Promise<RollResult | null> {
+  const senderName = selectedCombatant.value?.name ?? "Encounter";
+  const silent = chatMode.value === "silent";
+  const r = await promptRoll({
+    counts: { 20: 1 },
+    modifier,
+    label,
+    mode: rollMode.value,
+    senderName,
+    silent,
+  });
+  if (!r) return null;
   const kept = r.breakdown.find((d) => !d.dropped)!;
   const dropped = r.breakdown.find((d) => d.dropped);
   lastCheck.value = {
@@ -799,6 +813,7 @@ function performCheck(modifier: number, label: string) {
     isCrit: r.isCrit,
     isFumble: r.isFumble,
   };
+  return r;
 }
 
 // ── Action roll helpers ───────────────────────────────────────────────────────
@@ -848,28 +863,39 @@ async function postRollToChat(
 }
 
 function rollAttack(attackBonus: number, actionName: string) {
-  performCheck(attackBonus, actionName + " Attack");
-  if (lastCheck.value) {
-    const lc = lastCheck.value;
-    const breakdown: { val: number; dropped: boolean }[] = [{ val: lc.d20, dropped: false }];
-    if (lc.dropped !== undefined) breakdown.push({ val: lc.dropped, dropped: true });
-    void postRollToChat(lc.label, lc.total, breakdown, lc.modifier, lc.isCrit, lc.isFumble, selectedCombatant.value?.name ?? "Encounter");
-  }
+  void performCheck(attackBonus, actionName + " Attack");
 }
 
-function rollActionDamage(desc: string, actionName: string) {
+function parsedTermsToCounts(terms: { count: number; sides: number }[]): Partial<Record<DieSize, number>> {
+  const counts: Partial<Record<DieSize, number>> = {};
+  for (const t of terms) {
+    if ([4, 6, 8, 10, 12, 20, 100].includes(t.sides)) {
+      const k = t.sides as DieSize;
+      counts[k] = (counts[k] ?? 0) + t.count;
+    }
+  }
+  return counts;
+}
+
+async function rollActionDamage(desc: string, actionName: string) {
   const parsed = parseExpression(desc);
   if (!parsed || !parsed.terms.length) return;
-  const { total, breakdown } = rollParsed(parsed);
   const label = `${actionName} (${actionDiceLabel(desc)})`;
-  lastCheck.value = { total, label, modifier: parsed.modifier, d20: breakdown[0]?.val ?? total, isCrit: false, isFumble: false };
-  void postRollToChat(label, total, breakdown, parsed.modifier, false, false, selectedCombatant.value?.name ?? "Encounter");
+  const counts = parsedTermsToCounts(parsed.terms);
+  const r = await promptRoll({
+    counts,
+    modifier: parsed.modifier,
+    label,
+    senderName: selectedCombatant.value?.name ?? "Encounter",
+    silent: chatMode.value === "silent",
+  });
+  if (!r) return;
+  lastCheck.value = { total: r.total, label, modifier: parsed.modifier, d20: r.breakdown[0]?.val ?? r.total, isCrit: false, isFumble: false };
 }
 
-function rollSpellDamage(spell: SpellType) {
+async function rollSpellDamage(spell: SpellType) {
   const rolls = spell.damage_rolls;
   if (!rolls?.length) return;
-  // Combine all damage terms (multi-type spells) into one roll event for a single sound
   const combined = rolls.reduce<{ terms: { count: number; sides: number }[]; modifier: number }>(
     (acc, roll) => {
       const parsed = parseExpression(roll.dice);
@@ -878,11 +904,24 @@ function rollSpellDamage(spell: SpellType) {
     },
     { terms: [], modifier: 0 },
   );
-  const { total, breakdown } = rollParsed(combined);
   const diceLabel = rolls.map((r) => `${r.dice}${r.type ? " " + r.type : ""}`).join(" + ");
   const label = `${spell.name} (${diceLabel})`;
-  lastCheck.value = { total, label, modifier: 0, d20: breakdown[0]?.val ?? total, isCrit: false, isFumble: false };
-  void postRollToChat(label, total, breakdown, 0, false, false, selectedMember.value?.name ?? "Player");
+  const counts = parsedTermsToCounts(combined.terms);
+  if (Object.keys(counts).length === 0) {
+    const { total, breakdown } = rollParsed(combined);
+    lastCheck.value = { total, label, modifier: 0, d20: breakdown[0]?.val ?? total, isCrit: false, isFumble: false };
+    void postRollToChat(label, total, breakdown, 0, false, false, selectedMember.value?.name ?? "Player");
+    return;
+  }
+  const r = await promptRoll({
+    counts,
+    modifier: combined.modifier,
+    label,
+    senderName: selectedMember.value?.name ?? "Player",
+    silent: chatMode.value === "silent",
+  });
+  if (!r) return;
+  lastCheck.value = { total: r.total, label, modifier: 0, d20: r.breakdown[0]?.val ?? r.total, isCrit: false, isFumble: false };
 }
 
 // ── Combatant selection ───────────────────────────────────────────────────────

--- a/src/components/player/PlayerCharacterHeader.vue
+++ b/src/components/player/PlayerCharacterHeader.vue
@@ -64,12 +64,21 @@
         </div>
 
         <!-- HP readout -->
-        <div class="flex items-baseline gap-1.5 px-3">
+        <div class="flex items-baseline gap-1.5 px-3 flex-wrap">
           <span class="font-cinzel text-2xl font-bold" :class="hpColor">{{ member.current_hp }}</span>
           <span class="font-fell text-sm text-muted-foreground">/ {{ member.max_hp }}</span>
           <span v-if="member.temp_hp" class="font-cinzel text-[10px] text-blue-400 ml-1">+{{ member.temp_hp }} tmp</span>
           <span v-if="attackDisadvantage" class="font-cinzel text-[9px] text-amber-500 tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 border border-amber-500/20 ml-1" title="Disadvantage on attack rolls">⚔ Dis</span>
           <span v-if="checkDisadvantage"  class="font-cinzel text-[9px] text-amber-500 tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 border border-amber-500/20 ml-1" title="Disadvantage on ability checks">✦ Dis</span>
+          <button
+            v-if="member.concentration"
+            class="font-cinzel text-[9px] text-indigo-300 tracking-wider px-1.5 py-0.5 rounded bg-indigo-500/10 border border-indigo-500/30 ml-1 hover:bg-indigo-500/20 transition-colors inline-flex items-center gap-1"
+            :title="`Concentrating on ${member.concentration.spellName} — click to drop`"
+            @click="dropConcentration"
+          >
+            ✦ Conc: {{ member.concentration.spellName }}
+            <span class="text-muted-foreground">×</span>
+          </button>
         </div>
 
         <!-- AC / SPD / INIT / PROF + condition picker -->
@@ -139,6 +148,7 @@ import { ref, computed, nextTick } from "vue";
 import { RouterLink } from "vue-router";
 import { Star, TrendingUp, Settings } from "lucide-vue-next";
 import { useUpdatePartyMember } from "@/composables/useParty";
+import { useConcentration } from "@/composables/useConcentration";
 import { patchLiveCombatantConditions } from "@/composables/useEncounterLive";
 import {
   CONDITIONS,
@@ -164,6 +174,7 @@ const speciesName = computed(() =>
 );
 
 const { mutateAsync: updateMember } = useUpdatePartyMember();
+const { rollConcentrationSave, endConcentration } = useConcentration();
 
 const hpInput = ref(0);
 
@@ -235,9 +246,17 @@ const checkDisadvantage  = computed(() => hasCheckDisadvantage(props.member.cond
 
 async function applyDamage() {
   if (hpInput.value <= 0) return;
-  const newHp = Math.max(0, props.member.current_hp - hpInput.value);
+  const dmg = hpInput.value;
+  const newHp = Math.max(0, props.member.current_hp - dmg);
   await updateMember({ id: props.member.id, update: { current_hp: newHp } });
   hpInput.value = 0;
+  if (props.member.concentration) {
+    if (newHp === 0) {
+      await endConcentration(props.member, { reason: "dropped to 0 HP" });
+    } else {
+      await rollConcentrationSave(props.member, dmg);
+    }
+  }
 }
 async function applyHeal() {
   if (hpInput.value <= 0) return;
@@ -253,5 +272,10 @@ async function applyTempHp() {
 
 async function toggleInspiration() {
   await updateMember({ id: props.member.id, update: { inspiration: !props.member.inspiration } });
+}
+
+async function dropConcentration() {
+  if (!props.member.concentration) return;
+  await endConcentration(props.member, { reason: "dropped" });
 }
 </script>

--- a/src/components/player/PlayerCombatTab.vue
+++ b/src/components/player/PlayerCombatTab.vue
@@ -90,12 +90,14 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { Sword, Zap } from "lucide-vue-next";
-import { rollDice, rollParsed } from "@/lib/roller";
-import type { RollMode } from "@/lib/roller";
+import { rollParsed } from "@/lib/roller";
+import type { RollMode, DieSize } from "@/lib/roller";
 import { parseExpression } from "@/lib/dice";
+import type { ParsedExpression } from "@/lib/dice";
 import { usePartyInventory } from "@/composables/usePartyInventory";
 import { useItems } from "@/composables/useItems";
 import { useCampaignMessages } from "@/composables/useCampaignMessages";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import type { PartyMember } from "@/types/party.types";
 import type { PartyInventoryItem } from "@/types/inventory.types";
 import type { Item } from "@/types/item.types";
@@ -106,6 +108,7 @@ const emit = defineEmits<{ roll: [result: { label: string; dice: number; modifie
 const { data: inventory } = usePartyInventory();
 const { data: allItems } = useItems();
 const { sendRoll } = useCampaignMessages();
+const { promptRoll } = usePromptedRoll();
 
 function abilityMod(score: number) { return Math.floor((score - 10) / 2); }
 function signedNum(n: number) { return n >= 0 ? `+${n}` : `${n}`; }
@@ -148,53 +151,63 @@ function modeTag(mode: RollMode) {
   return mode === "advantage" ? " (Adv)" : mode === "disadvantage" ? " (Dis)" : "";
 }
 
-function rollUnarmedAttack() {
-  const mod = unarmedAttackMod.value;
+async function rollAttackWith(mod: number, baseLabel: string) {
   const mode: RollMode = props.attackDisadvantage ? "disadvantage" : "normal";
-  const result = rollDice({ 20: 1 }, mod, mode);
+  const fullLabel = `${baseLabel} — Attack` + modeTag(mode);
+  const result = await promptRoll({ counts: { 20: 1 }, modifier: mod, label: fullLabel, mode });
+  if (!result) return;
   const kept = result.breakdown.find(d => !d.dropped)!;
-  const fullLabel = `Unarmed Strike — Attack` + modeTag(mode);
   emit("roll", { label: fullLabel, dice: kept.val, modifier: mod, total: result.total });
-  void sendRoll({ ...result, label: fullLabel });
 }
 
-function rollImprovisedAttack() {
-  const mod = improvisedAttackMod.value;
-  const mode: RollMode = props.attackDisadvantage ? "disadvantage" : "normal";
-  const result = rollDice({ 20: 1 }, mod, mode);
-  const kept = result.breakdown.find(d => !d.dropped)!;
-  const fullLabel = `Improvised Weapon — Attack` + modeTag(mode);
-  emit("roll", { label: fullLabel, dice: kept.val, modifier: mod, total: result.total });
-  void sendRoll({ ...result, label: fullLabel });
+function rollUnarmedAttack() { return rollAttackWith(unarmedAttackMod.value, "Unarmed Strike"); }
+function rollImprovisedAttack() { return rollAttackWith(improvisedAttackMod.value, "Improvised Weapon"); }
+function rollWeaponAttack(inv: PartyInventoryItem, item: Item) {
+  void item;
+  return rollAttackWith(weaponAttackMod(item), inv.name);
+}
+
+function parsedToCounts(parsed: ParsedExpression): Partial<Record<DieSize, number>> {
+  const counts: Partial<Record<DieSize, number>> = {};
+  for (const t of parsed.terms) {
+    if ([4, 6, 8, 10, 12, 20, 100].includes(t.sides)) {
+      const k = t.sides as DieSize;
+      counts[k] = (counts[k] ?? 0) + t.count;
+    }
+  }
+  return counts;
+}
+
+async function rollDamageLabelled(parsed: ParsedExpression, mod: number, label: string) {
+  const counts = parsedToCounts(parsed);
+  if (Object.keys(counts).length === 0) {
+    // Flat damage — no prompt needed, just emit+post via rollParsed path.
+    const { total: diceTotal, breakdown } = rollParsed(parsed);
+    const total = diceTotal + mod;
+    emit("roll", { label, dice: diceTotal, modifier: mod, total });
+    void sendRoll({ total, label, modifier: mod, breakdown, isCrit: false, isFumble: false });
+    return;
+  }
+  const result = await promptRoll({ counts, modifier: mod + parsed.modifier, label });
+  if (!result) return;
+  const diceTotal = result.total - result.modifier;
+  emit("roll", { label, dice: diceTotal, modifier: result.modifier, total: result.total });
 }
 
 function rollImprovisedDamage() {
-  const mod = improvisedAttackMod.value;
-  const { total: diceTotal, breakdown } = rollParsed({ terms: [{ count: 1, sides: 4 }], modifier: 0 });
-  const total = diceTotal + mod;
-  const label = `Improvised Weapon — Damage`;
-  emit("roll", { label, dice: diceTotal, modifier: mod, total });
-  void sendRoll({ total, label, modifier: mod, breakdown, isCrit: false, isFumble: false });
-}
-
-function rollWeaponAttack(inv: PartyInventoryItem, item: Item) {
-  const mod = weaponAttackMod(item);
-  const mode: RollMode = props.attackDisadvantage ? "disadvantage" : "normal";
-  const result = rollDice({ 20: 1 }, mod, mode);
-  const kept = result.breakdown.find(d => !d.dropped)!;
-  const fullLabel = `${inv.name} — Attack` + modeTag(mode);
-  emit("roll", { label: fullLabel, dice: kept.val, modifier: mod, total: result.total });
-  void sendRoll({ ...result, label: fullLabel });
+  return rollDamageLabelled(
+    { terms: [{ count: 1, sides: 4 }], modifier: 0 },
+    improvisedAttackMod.value,
+    "Improvised Weapon — Damage",
+  );
 }
 
 function rollWeaponDamage(inv: PartyInventoryItem, item: Item) {
   if (!item.damage_rolls?.length) return;
   const abilMod = weaponAbilityMod(item);
   const parsed = parseExpression(item.damage_rolls[0].dice);
-  const { total: diceTotal, breakdown } = parsed ? rollParsed(parsed) : { total: 0, breakdown: [] };
-  const total = diceTotal + abilMod;
+  if (!parsed) return;
   const label = `${inv.name} — Damage (${item.damage_rolls[0].type})`;
-  emit("roll", { label, dice: diceTotal, modifier: abilMod, total });
-  void sendRoll({ total, label, modifier: abilMod, breakdown, isCrit: false, isFumble: false });
+  return rollDamageLabelled(parsed, abilMod, label);
 }
 </script>

--- a/src/components/player/PlayerConditions.vue
+++ b/src/components/player/PlayerConditions.vue
@@ -77,7 +77,7 @@
 import { computed } from "vue";
 import { useUpdatePartyMember } from "@/composables/useParty";
 import { useCampaignMessages } from "@/composables/useCampaignMessages";
-import { rollDice } from "@/lib/roller";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import { patchLiveCombatantConditions } from "@/composables/useEncounterLive";
 import {
   getConditionDescription,
@@ -93,6 +93,7 @@ const emit = defineEmits<{ roll: [result: { label: string; dice: number; modifie
 
 const { mutateAsync: updateMember } = useUpdatePartyMember();
 const { sendRoll } = useCampaignMessages();
+const { promptRoll } = usePromptedRoll();
 
 // ── Condition helpers ─────────────────────────────────────────────────────────
 
@@ -120,9 +121,10 @@ async function toggleDeathSave(type: "success" | "failure", pip: number) {
 }
 
 async function rollDeathSave() {
-  const r = rollDice({ 20: 1 }, 0);
-  const d = r.breakdown[0].val;
   const name = props.member.name;
+  const r = await promptRoll({ counts: { 20: 1 }, modifier: 0, label: `${name} — Death Save`, silent: true });
+  if (!r) return;
+  const d = r.breakdown.find(b => !b.dropped)!.val;
   let update: Partial<{ current_hp: number; death_save_successes: number; death_save_failures: number }>;
   let outcome: string;
 
@@ -143,6 +145,6 @@ async function rollDeathSave() {
   await updateMember({ id: props.member.id, update });
   const label = `${name} — Death Save (${outcome})`;
   emit("roll", { label, dice: d, modifier: 0, total: d });
-  void sendRoll({ ...r, label });
+  await sendRoll({ ...r, label });
 }
 </script>

--- a/src/components/player/PlayerSkillsTab.vue
+++ b/src/components/player/PlayerSkillsTab.vue
@@ -72,9 +72,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { ChevronRight } from "lucide-vue-next";
-import { rollDice } from "@/lib/roller";
 import type { RollMode } from "@/lib/roller";
 import { useCampaignMessages } from "@/composables/useCampaignMessages";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import { useCampaignMembers } from "@/composables/useCampaignMembers";
 import { useCampaignStore } from "@/stores/campaign";
 import { SKILLS } from "@/types/party.types";
@@ -83,7 +83,8 @@ import type { PartyMember, SkillProficiencies } from "@/types/party.types";
 const props = defineProps<{ member: PartyMember; checkDisadvantage: boolean }>();
 const emit = defineEmits<{ roll: [result: { label: string; dice: number; modifier: number; total: number }] }>();
 
-const { sendRoll, sendFlavorMessage } = useCampaignMessages();
+const { sendFlavorMessage } = useCampaignMessages();
+const { promptRoll } = usePromptedRoll();
 const { data: campaignMembers } = useCampaignMembers();
 const campaignStore = useCampaignStore();
 const dmUserId = computed(() => campaignMembers.value?.find((m) => m.role === "dm")?.user_id ?? null);
@@ -143,24 +144,27 @@ function modeTag(mode: RollMode) {
 async function rollSkill(skill: (typeof SKILLS)[number]) {
   const isImmersive = campaignStore.activeCampaign?.immersive_rolls && IMMERSIVE_SKILL_KEYS.has(skill.key);
   const mode: RollMode = props.checkDisadvantage ? "disadvantage" : "normal";
+  const modifier = skillBonusValue(skill);
+  const name = props.member.name;
 
   if (isImmersive) {
-    const modifier = skillBonusValue(skill);
-    const result = rollDice({ 20: 1 }, modifier, mode);
-    const kept = result.breakdown.find(d => !d.dropped)!;
     const label = `${skill.label} Check`;
-    const name = props.member.name;
     await sendFlavorMessage(immersiveFlavor(label, name), skill.label);
-    if (dmUserId.value) await sendRoll({ ...result, label }, dmUserId.value, name);
-    void kept;
+    await promptRoll({
+      counts: { 20: 1 },
+      modifier,
+      label,
+      mode,
+      recipientUserId: dmUserId.value,
+      senderName: name,
+    });
     return;
   }
 
-  const modifier = skillBonusValue(skill);
-  const result = rollDice({ 20: 1 }, modifier, mode);
-  const kept = result.breakdown.find(d => !d.dropped)!;
   const fullLabel = `${skill.label} Check` + modeTag(mode);
+  const result = await promptRoll({ counts: { 20: 1 }, modifier, label: fullLabel, mode });
+  if (!result) return;
+  const kept = result.breakdown.find(d => !d.dropped)!;
   emit("roll", { label: fullLabel, dice: kept.val, modifier, total: result.total });
-  void sendRoll({ ...result, label: fullLabel });
 }
 </script>

--- a/src/components/spells/PlayerMySpells.vue
+++ b/src/components/spells/PlayerMySpells.vue
@@ -189,8 +189,9 @@ import {
   useRemoveCharacterSpell,
   useTogglePrepared,
 } from "@/composables/useCharacterSpells";
-import { useUpdatePartyMember } from "@/composables/useParty";
+import { useUpdatePartyMember, useParty } from "@/composables/useParty";
 import { useCampaignMessages } from "@/composables/useCampaignMessages";
+import { useConcentration } from "@/composables/useConcentration";
 import { useUiStore } from "@/stores/ui";
 import { SCHOOL_COLORS } from "@/types/spell.types";
 import type { CasterType, CharacterSpellEntry, Spell } from "@/types/spell.types";
@@ -224,6 +225,13 @@ const { mutate: removeSpell, isPending: isRemoving } = useRemoveCharacterSpell()
 const { mutate: togglePreparedMutation, isPending: isToggling } = useTogglePrepared();
 const { mutateAsync: updateMember } = useUpdatePartyMember();
 const { sendFlavorMessage } = useCampaignMessages();
+const { data: partyList } = useParty();
+const { startConcentration } = useConcentration();
+const thisMember = computed(() =>
+  props.partyMemberId && partyList.value
+    ? (partyList.value.find((m) => m.id === props.partyMemberId) ?? null)
+    : null,
+);
 const ui = useUiStore();
 
 // ── Modal ──────────────────────────────────────────────────────────────────────
@@ -287,6 +295,12 @@ async function castSpell(entry: CharacterSpellEntry) {
   isCasting.value = true;
   try {
     const level = entry.spell.level;
+
+    // Concentration guard: casting a new concentration spell ends the previous.
+    if (entry.spell.concentration && thisMember.value) {
+      const ok = await startConcentration(thisMember.value, entry.spell, { castAtLevel: level });
+      if (!ok) return;
+    }
 
     // Build flavor text
     let text = `${props.memberName} casts ${entry.spell.name}`;

--- a/src/composables/useConcentration.ts
+++ b/src/composables/useConcentration.ts
@@ -1,0 +1,112 @@
+import { useConfirm } from "@/composables/useConfirm";
+import { useUpdatePartyMember } from "@/composables/useParty";
+import { useCampaignMessages } from "@/composables/useCampaignMessages";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
+import type { ConcentrationState, PartyMember } from "@/types/party.types";
+import type { Spell } from "@/types/spell.types";
+
+/**
+ * Conditions that automatically end concentration when applied to a creature.
+ * Per 5e RAW: Unconscious, Paralyzed, Stunned, Petrified, Incapacitated (and death).
+ */
+export const CONCENTRATION_BREAKING_CONDITIONS = [
+  "Unconscious",
+  "Paralyzed",
+  "Stunned",
+  "Petrified",
+  "Incapacitated",
+];
+
+/** DC for a concentration check after taking `damage` HP of damage. */
+export function concentrationSaveDC(damage: number): number {
+  return Math.max(10, Math.floor(damage / 2));
+}
+
+export function useConcentration() {
+  const { mutateAsync: updateMember } = useUpdatePartyMember();
+  const { confirm } = useConfirm();
+  const { sendFlavorMessage } = useCampaignMessages();
+  const { promptRoll } = usePromptedRoll();
+
+  /**
+   * Begin concentration on a spell. If the caster is already concentrating,
+   * prompts the user to drop the previous one.
+   *
+   * Returns true if concentration was started, false if the user cancelled.
+   */
+  async function startConcentration(
+    member: PartyMember,
+    spell: Spell,
+    opts: { castAtLevel?: number; round?: number | null } = {},
+  ): Promise<boolean> {
+    if (member.concentration) {
+      const ok = await confirm(
+        `You are concentrating on ${member.concentration.spellName}. Casting ${spell.name} will end ${member.concentration.spellName}.`,
+        { title: "Break concentration?", confirmLabel: "Cast anyway", danger: false },
+      );
+      if (!ok) return false;
+      await endConcentration(member, { silent: true });
+    }
+    const state: ConcentrationState = {
+      spellId: spell.id ?? null,
+      spellName: spell.name,
+      castAtLevel: opts.castAtLevel ?? spell.level ?? 0,
+      startedRound: opts.round ?? null,
+      appliedEffectIds: [],
+    };
+    await updateMember({ id: member.id, update: { concentration: state } });
+    void sendFlavorMessage(`${member.name} begins concentrating on ${spell.name}`, spell.name);
+    return true;
+  }
+
+  /** Clear the member's concentration. Silent mode skips the chat log entry. */
+  async function endConcentration(
+    member: PartyMember,
+    opts: { silent?: boolean; reason?: string } = {},
+  ): Promise<void> {
+    if (!member.concentration) return;
+    const prevName = member.concentration.spellName;
+    await updateMember({ id: member.id, update: { concentration: null } });
+    if (!opts.silent) {
+      const tail = opts.reason ? ` (${opts.reason})` : "";
+      void sendFlavorMessage(`${member.name}'s concentration on ${prevName} ends${tail}`, prevName);
+    }
+  }
+
+  /**
+   * Prompt a Constitution saving throw for concentration after taking `damage`.
+   * Returns true if concentration held (or member wasn't concentrating), false
+   * if the save failed (caller should expect concentration to be cleared).
+   * Ends concentration automatically on failure.
+   */
+  async function rollConcentrationSave(
+    member: PartyMember,
+    damage: number,
+  ): Promise<boolean> {
+    if (!member.concentration || damage <= 0) return true;
+    const dc = concentrationSaveDC(damage);
+    const conMod = Math.floor((member.con - 10) / 2);
+    const pb = member.saving_throw_proficiencies?.includes("con") ? member.proficiency_bonus : 0;
+    const modifier = conMod + pb;
+    const spellName = member.concentration.spellName;
+    const label = `Con Save (concentration on ${spellName}, DC ${dc})`;
+    const result = await promptRoll({
+      counts: { 20: 1 },
+      modifier,
+      label,
+      senderName: member.name,
+    });
+    if (!result) return true;
+    const success = result.total >= dc;
+    if (!success) {
+      await endConcentration(member, { reason: "failed save" });
+    }
+    return success;
+  }
+
+  return {
+    startConcentration,
+    endConcentration,
+    rollConcentrationSave,
+  };
+}

--- a/src/composables/useDicePrefs.ts
+++ b/src/composables/useDicePrefs.ts
@@ -1,7 +1,14 @@
 import { ref } from "vue";
-import { getDiceAudioEnabled, setDiceAudioEnabled } from "@/lib/diceAudio";
+import {
+  getDiceAudioEnabled,
+  setDiceAudioEnabled,
+  getDiceMode,
+  setDiceModePref,
+  type DiceMode,
+} from "@/lib/diceAudio";
 
 const diceAudioEnabled = ref(getDiceAudioEnabled());
+const diceMode = ref<DiceMode>(getDiceMode());
 
 export function useDicePrefs() {
   function setDiceAudio(enabled: boolean) {
@@ -9,5 +16,12 @@ export function useDicePrefs() {
     setDiceAudioEnabled(enabled);
   }
 
-  return { diceAudioEnabled, setDiceAudio };
+  function setDiceMode(mode: DiceMode) {
+    diceMode.value = mode;
+    setDiceModePref(mode);
+  }
+
+  return { diceAudioEnabled, setDiceAudio, diceMode, setDiceMode };
 }
+
+export type { DiceMode };

--- a/src/composables/usePromptedRoll.ts
+++ b/src/composables/usePromptedRoll.ts
@@ -1,0 +1,127 @@
+import { ref } from "vue";
+import { rollDice } from "@/lib/roller";
+import type { DieSize, RollMode, RollResult, DieResult } from "@/lib/dice";
+import { useDicePrefs } from "@/composables/useDicePrefs";
+import { useCampaignMessages } from "@/composables/useCampaignMessages";
+
+export interface PromptedRollArgs {
+  counts: Partial<Record<DieSize, number>>;
+  modifier: number;
+  label: string;
+  mode?: RollMode;
+  recipientUserId?: string | null;
+  senderName?: string;
+  /** Skip posting to chat (e.g. internal mechanics rolls). Default false. */
+  silent?: boolean;
+}
+
+export interface PendingManualRoll {
+  counts: Partial<Record<DieSize, number>>;
+  modifier: number;
+  label: string;
+  mode: RollMode;
+  resolve: (result: RollResult | null) => void;
+}
+
+const pending = ref<PendingManualRoll | null>(null);
+
+function buildLabel(
+  counts: Partial<Record<DieSize, number>>,
+  modifier: number,
+  mode: RollMode,
+  hasD20: boolean,
+): string {
+  const parts: string[] = [];
+  for (const sides of [4, 6, 8, 10, 12, 20, 100] as DieSize[]) {
+    const n = counts[sides] ?? 0;
+    if (n > 0) parts.push(`${n}d${sides}`);
+  }
+  if (modifier !== 0) parts.push(modifier > 0 ? `+${modifier}` : `${modifier}`);
+  const modeSuffix = hasD20 && mode !== "normal" ? ` (${mode === "advantage" ? "Adv" : "Dis"})` : "";
+  return parts.join("+") + modeSuffix;
+}
+
+export function usePromptedRoll() {
+  const { diceMode } = useDicePrefs();
+  const { sendRoll } = useCampaignMessages();
+
+  async function promptRoll(args: PromptedRollArgs): Promise<RollResult | null> {
+    const mode = args.mode ?? "normal";
+    let result: RollResult | null = null;
+
+    if (diceMode.value === "physical") {
+      const manual = await new Promise<RollResult | null>((resolve) => {
+        pending.value = {
+          counts: args.counts,
+          modifier: args.modifier,
+          label: args.label,
+          mode,
+          resolve,
+        };
+      });
+      result = manual;
+    } else {
+      result = rollDice(args.counts, args.modifier, mode);
+    }
+
+    if (result) {
+      if (args.label) result.label = args.label;
+      if (!args.silent) {
+        await sendRoll(result, args.recipientUserId ?? null, args.senderName);
+      }
+    }
+    return result;
+  }
+
+  function _resolveManual(values: Record<DieSize, number[]> | null): void {
+    const p = pending.value;
+    if (!p) return;
+    pending.value = null;
+    if (values === null) {
+      p.resolve(null);
+      return;
+    }
+    const breakdown: DieResult[] = [];
+    let sum = 0;
+    let isCrit = false;
+    let isFumble = false;
+
+    for (const sides of [4, 6, 8, 10, 12, 20, 100] as DieSize[]) {
+      const entered = values[sides] ?? [];
+      const need = p.counts[sides] ?? 0;
+      if (need === 0 || entered.length === 0) continue;
+
+      if (sides === 20 && need === 1 && p.mode !== "normal" && entered.length === 2) {
+        const [r1, r2] = entered;
+        const keep = p.mode === "advantage" ? Math.max(r1, r2) : Math.min(r1, r2);
+        const drop = p.mode === "advantage" ? Math.min(r1, r2) : Math.max(r1, r2);
+        breakdown.push({ val: keep, dropped: false });
+        breakdown.push({ val: drop, dropped: true });
+        sum += keep;
+        if (keep === 20) isCrit = true;
+        if (keep === 1) isFumble = true;
+      } else {
+        for (const val of entered) {
+          breakdown.push({ val, dropped: false });
+          sum += val;
+          if (sides === 20 && val === 20) isCrit = true;
+          if (sides === 20 && val === 1) isFumble = true;
+        }
+      }
+    }
+
+    const hasD20 = (p.counts[20] ?? 0) > 0;
+    const result: RollResult = {
+      total: sum + p.modifier,
+      label: buildLabel(p.counts, p.modifier, p.mode, hasD20),
+      modifier: p.modifier,
+      breakdown,
+      isCrit,
+      isFumble,
+      manual: true,
+    };
+    p.resolve(result);
+  }
+
+  return { promptRoll, pending, _resolveManual };
+}

--- a/src/lib/dice.ts
+++ b/src/lib/dice.ts
@@ -54,6 +54,7 @@ export interface RollResult {
   breakdown: DieResult[];
   isCrit: boolean;
   isFumble: boolean;
+  manual?: boolean;
 }
 
 export const ALL_DICE: DieSize[] = [4, 6, 8, 10, 12, 20, 100];

--- a/src/lib/diceAudio.ts
+++ b/src/lib/diceAudio.ts
@@ -6,6 +6,9 @@ export { primeAudioContext as primeDiceAudio };
 // ── Sound preferences ───────────────────────────────────────────────────────
 
 const PREF_KEY = "grimoire_dice_sounds";
+const MODE_KEY = "grimoire_dice_mode";
+
+export type DiceMode = "tool" | "physical";
 
 export function getDiceAudioEnabled(): boolean {
   return localStorage.getItem(PREF_KEY) !== "false"; // default on
@@ -13,6 +16,14 @@ export function getDiceAudioEnabled(): boolean {
 
 export function setDiceAudioEnabled(enabled: boolean): void {
   localStorage.setItem(PREF_KEY, String(enabled));
+}
+
+export function getDiceMode(): DiceMode {
+  return localStorage.getItem(MODE_KEY) === "physical" ? "physical" : "tool";
+}
+
+export function setDiceModePref(mode: DiceMode): void {
+  localStorage.setItem(MODE_KEY, mode);
 }
 
 // ── Synthesis helpers ────────────────────────────────────────────────────────

--- a/src/types/chat.types.ts
+++ b/src/types/chat.types.ts
@@ -7,6 +7,7 @@ export interface RollMetadata {
   modifier: number;
   isCrit: boolean;
   isFumble: boolean;
+  manual?: boolean;
 }
 
 export interface ItemDropClaim {

--- a/src/types/encounter.types.ts
+++ b/src/types/encounter.types.ts
@@ -130,6 +130,15 @@ export interface RunCombatant {
   wildshape?: WildshapeState;
   // temp HP — absorbs damage first, doesn't stack with healing
   temp_hp?: number;
+  // concentration — set when this combatant is concentrating on a spell.
+  // Mirrors ConcentrationState on party_members; cleared on short rest / encounter end for monsters.
+  concentration?: {
+    spellId: string | null;
+    spellName: string;
+    castAtLevel: number;
+    startedRound: number | null;
+    appliedEffectIds: string[];
+  } | null;
 }
 
 // ── XP / CR tables (D&D 5e) ──────────────────────────────────────────────────

--- a/src/types/party.types.ts
+++ b/src/types/party.types.ts
@@ -107,8 +107,17 @@ export interface PartyMember {
   hit_dice_remaining?: number | null;
   class_resources: Record<string, { current: number; max: number; rest: "short" | "long" }>;
   class_choices: Record<string, unknown>;
+  concentration?: ConcentrationState | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface ConcentrationState {
+  spellId: string | null;
+  spellName: string;
+  castAtLevel: number;
+  startedRound: number | null;
+  appliedEffectIds: string[];
 }
 
 export type PartyMemberInsert = Omit<PartyMember, "id" | "user_id" | "created_at" | "updated_at">;

--- a/src/views/play/PlayerCharacterView.vue
+++ b/src/views/play/PlayerCharacterView.vue
@@ -107,12 +107,11 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { RouterLink } from "vue-router";
-import { rollDice } from "@/lib/roller";
 import type { RollMode } from "@/lib/roller";
+import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import { useAuthStore } from "@/stores/auth";
 import { useUiStore } from "@/stores/ui";
 import { useParty } from "@/composables/useParty";
-import { useCampaignMessages } from "@/composables/useCampaignMessages";
 import { getCasterType, getDefaultSpellSlots, computeMaxPrepared } from "@/types/spell.types";
 import { useClassByName } from "@/composables/useCustomClasses";
 import { hasAttackDisadvantage, hasCheckDisadvantage } from "@/lib/conditions";
@@ -146,7 +145,7 @@ const customTrackers = computed(() => {
     .map((r) => ({ ruleId: r.id, def: r.tracker! }));
 });
 const { data: partyMembers } = useParty();
-const { sendRoll } = useCampaignMessages();
+const { promptRoll } = usePromptedRoll();
 
 const resolvedMemberId = computed(() =>
   props.memberId ?? (ui.dmPreviewMode ? ui.dmPreviewPartyMemberId : auth.linkedPartyMemberId),
@@ -235,13 +234,13 @@ const lastRoll = ref<RollResult | null>(null);
 
 function onChildRoll(result: RollResult) { lastRoll.value = { ...result }; }
 
-function doRoll(label: string, modifier: number, mode: RollMode = "normal") {
+async function doRoll(label: string, modifier: number, mode: RollMode = "normal") {
   const modeTag = mode === "advantage" ? " (Adv)" : mode === "disadvantage" ? " (Dis)" : "";
-  const result = rollDice({ 20: 1 }, modifier, mode);
-  const kept = result.breakdown.find(d => !d.dropped)!;
   const fullLabel = label + modeTag;
+  const result = await promptRoll({ counts: { 20: 1 }, modifier, label: fullLabel, mode });
+  if (!result) return;
+  const kept = result.breakdown.find(d => !d.dropped)!;
   lastRoll.value = { label: fullLabel, dice: kept.val, modifier, total: result.total };
-  void sendRoll({ ...result, label: fullLabel });
 }
 
 function onRollAbility(_key: string, label: string, mod: number) {

--- a/src/views/play/PlayerSettingsView.vue
+++ b/src/views/play/PlayerSettingsView.vue
@@ -340,6 +340,26 @@
           />
         </button>
       </div>
+      <div class="flex items-center justify-between">
+        <div>
+          <p class="font-cinzel text-xs text-foreground tracking-wide">Dice source</p>
+          <p class="font-fell text-xs text-muted-foreground italic">Choose where rolls come from. Physical mode prompts you to enter the result of dice you rolled yourself.</p>
+        </div>
+        <div class="flex rounded-md border border-border overflow-hidden text-[10px] font-cinzel tracking-wider">
+          <button
+            type="button"
+            class="px-3 py-1 transition-colors"
+            :class="diceMode === 'tool' ? 'bg-primary text-primary-foreground' : 'bg-muted/40 text-muted-foreground hover:text-foreground'"
+            @click="setDiceMode('tool')"
+          >TOOL</button>
+          <button
+            type="button"
+            class="px-3 py-1 transition-colors border-l border-border"
+            :class="diceMode === 'physical' ? 'bg-primary text-primary-foreground' : 'bg-muted/40 text-muted-foreground hover:text-foreground'"
+            @click="setDiceMode('physical')"
+          >PHYSICAL</button>
+        </div>
+      </div>
     </section>
 
     <!-- Keep screen awake -->
@@ -445,7 +465,7 @@ const { sortedNav, setNavOrder } = usePlayerNavPrefs();
 
 // ── Combat preferences ────────────────────────────────────────────────────────
 const { turnAudioEnabled, setTurnAudio } = usePlayerCombatPrefs();
-const { diceAudioEnabled, setDiceAudio } = useDicePrefs();
+const { diceAudioEnabled, setDiceAudio, diceMode, setDiceMode } = useDicePrefs();
 
 const dragListRef = ref<HTMLElement | null>(null);
 const draggingIdx = ref<number | null>(null);

--- a/supabase/migrations/20260417000004_party_member_concentration.sql
+++ b/supabase/migrations/20260417000004_party_member_concentration.sql
@@ -1,0 +1,8 @@
+-- Migration: party_member_concentration
+-- Adds a jsonb column to party_members tracking the spell a character is concentrating on.
+
+alter table party_members
+  add column if not exists concentration jsonb;
+
+comment on column party_members.concentration is
+  'Nullable. Shape: { spellId: string|null, spellName: string, castAtLevel: int, startedRound: int|null, appliedEffectIds: string[] }. Represents the single spell this character is currently concentrating on.';


### PR DESCRIPTION
Implements #185 — the full concentration enforcement feature, plus a cross-cutting physical-dice capability that rolls the groundwork for the broader "any roll in either mode" goal from #184.

## Summary

- **Physical dice mode** — every retrofitted roll now routes through `usePromptedRoll()`, which checks the `diceMode` user preference and either (a) uses the app's RNG as before, or (b) opens a new `<ManualRollPrompt>` modal asking the user to type in the values from their physical dice. Advantage/disadvantage shows two d20 inputs; crit/fumble detection works on the kept die. Manual rolls are labelled `MANUAL` in chat.
- **Dice source toggle** in Player Settings (TOOL / PHYSICAL), persisted in `localStorage['grimoire_dice_mode']`.
- **Concentration enforcement** per 5e RAW on both the player sheet and the encounter runner:
  - new `party_members.concentration jsonb` column (migration `20260417000004_party_member_concentration.sql`)
  - casting a concentration spell prompts to drop the previous one
  - taking damage triggers a Con save at `DC max(10, floor(damage / 2))`; failure drops concentration
  - hitting 0 HP auto-drops
  - concentration-breaking conditions (Paralyzed, Stunned, Petrified, Incapacitated, Unconscious) added in the runner drop concentration
  - concentration chip on the player header and the runner combatant card, click-to-drop

## Roll sites retrofitted

Player: ability checks, saves, all 18 skills, weapon attack + damage, unarmed, improvised, death saves.
DM runner: `performCheck`, `rollAttack`, `rollActionDamage`, `rollSpellDamage`.

Remaining sites (initiative, crafting, bestiary form attack, random tables, in-chat free-roll panel) are queued for Phase 5 of the spec.

## Files added

- `src/components/common/ManualRollPrompt.vue` — global manual-entry modal
- `src/composables/usePromptedRoll.ts` — reusable roll entry point with tool/physical branching
- `src/composables/useConcentration.ts` — `startConcentration`, `endConcentration`, `rollConcentrationSave`, `CONCENTRATION_BREAKING_CONDITIONS`
- `supabase/migrations/20260417000004_party_member_concentration.sql`

## Before merging

Apply the migration: `supabase db push` (couldn't be applied from the work environment).

## Test plan

- [ ] Run `supabase db push` and confirm `party_members.concentration` column exists
- [ ] In Player Settings, flip Dice source to **Physical**. Click a skill — the manual-entry modal appears. Enter values. Chat shows `MANUAL` tag, total respects modifier and adv/dis.
- [ ] Flip back to **Tool**. Roll a save. Rolls normally, no modal, no MANUAL tag.
- [ ] As a caster, cast a concentration spell. Chat: "begins concentrating". Chip appears on header.
- [ ] Cast a second concentration spell. Confirm dialog fires. On confirm, old chip gone, new chip appears.
- [ ] DM applies 12 damage in runner to the concentrating PC. Con save prompt fires with DC 10. Fail → chip disappears and chat logs the break.
- [ ] DM applies Paralyzed to the concentrating PC in the runner. Chip disappears; chat logs the break.
- [ ] Concentrating PC drops to 0 HP. Chip disappears without a save prompt.
- [ ] Click the `×` on the concentration chip (header or runner card). Chip clears; chat logs "dropped".
- [ ] Advantage d20 in physical mode prompts two inputs; kept value matches adv/dis rule.
- [ ] Build + typecheck pass (`npm run build`).

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW