### PR TITLE
feat(multiclassing): combined spell slot table + multiclass-aware labels

### DIFF
--- a/src/components/campaign/DetailsTab.vue
+++ b/src/components/campaign/DetailsTab.vue
@@ -158,6 +158,30 @@
       </label>
     </div>
 
+    <!-- Optional rules -->
+    <div class="pt-2">
+      <p class="font-cinzel text-xs font-semibold text-foreground tracking-wide mb-2">Optional Rules</p>
+      <label class="flex items-start gap-3 cursor-pointer" @click="form.ignore_multiclass_prereqs = !form.ignore_multiclass_prereqs">
+        <div class="shrink-0 mt-0.5">
+          <div
+            class="h-5 w-9 rounded-full border-2 transition-colors relative"
+            :class="form.ignore_multiclass_prereqs ? 'bg-primary border-primary' : 'bg-muted border-border'"
+          >
+            <div
+              class="absolute top-0.5 h-3 w-3 rounded-full bg-white shadow transition-transform"
+              :class="form.ignore_multiclass_prereqs ? 'translate-x-4' : 'translate-x-0.5'"
+            />
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <span class="font-cinzel text-xs font-semibold text-foreground tracking-wide">Ignore multiclass prereqs</span>
+          <p class="font-fell text-xs text-muted-foreground mt-0.5">
+            Waive the PHB ability-score thresholds for multiclassing. When off, players must meet the usual ability requirements (e.g. STR 13 to take a Fighter level).
+          </p>
+        </div>
+      </label>
+    </div>
+
     <!-- Save -->
     <div class="flex justify-end pt-1">
       <button
@@ -205,6 +229,7 @@ function buildForm(c: typeof campaign.value) {
     theme: c?.theme ?? "grimoire",
     health_visibility: (c?.health_visibility as "strategic" | "immersive" | "unknown") ?? "strategic",
     immersive_rolls: c?.immersive_rolls ?? false,
+    ignore_multiclass_prereqs: c?.optional_rules?.ignore_multiclass_prereqs ?? false,
   };
 }
 
@@ -237,6 +262,9 @@ async function submitForm() {
       theme: form.value.theme,
       health_visibility: form.value.health_visibility,
       immersive_rolls: form.value.immersive_rolls,
+      optional_rules: {
+        ignore_multiclass_prereqs: form.value.ignore_multiclass_prereqs,
+      },
     },
   });
   campaignStore.switchToCampaign(updated);

--- a/src/components/encounters/EncounterDetail.vue
+++ b/src/components/encounters/EncounterDetail.vue
@@ -206,8 +206,8 @@
                   {{
                     [
                       member.race,
-                      member.class,
-                      member.level ? `Lv${member.level}` : "",
+                      memberClassLabel(member.id, member.class),
+                      memberLevelDisplay(member.id, member.level) ? `Lv${memberLevelDisplay(member.id, member.level)}` : "",
                     ]
                       .filter(Boolean)
                       .join(" · ")
@@ -217,7 +217,7 @@
               <span
                 class="font-cinzel text-[10px] text-muted-foreground shrink-0"
               >
-                Lv {{ member.level }}
+                Lv {{ memberLevelDisplay(member.id, member.level) }}
               </span>
               <select
                 v-if="form.party_member_ids.includes(member.id)"
@@ -434,6 +434,9 @@ import {
 } from "lucide-vue-next";
 import { useAllMonsters } from "@/composables/useMonsters";
 import { useParty } from "@/composables/useParty";
+import { useAllCampaignCharacterClasses } from "@/composables/useCharacterClasses";
+import { formatMulticlassLabel, totalLevel } from "@/types/multiclass.types";
+import type { CharacterClass } from "@/types/multiclass.types";
 import { useCompanions } from "@/composables/useCompanions";
 import { useNpcs } from "@/composables/useNpcs";
 import { useItems } from "@/composables/useItems";
@@ -675,11 +678,36 @@ const enemyEntries = computed(() =>
     })),
 );
 
+const { data: allCharacterClasses } = useAllCampaignCharacterClasses();
+const classesByMember = computed(() => {
+  const m = new Map<string, CharacterClass[]>();
+  for (const cc of allCharacterClasses.value ?? []) {
+    const list = m.get(cc.party_member_id) ?? [];
+    list.push(cc);
+    m.set(cc.party_member_id, list);
+  }
+  return m;
+});
+
+function memberClassLabel(memberId: string, legacyClass: string | null): string {
+  const list = classesByMember.value.get(memberId) ?? [];
+  if (list.length > 1) return formatMulticlassLabel(list);
+  if (list.length === 1) return list[0].class_name;
+  return legacyClass ?? "";
+}
+
+function memberLevelDisplay(memberId: string, legacyLevel: number): number {
+  const list = classesByMember.value.get(memberId) ?? [];
+  return list.length > 0 ? totalLevel(list) : legacyLevel;
+}
+
 const partyLevels = computed(() => {
   const members = party.value ?? [];
-  return form.party_member_ids.map(
-    (id) => members.find((m) => m.id === id)?.level ?? 1,
-  );
+  return form.party_member_ids.map((id) => {
+    const m = members.find((mem) => mem.id === id);
+    if (!m) return 1;
+    return memberLevelDisplay(m.id, m.level);
+  });
 });
 
 const allyFactionIds = computed(() => {

--- a/src/components/factions/FactionPartyMembersSection.vue
+++ b/src/components/factions/FactionPartyMembersSection.vue
@@ -20,8 +20,8 @@
           <span class="font-cinzel text-xs font-semibold text-foreground truncate block">
             {{ m.party_member.name }}
           </span>
-          <p v-if="m.party_member.race || m.party_member.class" class="font-fell text-[11px] text-muted-foreground italic truncate">
-            {{ [m.party_member.race, m.party_member.class, m.party_member.level ? `Lv${m.party_member.level}` : ''].filter(Boolean).join(' · ') }}
+          <p v-if="m.party_member.race || memberClassLabel(m.party_member.id, m.party_member.class)" class="font-fell text-[11px] text-muted-foreground italic truncate">
+            {{ [m.party_member.race, memberClassLabel(m.party_member.id, m.party_member.class), memberLevelDisplay(m.party_member.id, m.party_member.level) ? `Lv${memberLevelDisplay(m.party_member.id, m.party_member.level)}` : ''].filter(Boolean).join(' · ') }}
           </p>
         </div>
 
@@ -127,6 +127,9 @@ import {
   type FactionPartyMemberWithMember,
 } from "@/composables/useFactions";
 import { useParty } from "@/composables/useParty";
+import { useAllCampaignCharacterClasses } from "@/composables/useCharacterClasses";
+import { formatMulticlassLabel, totalLevel } from "@/types/multiclass.types";
+import type { CharacterClass } from "@/types/multiclass.types";
 import { NPC_FACTION_ROLES, NPC_FACTION_STATUSES, NPC_FACTION_STATUS_COLORS, type NpcFactionStatus } from "@/types/faction.types";
 import EntityCombobox from "@/components/common/EntityCombobox.vue";
 
@@ -134,6 +137,26 @@ const props = defineProps<{ factionId: string }>();
 
 const { data: members }     = useFactionPartyMembers(props.factionId);
 const { data: allMembers }  = useParty();
+const { data: allCharacterClasses } = useAllCampaignCharacterClasses();
+const classesByMember = computed(() => {
+  const m = new Map<string, CharacterClass[]>();
+  for (const cc of allCharacterClasses.value ?? []) {
+    const list = m.get(cc.party_member_id) ?? [];
+    list.push(cc);
+    m.set(cc.party_member_id, list);
+  }
+  return m;
+});
+function memberClassLabel(memberId: string, legacyClass: string | null): string {
+  const list = classesByMember.value.get(memberId) ?? [];
+  if (list.length > 1) return formatMulticlassLabel(list);
+  if (list.length === 1) return list[0].class_name;
+  return legacyClass ?? "";
+}
+function memberLevelDisplay(memberId: string, legacyLevel: number): number {
+  const list = classesByMember.value.get(memberId) ?? [];
+  return list.length > 0 ? totalLevel(list) : legacyLevel;
+}
 const addMut          = useAddFactionPartyMember();
 const updateRoleMut   = useUpdateFactionPartyMemberRole();
 const updateStatusMut = useUpdateFactionPartyMemberStatus();

--- a/src/components/party/PartyTracker.vue
+++ b/src/components/party/PartyTracker.vue
@@ -83,8 +83,8 @@
                 {{
                   [
                     member.race ? (speciesNameMap.get(member.race) ?? member.race) : null,
-                    member.class,
-                    member.level ? `Lv${member.level}` : "",
+                    memberClassLabel(member.id, member.class),
+                    memberLevelDisplay(member.id, member.level) ? `Lv${memberLevelDisplay(member.id, member.level)}` : "",
                   ]
                     .filter(Boolean)
                     .join(" · ")
@@ -688,6 +688,9 @@ import type { Item } from "@/types/item.types";
 import { ITEM_TYPE_LABELS, RARITY_COLORS } from "@/types/item.types";
 import { useCompanions, useDeleteCompanion } from "@/composables/useCompanions";
 import { useAllSpecies } from "@/composables/useSpecies";
+import { useAllCampaignCharacterClasses } from "@/composables/useCharacterClasses";
+import { formatMulticlassLabel, totalLevel } from "@/types/multiclass.types";
+import type { CharacterClass } from "@/types/multiclass.types";
 import { isInDisguise } from "@/lib/partyMemberDisplay";
 import { useAllMonsters } from "@/composables/useMonsters";
 import { useNpcs } from "@/composables/useNpcs";
@@ -729,6 +732,29 @@ const speciesNameMap = computed(() => {
   for (const s of allSpecies.value ?? []) m.set(s.id, s.name);
   return m;
 });
+
+const { data: allCharacterClasses } = useAllCampaignCharacterClasses();
+const classesByMember = computed(() => {
+  const m = new Map<string, CharacterClass[]>();
+  for (const cc of allCharacterClasses.value ?? []) {
+    const list = m.get(cc.party_member_id) ?? [];
+    list.push(cc);
+    m.set(cc.party_member_id, list);
+  }
+  return m;
+});
+
+function memberClassLabel(memberId: string, legacyClass: string | null): string {
+  const list = classesByMember.value.get(memberId) ?? [];
+  if (list.length > 1) return formatMulticlassLabel(list);
+  if (list.length === 1) return list[0].class_name;
+  return legacyClass ?? "";
+}
+
+function memberLevelDisplay(memberId: string, legacyLevel: number): number {
+  const list = classesByMember.value.get(memberId) ?? [];
+  return list.length > 0 ? totalLevel(list) : legacyLevel;
+}
 
 // Initiative
 const sortedMembers = computed(() => {

--- a/src/components/player/PlayerCharacterHeader.vue
+++ b/src/components/player/PlayerCharacterHeader.vue
@@ -31,8 +31,8 @@
               ><Star class="h-3.5 w-3.5" :class="member.inspiration ? 'fill-gold-500' : ''" /></button>
             </div>
             <p class="font-fell text-xs text-muted-foreground italic">
-              {{ [speciesName, member.subrace, member.class, member.subclass].filter(Boolean).join(" · ") }}
-              <span v-if="member.level" class="font-cinzel text-[10px] text-primary not-italic ml-1">Lv {{ member.level }}</span>
+              {{ [speciesName, member.subrace, classLabel].filter(Boolean).join(" · ") }}
+              <span v-if="memberTotalLevel" class="font-cinzel text-[10px] text-primary not-italic ml-1">Lv {{ memberTotalLevel }}</span>
             </p>
           </div>
           <div v-if="!hidePlayerActions" class="shrink-0 flex items-center gap-1 pt-0.5">
@@ -149,6 +149,8 @@ import { RouterLink } from "vue-router";
 import { Star, TrendingUp, Settings } from "lucide-vue-next";
 import { useUpdatePartyMember } from "@/composables/useParty";
 import { useClassByName } from "@/composables/useCustomClasses";
+import { useCharacterClasses } from "@/composables/useCharacterClasses";
+import { formatMulticlassLabel, totalLevel } from "@/types/multiclass.types";
 import { getHitDie } from "@/types/spell.types";
 import { useConcentration } from "@/composables/useConcentration";
 import { patchLiveCombatantConditions } from "@/composables/useEncounterLive";
@@ -220,8 +222,36 @@ async function addCondition(cond: string) {
 const classNameRef = computed(() => props.member.class ?? "");
 const classData = useClassByName(classNameRef);
 const hitDie = computed<number>(() => classData.value?.hit_die ?? getHitDie(classNameRef.value));
+
+const memberIdRef = computed(() => props.member.id);
+const { data: characterClasses } = useCharacterClasses(memberIdRef);
+
+/**
+ * Total character level. Sum of `character_classes` rows if populated;
+ * otherwise falls back to the legacy single `party_members.level`.
+ */
+const memberTotalLevel = computed(() => {
+  const list = characterClasses.value ?? [];
+  return list.length > 0 ? totalLevel(list) : props.member.level;
+});
+
+/**
+ * Label rendered next to the name: "Fighter 5 / Wizard 3" when multiclass,
+ * otherwise the single class from the legacy column.
+ */
+const classLabel = computed(() => {
+  const list = characterClasses.value ?? [];
+  if (list.length > 1) return formatMulticlassLabel(list);
+  if (list.length === 1) {
+    const only = list[0];
+    const parts = [only.class_name, only.subclass_name].filter(Boolean);
+    return parts.join(" · ");
+  }
+  return [props.member.class, props.member.subclass].filter(Boolean).join(" · ");
+});
+
 const hitDiceRemaining = computed(() =>
-  Math.min(props.member.level, props.member.hit_dice_remaining ?? props.member.level),
+  Math.min(memberTotalLevel.value, props.member.hit_dice_remaining ?? memberTotalLevel.value),
 );
 
 const combatStats = computed(() => [
@@ -229,7 +259,7 @@ const combatStats = computed(() => [
   { label: "SPD",  value: props.member.speed, suffix: "ft" },
   { label: "INIT", value: abilityModifier(props.member.dex), suffix: "" },
   { label: "PROF", value: `+${props.member.proficiency_bonus}`, suffix: "" },
-  { label: "HD",   value: `${hitDiceRemaining.value}/${props.member.level}`, suffix: `d${hitDie.value}` },
+  { label: "HD",   value: `${hitDiceRemaining.value}/${memberTotalLevel.value}`, suffix: `d${hitDie.value}` },
 ]);
 
 const hpPct = computed(() => {

--- a/src/composables/useCharacterClasses.ts
+++ b/src/composables/useCharacterClasses.ts
@@ -1,0 +1,117 @@
+import { computed, type Ref } from "vue";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
+import { supabase } from "@/lib/supabase";
+import { useCampaignStore } from "@/stores/campaign";
+import type {
+  CharacterClass,
+  CharacterClassInsert,
+  CharacterClassUpdate,
+  MulticlassPrereq,
+} from "@/types/multiclass.types";
+
+const QUERY_KEY = "character_classes";
+const PREREQS_KEY = "multiclass_prerequisites";
+
+async function fetchClassesForMember(partyMemberId: string): Promise<CharacterClass[]> {
+  const { data, error } = await supabase
+    .from("character_classes")
+    .select("*")
+    .eq("party_member_id", partyMemberId)
+    .order("sort_order", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as CharacterClass[];
+}
+
+async function fetchAllClassesForCampaign(campaignId: string): Promise<CharacterClass[]> {
+  // Join through party_members to scope by campaign. RLS already restricts to
+  // the caller's own members — campaign filter is belt-and-braces.
+  const { data, error } = await supabase
+    .from("character_classes")
+    .select("*, party_members!inner(campaign_id)")
+    .eq("party_members.campaign_id", campaignId)
+    .order("sort_order", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as CharacterClass[];
+}
+
+async function fetchPrereqs(): Promise<MulticlassPrereq[]> {
+  const { data, error } = await supabase.from("multiclass_prerequisites").select("*");
+  if (error) throw error;
+  return (data ?? []) as MulticlassPrereq[];
+}
+
+/**
+ * Reactive list of class entries for one party member. Pre-multiclass data
+ * (a character with no `character_classes` rows) returns an empty array —
+ * consumers should fall back to `party_members.class`/`level` in that case.
+ */
+export function useCharacterClasses(partyMemberId: Ref<string | null | undefined>) {
+  return useQuery({
+    queryKey: computed(() => [QUERY_KEY, partyMemberId.value]),
+    queryFn: () => fetchClassesForMember(partyMemberId.value!),
+    enabled: () => !!partyMemberId.value,
+  });
+}
+
+/**
+ * All class entries for the active campaign's party members. Used by views
+ * that render a roster (dashboard, party tracker) so each card can show the
+ * "Fighter 5 / Wizard 3" label without per-row fetches.
+ */
+export function useAllCampaignCharacterClasses() {
+  const campaign = useCampaignStore();
+  const campaignId = computed(() => campaign.activeCampaignId);
+  return useQuery({
+    queryKey: computed(() => [QUERY_KEY, "by-campaign", campaignId.value]),
+    queryFn: () => fetchAllClassesForCampaign(campaignId.value!),
+    enabled: () => !!campaignId.value,
+  });
+}
+
+/** Static PHB prereq table. Cached indefinitely — migrations change it. */
+export function useMulticlassPrereqs() {
+  return useQuery({
+    queryKey: [PREREQS_KEY],
+    queryFn: fetchPrereqs,
+    staleTime: Infinity,
+  });
+}
+
+export function useAddCharacterClass() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (row: CharacterClassInsert) => {
+      const { data, error } = await supabase
+        .from("character_classes")
+        .insert(row)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as CharacterClass;
+    },
+    onSuccess: (row) => {
+      void queryClient.invalidateQueries({ queryKey: [QUERY_KEY, row.party_member_id] });
+      void queryClient.invalidateQueries({ queryKey: [QUERY_KEY, "by-campaign"] });
+    },
+  });
+}
+
+export function useUpdateCharacterClass() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, update }: { id: string; update: CharacterClassUpdate }) => {
+      const { data, error } = await supabase
+        .from("character_classes")
+        .update(update)
+        .eq("id", id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as CharacterClass;
+    },
+    onSuccess: (row) => {
+      void queryClient.invalidateQueries({ queryKey: [QUERY_KEY, row.party_member_id] });
+      void queryClient.invalidateQueries({ queryKey: [QUERY_KEY, "by-campaign"] });
+    },
+  });
+}

--- a/src/composables/useCharacterCreationForm.ts
+++ b/src/composables/useCharacterCreationForm.ts
@@ -2,6 +2,7 @@ import { ref, reactive, computed, watch, type InjectionKey } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
 import { useParty, useCreatePartyMember, useUpdatePartyMember } from "@/composables/useParty";
+import { useAddCharacterClass } from "@/composables/useCharacterClasses";
 import { useCampaignMembers, useUpdateCampaignMember } from "@/composables/useCampaignMembers";
 import { SKILLS } from "@/types/party.types";
 import { useAllSystemClasses, useAllCustomClasses } from "@/composables/useCustomClasses";
@@ -101,6 +102,7 @@ export function useCharacterCreationForm() {
   const { data: campaignMembers } = useCampaignMembers();
   const { mutateAsync: create }               = useCreatePartyMember();
   const { mutateAsync: update }               = useUpdatePartyMember();
+  const { mutateAsync: addCharacterClass }    = useAddCharacterClass();
   const { mutateAsync: updateCampaignMember } = useUpdateCampaignMember();
 
   const editMemberId = computed(() =>
@@ -339,6 +341,20 @@ export function useCharacterCreationForm() {
       const myMembership = (campaignMembers.value ?? []).find((cm) => cm.user_id === auth.user?.id);
       if (myMembership) {
         await updateCampaignMember({ id: myMembership.id, update: { party_member_id: created.id } });
+      }
+      // Seed the primary character_classes row. Characters above level 1
+      // immediately route to the level-up wizard, which increments from 1
+      // per-class-level for each remaining level.
+      if (f.class) {
+        await addCharacterClass({
+          party_member_id: created.id,
+          class_name:      f.class,
+          subclass_name:   f.subclass || null,
+          levels:          1,
+          is_primary:      true,
+          hit_dice_used:   0,
+          sort_order:      0,
+        });
       }
       await auth.refreshMembership();
       saving.value = false;

--- a/src/levelup/LevelUpWizard.vue
+++ b/src/levelup/LevelUpWizard.vue
@@ -27,6 +27,64 @@
     </div>
 
     <template v-else>
+      <!-- Class picker — choose which class gets this level. For single-class
+           characters this is the only option; for multiclass the player picks
+           between continuing an existing class or taking a new one. -->
+      <div class="rounded-lg border border-border bg-card p-4 space-y-3">
+        <h3 class="font-cinzel text-xs tracking-wider text-muted-foreground uppercase">Leveling in</h3>
+        <select
+          v-model="chosenClassSelector"
+          class="w-full rounded border border-border bg-muted/40 px-3 py-2 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <option v-for="entry in existingClassOptions" :key="entry.id" :value="entry.id">
+            {{ entry.class_name }}{{ entry.subclass_name ? ` (${entry.subclass_name})` : '' }}
+            — Level {{ entry.levels }} → {{ entry.levels + 1 }}
+          </option>
+          <option value="__new__">Take a level in a new class…</option>
+        </select>
+
+        <template v-if="isAddingNewClass">
+          <div class="space-y-2">
+            <label class="font-cinzel text-[10px] text-muted-foreground tracking-wider">New Class</label>
+            <select
+              v-model="newClassName"
+              class="w-full rounded border border-border bg-muted/40 px-3 py-2 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              <option value="" disabled>Select…</option>
+              <option v-for="name in newClassCandidates" :key="name" :value="name">{{ name }}</option>
+            </select>
+          </div>
+          <!-- Prereq warning -->
+          <div
+            v-if="newClassName && !newClassPrereq.ok"
+            class="rounded-md px-3 py-2 flex items-start gap-2"
+            :class="ignoreMulticlassPrereqs
+              ? 'bg-amber-500/10 border border-amber-500/30 text-amber-400'
+              : 'bg-destructive/10 border border-destructive/30 text-destructive'"
+          >
+            <span class="font-cinzel text-[10px] tracking-wider shrink-0">{{ ignoreMulticlassPrereqs ? 'PREREQ IGNORED' : 'PREREQ' }}</span>
+            <span class="font-fell text-xs">
+              {{ newClassPrereq.reason }}.
+              <template v-if="ignoreMulticlassPrereqs">
+                Multiclass prereqs are disabled for this campaign.
+              </template>
+              <template v-else>
+                The DM can enable "Ignore multiclass prereqs" in Campaign Settings.
+              </template>
+            </span>
+          </div>
+          <div
+            v-if="newClassName && newClassProficiencyGrants.length > 0"
+            class="rounded-md bg-primary/10 border border-primary/20 px-3 py-2"
+          >
+            <p class="font-cinzel text-[10px] text-primary tracking-wider mb-1">Multiclass Proficiencies</p>
+            <p class="font-fell text-xs text-foreground">
+              You gain: {{ newClassProficiencyGrants.join(', ') }}
+            </p>
+          </div>
+        </template>
+      </div>
+
       <!-- Features gained -->
       <div class="rounded-lg border border-border bg-card p-4 space-y-3">
         <h3 class="font-cinzel text-xs tracking-wider text-muted-foreground uppercase">Features Gained</h3>
@@ -419,7 +477,16 @@ import { ChevronDown } from "lucide-vue-next";
 import RichTextViewer from "@/components/common/RichTextViewer.vue";
 import { useUpdatePartyMember } from "@/composables/useParty";
 import { useAllCustomSubclasses, useCustomSubclassByClassAndSubclass } from "@/composables/useCustomSubclasses";
-import { useCustomClassByName, useAllSystemClasses } from "@/composables/useCustomClasses";
+import { useCustomClassByName, useAllSystemClasses, useAllCustomClasses } from "@/composables/useCustomClasses";
+import {
+  useCharacterClasses,
+  useMulticlassPrereqs,
+  useAddCharacterClass,
+  useUpdateCharacterClass,
+} from "@/composables/useCharacterClasses";
+import { useCampaignStore } from "@/stores/campaign";
+import { meetsMulticlassPrereq } from "@/types/multiclass.types";
+import type { CharacterClass } from "@/types/multiclass.types";
 import { getHitDie } from "@/types/spell.types";
 import { rollDie } from "@/lib/dice";
 import { useAllFeatures } from "@/composables/useFeatures";
@@ -438,14 +505,82 @@ const props = defineProps<{
 
 const router = useRouter();
 const { mutateAsync: updateMember, isPending } = useUpdatePartyMember();
+const { mutateAsync: addCharacterClass } = useAddCharacterClass();
+const { mutateAsync: updateCharacterClass } = useUpdateCharacterClass();
+const campaign = useCampaignStore();
 
-// ── Class data ─────────────────────────────────────────────────────────────────
-const memberClass    = computed(() => props.member.class ?? "");
-const memberSubclass = computed(() => props.member.subclass ?? "");
+// ── Multiclass state ───────────────────────────────────────────────────────────
+const memberIdRef = computed(() => props.member.id);
+const { data: characterClasses } = useCharacterClasses(memberIdRef);
+const { data: multiclassPrereqs } = useMulticlassPrereqs();
+const { data: allCustomClasses } = useAllCustomClasses();
+const { data: allSystemClasses } = useAllSystemClasses();
+
+/** Synthetic fallback row for pre-multiclass characters (no character_classes yet). */
+const memberClassEntries = computed<CharacterClass[]>(() => {
+  const list = characterClasses.value ?? [];
+  if (list.length > 0) return list;
+  if (!props.member.class) return [];
+  return [{
+    id: "__legacy__",
+    party_member_id: props.member.id,
+    class_name: props.member.class,
+    subclass_name: props.member.subclass ?? null,
+    levels: props.member.level,
+    is_primary: true,
+    hit_dice_used: 0,
+    sort_order: 0,
+    created_at: props.member.created_at,
+    updated_at: props.member.updated_at,
+  }];
+});
+
+const existingClassOptions = computed(() => memberClassEntries.value);
+
+/** User's choice for this level-up: either an existing class entry or "__new__" */
+const chosenClassSelector = ref<string>("");
+
+/** When adding a new class, which class is being taken. */
+const newClassName = ref<string>("");
+
+// Seed the picker on mount / when member classes load.
+const initClassSelectorOnce = computed(() => {
+  if (chosenClassSelector.value) return true;
+  const primary = existingClassOptions.value.find(c => c.is_primary) ?? existingClassOptions.value[0];
+  if (primary) {
+    chosenClassSelector.value = primary.id;
+    return true;
+  }
+  return false;
+});
+// Touch the computed so it runs its seeding effect.
+void initClassSelectorOnce;
+
+const isAddingNewClass = computed(() => chosenClassSelector.value === "__new__");
+
+const chosenExistingEntry = computed<CharacterClass | null>(() => {
+  if (isAddingNewClass.value) return null;
+  return existingClassOptions.value.find(c => c.id === chosenClassSelector.value) ?? null;
+});
+
+/** The class name for this level-up — existing-class name or newly-picked class. */
+const memberClass = computed(() => {
+  if (isAddingNewClass.value) return newClassName.value;
+  return chosenExistingEntry.value?.class_name ?? props.member.class ?? "";
+});
+
+const memberSubclass = computed(() =>
+  chosenExistingEntry.value?.subclass_name ?? "",
+);
+
+/** Per-chosen-class level: the level *inside the chosen class* after this bump. */
+const levelInChosenClass = computed(() => {
+  if (isAddingNewClass.value) return 1;
+  return (chosenExistingEntry.value?.levels ?? 0) + 1;
+});
 
 const { data: customSubclass } = useCustomSubclassByClassAndSubclass(memberClass, memberSubclass);
 const { data: customClass }    = useCustomClassByName(memberClass);
-const { data: allSystemClasses } = useAllSystemClasses();
 const systemClass = computed(() => (allSystemClasses.value ?? []).find(c => c.class_name === memberClass.value));
 const { data: allFeatures }   = useAllFeatures();
 const { data: allCustomSubclasses } = useAllCustomSubclasses();
@@ -455,7 +590,42 @@ const customSubclassNamesForClass = computed<string[]>(() =>
     .map(cs => cs.subclass_name),
 );
 
+// Classes the character doesn't already have — candidates for a new level.
+const newClassCandidates = computed<string[]>(() => {
+  const existing = new Set(existingClassOptions.value.map(c => c.class_name));
+  const custom = (allCustomClasses.value ?? []).map(c => c.class_name);
+  const system = (allSystemClasses.value ?? []).map(c => c.class_name);
+  const all = Array.from(new Set([...custom, ...system]));
+  return all.filter(name => !existing.has(name)).sort();
+});
+
+const ignoreMulticlassPrereqs = computed<boolean>(() => {
+  const rules = (campaign.activeCampaign?.optional_rules ?? {}) as Record<string, unknown>;
+  return rules.ignore_multiclass_prereqs === true;
+});
+
+/** Prereq check for the currently-selected new class. */
+const newClassPrereq = computed(() => {
+  if (!isAddingNewClass.value || !newClassName.value) return { ok: true as const };
+  const prereq = (multiclassPrereqs.value ?? []).find(p => p.class_name === newClassName.value);
+  if (!prereq) return { ok: true as const };
+  return meetsMulticlassPrereq(prereq, {
+    str: props.member.str, dex: props.member.dex, con: props.member.con,
+    int: props.member.int, wis: props.member.wis, cha: props.member.cha,
+  });
+});
+
+const newClassProficiencyGrants = computed<string[]>(() => {
+  if (!isAddingNewClass.value || !newClassName.value) return [];
+  const prereq = (multiclassPrereqs.value ?? []).find(p => p.class_name === newClassName.value);
+  return prereq?.gained_proficiencies ?? [];
+});
+
 // ── Derived ────────────────────────────────────────────────────────────────────
+// `nextLevel` is the character's new TOTAL level — used for proficiency bonus.
+// `levelInChosenClass` (defined above) is the new level IN THE CLASS BEING
+// LEVELLED — used for features, ASI checks, subclass gates, hit die, and
+// class-specific spell/cantrip tables.
 const nextLevel    = computed(() => props.member.level + 1);
 const newProfBonus = computed(() => 2 + Math.floor((nextLevel.value - 1) / 4));
 
@@ -499,15 +669,15 @@ const currentHitDice = computed(() =>
 const newHitDiceCount = computed(() => Math.min(nextLevel.value, currentHitDice.value + 1));
 
 const grantsAsi = computed(() =>
-  systemClass.value?.asi_levels.includes(nextLevel.value) ||
-  customClass.value?.asi_levels.includes(nextLevel.value) ||
+  systemClass.value?.asi_levels.includes(levelInChosenClass.value) ||
+  customClass.value?.asi_levels.includes(levelInChosenClass.value) ||
   false,
 );
 
 const needsSubclassChoice = computed(() => {
-  if (props.member.subclass) return false;
-  if (systemClass.value?.subclass_level === nextLevel.value) return true;
-  if (customClass.value?.subclass_level === nextLevel.value) return true;
+  if (chosenExistingEntry.value?.subclass_name) return false;
+  if (systemClass.value?.subclass_level === levelInChosenClass.value) return true;
+  if (customClass.value?.subclass_level === levelInChosenClass.value) return true;
   return false;
 });
 
@@ -520,8 +690,9 @@ function dbSlots(level: number): SpellSlotEntry[] {
   return row.map((max, i) => ({ level: i + 1, max, used: 0 })).filter(s => s.max > 0);
 }
 
-const prevSpellSlots = computed<SpellSlotEntry[]>(() => dbSlots(props.member.level));
-const newSpellSlots  = computed<SpellSlotEntry[]>(() => dbSlots(nextLevel.value));
+const prevLevelInChosenClass = computed(() => Math.max(0, levelInChosenClass.value - 1));
+const prevSpellSlots = computed<SpellSlotEntry[]>(() => dbSlots(prevLevelInChosenClass.value));
+const newSpellSlots  = computed<SpellSlotEntry[]>(() => dbSlots(levelInChosenClass.value));
 const newSpellSlotSummary = computed(() => {
   const prev = prevSpellSlots.value;
   const next = newSpellSlots.value;
@@ -539,27 +710,27 @@ const newSpellSlotSummary = computed(() => {
 const spellsKnownGain = computed(() => {
   const table = customClass.value?.spells_known ?? systemClass.value?.spells_known;
   if (!table) return 0;
-  const cur  = table[nextLevel.value - 1] ?? 0;
-  const prev = table[props.member.level - 1] ?? 0;
+  const cur  = table[levelInChosenClass.value - 1] ?? 0;
+  const prev = table[prevLevelInChosenClass.value - 1] ?? 0;
   return Math.max(0, cur - prev);
 });
 
 const spellsKnownTotal = computed(() => {
   const table = customClass.value?.spells_known ?? systemClass.value?.spells_known;
-  return table?.[nextLevel.value - 1] ?? 0;
+  return table?.[levelInChosenClass.value - 1] ?? 0;
 });
 
 const cantripsKnownGain = computed(() => {
   const table = customClass.value?.cantrips_known ?? systemClass.value?.cantrips_known;
   if (!table) return 0;
-  const cur  = table[nextLevel.value - 1] ?? 0;
-  const prev = table[props.member.level - 1] ?? 0;
+  const cur  = table[levelInChosenClass.value - 1] ?? 0;
+  const prev = table[prevLevelInChosenClass.value - 1] ?? 0;
   return Math.max(0, cur - prev);
 });
 
 const cantripsKnownTotal = computed(() => {
   const table = customClass.value?.cantrips_known ?? systemClass.value?.cantrips_known;
-  return table?.[nextLevel.value - 1] ?? 0;
+  return table?.[levelInChosenClass.value - 1] ?? 0;
 });
 
 /** Highest spell slot level available at nextLevel — caps what spells can be learned. */
@@ -579,7 +750,8 @@ function toggleWizardFeature(name: string) {
 const featureObjectMap = computed(() => new Map((allFeatures.value ?? []).map(f => [f.id, f])));
 
 const customFeaturesForLevel = computed<FeatureEntry[]>(() => {
-  const lvlKey = nextLevel.value.toString();
+  // Features are indexed per-class-level, not per-total-level.
+  const lvlKey = levelInChosenClass.value.toString();
   const ids = customSubclass.value?.features[lvlKey] ?? customClass.value?.features[lvlKey] ?? systemClass.value?.features[lvlKey] ?? [];
   return mapFeatureIds(ids, featureObjectMap.value);
 });
@@ -610,8 +782,8 @@ const classDefs = computed<ClassResourceDef[]>(() => {
 
 const resourceNotices = computed(() =>
   classDefs.value.flatMap(def => {
-    const newMax = def.maxAtLevel(nextLevel.value);
-    const oldMax = def.maxAtLevel(props.member.level);
+    const newMax = def.maxAtLevel(levelInChosenClass.value);
+    const oldMax = def.maxAtLevel(prevLevelInChosenClass.value);
     if (newMax === oldMax) return [];
     return [{ key: def.key, label: def.label, oldMax, newMax }];
   }),
@@ -657,7 +829,7 @@ const subclassInput = ref("");
 const classSteps = computed<ClassStep[]>(() => {
   function stepsAt(steps: { level: number; step_type: string; type: "select" | "append"; key: string; label: string; description?: string; options: string[]; count?: number }[]): ClassStep[] {
     return steps
-      .filter(s => s.level === nextLevel.value)
+      .filter(s => s.level === levelInChosenClass.value)
       .map(({ level: _l, step_type: _st, ...rest }) => rest);
   }
   return [
@@ -744,6 +916,9 @@ const error = ref("");
 
 const canConfirm = computed(() => {
   if (nextLevel.value > 20) return false;
+  if (!memberClass.value) return false;
+  if (isAddingNewClass.value && !newClassName.value) return false;
+  if (isAddingNewClass.value && !ignoreMulticlassPrereqs.value && !newClassPrereq.value.ok) return false;
   if (hpMode.value === "roll" && rolledHp.value === null) return false;
   if (grantsAsi.value) {
     if (asiMode.value === "plus2" && !asiPrimary.value) return false;
@@ -798,7 +973,7 @@ async function confirm() {
   if (defs.length > 0) {
     const newResources = { ...props.member.class_resources };
     for (const def of defs) {
-      const newMax = def.maxAtLevel(nextLevel.value);
+      const newMax = def.maxAtLevel(levelInChosenClass.value);
       const existing = newResources[def.key];
       newResources[def.key] = {
         max:     newMax,
@@ -813,9 +988,23 @@ async function confirm() {
   const newChoices: Record<string, unknown> = { ...props.member.class_choices };
 
   const subclass = subclassInput.value.trim();
-  if (needsSubclassChoice.value && subclass) {
+  const leveledEntryIsPrimary = chosenExistingEntry.value?.is_primary ?? (isAddingNewClass.value && existingClassOptions.value.length === 0);
+  if (needsSubclassChoice.value && subclass && leveledEntryIsPrimary) {
+    // Keep the legacy column in sync only for the primary class; other
+    // classes' subclasses live on their character_classes row.
     update.subclass = subclass;
     newChoices.subclass = subclass;
+  }
+
+  // When taking a new class, persist the PHB multiclass proficiencies into
+  // the member's tool_proficiencies bag so the sheet reflects them. We
+  // intentionally keep them in tool_proficiencies (free-text) rather than
+  // trying to split by prof category — the grant list is freeform per PHB
+  // and not all entries are real tools.
+  if (isAddingNewClass.value && newClassProficiencyGrants.value.length > 0) {
+    const existingProfs = props.member.tool_proficiencies ?? [];
+    const merged = Array.from(new Set([...existingProfs, ...newClassProficiencyGrants.value]));
+    update.tool_proficiencies = merged;
   }
 
   // Feat choice
@@ -856,6 +1045,44 @@ async function confirm() {
 
   try {
     await updateMember({ id: props.member.id, update: update as PartyMemberUpdate });
+
+    // Persist to character_classes: insert a new row for a new class, or
+    // increment the levels on the existing row being leveled. Skip the
+    // synthetic "__legacy__" entry — those characters get a fresh row when
+    // the next level is taken (backfill migration should cover the rest).
+    if (isAddingNewClass.value && newClassName.value) {
+      await addCharacterClass({
+        party_member_id: props.member.id,
+        class_name: newClassName.value,
+        subclass_name: null,
+        levels: 1,
+        is_primary: existingClassOptions.value.length === 0,
+        hit_dice_used: 0,
+        sort_order: existingClassOptions.value.length,
+      });
+    } else if (chosenExistingEntry.value && chosenExistingEntry.value.id !== "__legacy__") {
+      const entry = chosenExistingEntry.value;
+      const patch: { levels: number; subclass_name?: string | null } = {
+        levels: entry.levels + 1,
+      };
+      if (needsSubclassChoice.value && subclass) {
+        patch.subclass_name = subclass;
+      }
+      await updateCharacterClass({ id: entry.id, update: patch });
+    } else if (chosenExistingEntry.value?.id === "__legacy__") {
+      // Pre-backfill character — create the primary row at its new level.
+      await addCharacterClass({
+        party_member_id: props.member.id,
+        class_name: chosenExistingEntry.value.class_name,
+        subclass_name: (needsSubclassChoice.value && subclass)
+          ? subclass
+          : (chosenExistingEntry.value.subclass_name ?? null),
+        levels: chosenExistingEntry.value.levels + 1,
+        is_primary: true,
+        hit_dice_used: 0,
+        sort_order: 0,
+      });
+    }
 
     // Add selected spells and cantrips to character_spells
     for (const spellId of selectedSpellIds.value) {

--- a/src/types/campaign.types.ts
+++ b/src/types/campaign.types.ts
@@ -1,3 +1,9 @@
+/** Per-campaign house-rule toggles. Shape is open-ended; known keys are typed. */
+export interface CampaignOptionalRules {
+  /** PHB multiclass prereqs waived — any character can multiclass regardless of ability scores. */
+  ignore_multiclass_prereqs?: boolean;
+}
+
 export interface Campaign {
   id: string;
   user_id: string;
@@ -9,6 +15,7 @@ export interface Campaign {
   theme: string;        // references GrimoireTheme.id, defaults to 'grimoire'
   health_visibility: "strategic" | "immersive" | "unknown";
   immersive_rolls: boolean;
+  optional_rules: CampaignOptionalRules;
   excluded_monster_ids: string[];
   disabled_class_names: string[];
   openai_api_key: string | null;
@@ -19,7 +26,7 @@ export interface Campaign {
   updated_at: string;
 }
 
-export type CampaignInsert = Omit<Campaign, "id" | "user_id" | "created_at" | "updated_at" | "excluded_monster_ids" | "disabled_class_names" | "health_visibility" | "immersive_rolls" | "openai_api_key" | "ai_setting_prompt" | "ical_token"> & { excluded_monster_ids?: string[]; disabled_class_names?: string[]; health_visibility?: Campaign["health_visibility"]; immersive_rolls?: boolean; openai_api_key?: string | null; ai_setting_prompt?: string | null };
+export type CampaignInsert = Omit<Campaign, "id" | "user_id" | "created_at" | "updated_at" | "excluded_monster_ids" | "disabled_class_names" | "health_visibility" | "immersive_rolls" | "optional_rules" | "openai_api_key" | "ai_setting_prompt" | "ical_token"> & { excluded_monster_ids?: string[]; disabled_class_names?: string[]; health_visibility?: Campaign["health_visibility"]; immersive_rolls?: boolean; optional_rules?: CampaignOptionalRules; openai_api_key?: string | null; ai_setting_prompt?: string | null };
 export type CampaignUpdate = Partial<CampaignInsert> & { ical_token?: string; spotify_client_id?: string | null };
 
 export type CampaignRole = "dm" | "player";

--- a/src/types/multiclass.types.ts
+++ b/src/types/multiclass.types.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-character class entry. A party member has one or more of these (one
+ * flagged as `is_primary`) representing levels taken in different classes.
+ * Single-class characters simply have a single primary row.
+ */
+export interface CharacterClass {
+  id: string;
+  party_member_id: string;
+  class_name: string;
+  subclass_name: string | null;
+  levels: number;
+  is_primary: boolean;
+  hit_dice_used: number;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type CharacterClassInsert = Omit<
+  CharacterClass,
+  "id" | "created_at" | "updated_at"
+>;
+export type CharacterClassUpdate = Partial<Omit<CharacterClass, "id" | "party_member_id" | "created_at" | "updated_at">>;
+
+/**
+ * PHB multiclass prerequisite row. Seeded by migration, read-only for clients.
+ */
+export interface MulticlassPrereq {
+  class_name: string;
+  require_kind: "and" | "or";
+  str: number;
+  dex: number;
+  con: number;
+  int: number;
+  wis: number;
+  cha: number;
+  /** Restricted proficiency list granted when taking this class as a secondary class. */
+  gained_proficiencies: string[];
+}
+
+export interface AbilityScores {
+  str: number;
+  dex: number;
+  con: number;
+  int: number;
+  wis: number;
+  cha: number;
+}
+
+/**
+ * Check whether a character's ability scores meet the multiclass prereqs for
+ * `className`. Returns a tuple of [passes, reason]. Used to gate the class
+ * picker; can be bypassed by the campaign's optional-rules flag.
+ */
+export function meetsMulticlassPrereq(
+  prereq: MulticlassPrereq | null | undefined,
+  scores: AbilityScores,
+): { ok: true } | { ok: false; reason: string } {
+  if (!prereq) return { ok: true };
+  const keys: (keyof AbilityScores)[] = ["str", "dex", "con", "int", "wis", "cha"];
+  const label: Record<keyof AbilityScores, string> = {
+    str: "STR", dex: "DEX", con: "CON", int: "INT", wis: "WIS", cha: "CHA",
+  };
+  const thresholds = keys
+    .map((k) => ({ k, threshold: prereq[k], score: scores[k] }))
+    .filter((r) => r.threshold > 0);
+  if (thresholds.length === 0) return { ok: true };
+
+  if (prereq.require_kind === "or") {
+    const ok = thresholds.some((r) => r.score >= r.threshold);
+    if (ok) return { ok: true };
+    const parts = thresholds.map((r) => `${label[r.k]} ${r.threshold}+`);
+    return { ok: false, reason: `Requires ${parts.join(" or ")}` };
+  }
+
+  const failing = thresholds.filter((r) => r.score < r.threshold);
+  if (failing.length === 0) return { ok: true };
+  const parts = failing.map((r) => `${label[r.k]} ${r.threshold}+`);
+  return { ok: false, reason: `Requires ${parts.join(" and ")}` };
+}
+
+/** Short "Fighter 5 / Wizard 3" label for sheet headers and roster rows. */
+export function formatMulticlassLabel(classes: CharacterClass[]): string {
+  if (classes.length === 0) return "";
+  const sorted = [...classes].sort((a, b) => {
+    if (a.is_primary && !b.is_primary) return -1;
+    if (!a.is_primary && b.is_primary) return 1;
+    return a.sort_order - b.sort_order;
+  });
+  return sorted.map((c) => `${c.class_name} ${c.levels}`).join(" / ");
+}
+
+/** Sum of all class levels — the character's total level for proficiency bonus. */
+export function totalLevel(classes: CharacterClass[]): number {
+  if (classes.length === 0) return 1;
+  return classes.reduce((s, c) => s + c.levels, 0);
+}
+
+/** Returns the primary class entry, or null if none marked. */
+export function primaryClass(classes: CharacterClass[]): CharacterClass | null {
+  return classes.find((c) => c.is_primary) ?? classes[0] ?? null;
+}

--- a/src/types/spell.types.ts
+++ b/src/types/spell.types.ts
@@ -413,6 +413,123 @@ export function getSlotRecovery(cls: string | null | undefined): "short" | "long
   return cls === "Warlock" ? "short" : "long";
 }
 
+/**
+ * How a class contributes to the multiclass caster-level sum (PHB page 164).
+ *
+ * - `full`       — full caster: +1 caster level per class level (Bard, Cleric, Druid, Sorcerer, Wizard)
+ * - `half_down`  — half caster (round down): Paladin, Ranger
+ * - `half_up`    — half caster (round up): Artificer
+ * - `third`      — third caster: Eldritch Knight, Arcane Trickster
+ * - `pact`       — warlock pact magic — tracked separately, not part of the sum
+ * - `none`       — non-caster
+ */
+export type CasterCategory = "full" | "half_down" | "half_up" | "third" | "pact" | "none";
+
+export function getCasterCategory(cls: string | null | undefined): CasterCategory {
+  switch (cls) {
+    case "Bard":
+    case "Cleric":
+    case "Druid":
+    case "Sorcerer":
+    case "Wizard":
+      return "full";
+    case "Paladin":
+    case "Ranger":
+      return "half_down";
+    case "Artificer":
+      return "half_up";
+    case "Fighter (Eldritch Knight)":
+    case "Rogue (Arcane Trickster)":
+      return "third";
+    case "Warlock":
+      return "pact";
+    default:
+      return "none";
+  }
+}
+
+/** The ability score a class uses for spell attack / save DC, or null if non-caster. */
+export function getCastingAbility(cls: string | null | undefined): "int" | "wis" | "cha" | null {
+  switch (cls) {
+    case "Cleric":
+    case "Druid":
+    case "Ranger":
+      return "wis";
+    case "Wizard":
+    case "Artificer":
+    case "Fighter (Eldritch Knight)":
+    case "Rogue (Arcane Trickster)":
+      return "int";
+    case "Bard":
+    case "Paladin":
+    case "Sorcerer":
+    case "Warlock":
+      return "cha";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Multiclass caster level per PHB: full = 1x, half_down = floor(L/2),
+ * half_up = ceil(L/2), third = floor(L/3). Pact and non-casters don't count.
+ */
+export function multiclassCasterLevel(
+  classes: { class_name: string; levels: number }[],
+): number {
+  let sum = 0;
+  for (const c of classes) {
+    const cat = getCasterCategory(c.class_name);
+    if (cat === "full") sum += c.levels;
+    else if (cat === "half_down") sum += Math.floor(c.levels / 2);
+    else if (cat === "half_up") sum += Math.ceil(c.levels / 2);
+    else if (cat === "third") sum += Math.floor(c.levels / 3);
+  }
+  return Math.min(20, sum);
+}
+
+/**
+ * Slot layout for a multiclass character. Combines classes into a single set
+ * of leveled slots from the full-caster table, plus separate pact slots from
+ * the warlock table (if the character has warlock levels).
+ *
+ * Falls back to `getDefaultSpellSlots(class, level)` for single-class
+ * characters so single-class casters keep their class-specific progression
+ * (Artificer's round-up half-caster table, etc.).
+ */
+export function getMulticlassSpellSlots(
+  classes: { class_name: string; levels: number }[],
+): import("@/types/party.types").SpellSlotEntry[] {
+  if (classes.length === 0) return [];
+  if (classes.length === 1) {
+    return getDefaultSpellSlots(classes[0].class_name, classes[0].levels);
+  }
+
+  const out: import("@/types/party.types").SpellSlotEntry[] = [];
+
+  const casterLevel = multiclassCasterLevel(classes);
+  if (casterLevel > 0) {
+    out.push(...slotsFromRow(FULL_CASTER_SLOTS[casterLevel - 1]));
+  }
+
+  const warlock = classes.find((c) => c.class_name === "Warlock");
+  if (warlock) {
+    const [slotLevel, count] = WARLOCK_PACT_SLOTS[Math.min(20, warlock.levels) - 1];
+    if (count > 0) {
+      // Keep pact slots as their own entry. If a leveled slot of the same
+      // level already exists from the multiclass sum, pact slots stack as a
+      // separate resource per RAW — but the UI currently renders a single
+      // entry per slot level, so we store them combined to avoid a regression.
+      // A follow-up PR will split them visually.
+      const existing = out.find((s) => s.level === slotLevel);
+      if (existing) existing.max += count;
+      else out.push({ level: slotLevel, max: count, used: 0 });
+    }
+  }
+
+  return out;
+}
+
 export function getHitDie(cls: string | null | undefined): number {
   const c = cls?.toLowerCase() ?? "";
   if (c === "barbarian") return 12;

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -128,7 +128,7 @@
                     {{ member.name }}
                   </p>
                   <p class="font-fell text-[11px] text-muted-foreground italic truncate leading-tight">
-                    {{ [member.race, member.class, member.level ? `Lvl ${member.level}` : null].filter(Boolean).join(" · ") || "—" }}
+                    {{ [member.race, memberClassLabel(member.id, member.class), memberLevelDisplay(member.id, member.level) ? `Lvl ${memberLevelDisplay(member.id, member.level)}` : null].filter(Boolean).join(" · ") || "—" }}
                   </p>
                 </div>
                 <!-- HP -->
@@ -323,6 +323,9 @@ import StatCard from "@/components/common/StatCard.vue";
 import { extractTiptapText } from "@/lib/utils";
 import { useAllQuests } from "@/composables/useQuests";
 import { useParty } from "@/composables/useParty";
+import { useAllCampaignCharacterClasses } from "@/composables/useCharacterClasses";
+import { formatMulticlassLabel, totalLevel } from "@/types/multiclass.types";
+import type { CharacterClass } from "@/types/multiclass.types";
 import { useNotes } from "@/composables/useNotes";
 import { useNpcs } from "@/composables/useNpcs";
 import { useAllLocations } from "@/composables/useLocations";
@@ -342,6 +345,26 @@ const campaignStore = useCampaignStore();
 
 const { data: allQuests,  isLoading: questsLoading } = useAllQuests();
 const { data: party,      isLoading: partyLoading }  = useParty();
+const { data: allCharacterClasses } = useAllCampaignCharacterClasses();
+const classesByMember = computed(() => {
+  const m = new Map<string, CharacterClass[]>();
+  for (const cc of allCharacterClasses.value ?? []) {
+    const list = m.get(cc.party_member_id) ?? [];
+    list.push(cc);
+    m.set(cc.party_member_id, list);
+  }
+  return m;
+});
+function memberClassLabel(memberId: string, legacyClass: string | null): string {
+  const list = classesByMember.value.get(memberId) ?? [];
+  if (list.length > 1) return formatMulticlassLabel(list);
+  if (list.length === 1) return list[0].class_name;
+  return legacyClass ?? "";
+}
+function memberLevelDisplay(memberId: string, legacyLevel: number): number {
+  const list = classesByMember.value.get(memberId) ?? [];
+  return list.length > 0 ? totalLevel(list) : legacyLevel;
+}
 const { data: notes,      isLoading: notesLoading }  = useNotes();
 const { data: npcs }      = useNpcs();
 const { data: locations } = useAllLocations();

--- a/src/views/play/PlayerCharacterView.vue
+++ b/src/views/play/PlayerCharacterView.vue
@@ -112,8 +112,9 @@ import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import { useAuthStore } from "@/stores/auth";
 import { useUiStore } from "@/stores/ui";
 import { useParty } from "@/composables/useParty";
-import { getCasterType, getDefaultSpellSlots, computeMaxPrepared } from "@/types/spell.types";
+import { getCasterType, getDefaultSpellSlots, getMulticlassSpellSlots, computeMaxPrepared } from "@/types/spell.types";
 import { useClassByName } from "@/composables/useCustomClasses";
+import { useCharacterClasses } from "@/composables/useCharacterClasses";
 import { hasAttackDisadvantage, hasCheckDisadvantage } from "@/lib/conditions";
 import type { SpellSlotEntry, PartyMember } from "@/types/party.types";
 import { useRules, usePlayerVisibleRules } from "@/composables/useRules";
@@ -204,10 +205,17 @@ const memberClassRef = computed(() => member.value?.class ?? "");
 const classData = useClassByName(memberClassRef);
 const casterType = computed(() => classData.value?.caster_type ?? getCasterType(member.value?.class ?? null));
 
+const { data: characterClasses } = useCharacterClasses(resolvedMemberId);
+
 const effectiveSpellSlots = computed<SpellSlotEntry[]>(() => {
   const m = member.value;
   if (!m || casterType.value === "none") return [];
   if (m.spell_slots?.length) return m.spell_slots;
+  // Multiclass: combine class levels per PHB caster-level rules. Single-class
+  // characters (or pre-backfill legacy rows) fall back to per-class progression.
+  const list = (characterClasses.value ?? [])
+    .map((c) => ({ class_name: c.class_name, levels: c.levels }));
+  if (list.length > 0) return getMulticlassSpellSlots(list);
   return getDefaultSpellSlots(m.class, m.level);
 });
 

--- a/src/views/play/PlayerSpellsView.vue
+++ b/src/views/play/PlayerSpellsView.vue
@@ -119,7 +119,8 @@ import { useParty } from "@/composables/useParty";
 import { useCharacterSpells, useCharacterSpellsWithDetails } from "@/composables/useCharacterSpells";
 import SpellList from "@/components/spells/SpellList.vue";
 import PlayerMySpells from "@/components/spells/PlayerMySpells.vue";
-import { SPELL_SCHOOLS, SPELL_CLASSES, getCasterType, computeMaxPrepared, getDefaultSpellSlots } from "@/types/spell.types";
+import { SPELL_SCHOOLS, SPELL_CLASSES, getCasterType, computeMaxPrepared, getDefaultSpellSlots, getMulticlassSpellSlots } from "@/types/spell.types";
+import { useCharacterClasses } from "@/composables/useCharacterClasses";
 import { useClassByName } from "@/composables/useCustomClasses";
 
 const LEVEL_FILTERS = [
@@ -150,11 +151,17 @@ const casterType  = computed(() => classData.value?.caster_type ?? getCasterType
 const maxPrepared = computed(() => computeMaxPrepared(member.value, classData.value, memberClass.value));
 const memberName  = computed(() => member.value?.name ?? "");
 
-// Effective spell slots — fall back to 5e defaults if none configured yet
+const { data: characterClasses } = useCharacterClasses(resolvedMemberId);
+
+// Effective spell slots — multiclass-aware: combines class levels per PHB.
+// Falls back to per-class progression for single-class characters and to the
+// legacy default when no character_classes rows exist yet.
 const effectiveSpellSlots = computed(() => {
   const m = member.value;
   if (!m || casterType.value === "none") return [];
   if (m.spell_slots?.length) return m.spell_slots;
+  const list = (characterClasses.value ?? []).map((c) => ({ class_name: c.class_name, levels: c.levels }));
+  if (list.length > 0) return getMulticlassSpellSlots(list);
   return getDefaultSpellSlots(m.class, m.level);
 });
 

--- a/supabase/migrations/20260417000005_character_classes.sql
+++ b/supabase/migrations/20260417000005_character_classes.sql
@@ -1,0 +1,96 @@
+-- Migration: character_classes
+-- Introduces a `character_classes` join table so a party member can hold levels
+-- in more than one class (5e multiclassing). Each row represents N levels taken
+-- in a given class for that character. `is_primary` flags the first class
+-- (the one picked at creation); multiclass RAW limits a character to one
+-- primary class.
+
+create table if not exists character_classes (
+  id              uuid primary key default gen_random_uuid(),
+  party_member_id uuid not null references party_members(id) on delete cascade,
+  class_name      text not null,
+  subclass_name   text,
+  levels          int  not null check (levels between 1 and 20),
+  is_primary      boolean not null default false,
+  hit_dice_used   int  not null default 0,
+  sort_order      int  not null default 0,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+-- Exactly one primary class per member. Nullable + partial unique index means
+-- rows without is_primary coexist freely.
+create unique index if not exists character_classes_one_primary_per_member
+  on character_classes (party_member_id)
+  where is_primary;
+
+create index if not exists character_classes_member_idx
+  on character_classes (party_member_id);
+
+create trigger character_classes_updated_at
+  before update on character_classes
+  for each row execute procedure update_updated_at();
+
+alter table character_classes enable row level security;
+
+-- Owner-through-party-member RLS: you can read/write class rows for party
+-- members you own. Matches the party_members RLS shape.
+create policy "character_classes_select" on character_classes
+  for select using (
+    exists (
+      select 1 from party_members pm
+      where pm.id = character_classes.party_member_id
+        and pm.user_id = auth.uid()
+    )
+  );
+
+create policy "character_classes_insert" on character_classes
+  for insert with check (
+    exists (
+      select 1 from party_members pm
+      where pm.id = character_classes.party_member_id
+        and pm.user_id = auth.uid()
+    )
+  );
+
+create policy "character_classes_update" on character_classes
+  for update using (
+    exists (
+      select 1 from party_members pm
+      where pm.id = character_classes.party_member_id
+        and pm.user_id = auth.uid()
+    )
+  );
+
+create policy "character_classes_delete" on character_classes
+  for delete using (
+    exists (
+      select 1 from party_members pm
+      where pm.id = character_classes.party_member_id
+        and pm.user_id = auth.uid()
+    )
+  );
+
+-- View used by clients to read aggregate class info without joining manually.
+-- total_level falls back to 1 so characters without any character_classes rows
+-- still return something sensible (legacy / pre-backfill defensive fallback).
+create or replace view party_member_levels as
+select
+  pm.id as party_member_id,
+  coalesce(sum(cc.levels), pm.level) as total_level,
+  coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'id',         cc.id,
+        'class',      cc.class_name,
+        'subclass',   cc.subclass_name,
+        'levels',     cc.levels,
+        'is_primary', cc.is_primary,
+        'sort_order', cc.sort_order
+      ) order by cc.sort_order
+    ) filter (where cc.id is not null),
+    '[]'::jsonb
+  ) as classes
+from party_members pm
+left join character_classes cc on cc.party_member_id = pm.id
+group by pm.id, pm.level;

--- a/supabase/migrations/20260417000006_character_classes_backfill.sql
+++ b/supabase/migrations/20260417000006_character_classes_backfill.sql
@@ -1,0 +1,24 @@
+-- Migration: character_classes_backfill
+-- Copies the existing single-class state from party_members into the new
+-- character_classes join table. Every existing character with a non-null class
+-- gets one primary row; characters with no class stay unbacked (UI will keep
+-- treating them as classless until the DM picks one).
+
+insert into character_classes (
+  party_member_id, class_name, subclass_name, levels, is_primary, hit_dice_used, sort_order
+)
+select
+  pm.id,
+  pm.class,
+  pm.subclass,
+  greatest(1, least(20, pm.level)),
+  true,
+  0,
+  0
+from party_members pm
+where pm.class is not null
+  and pm.class <> ''
+  and not exists (
+    select 1 from character_classes cc
+    where cc.party_member_id = pm.id
+  );

--- a/supabase/migrations/20260417000007_multiclass_prerequisites.sql
+++ b/supabase/migrations/20260417000007_multiclass_prerequisites.sql
@@ -1,0 +1,51 @@
+-- Migration: multiclass_prerequisites
+-- Static table of PHB multiclass ability-score prerequisites and the limited
+-- set of proficiencies granted when a character takes their first level in a
+-- second (or third) class. Both are readable by all authenticated users.
+--
+-- A row's `require_kind` is:
+--   'and' — every non-zero ability on the row must meet its threshold
+--           (e.g. Monk: Dex 13 AND Wis 13).
+--   'or'  — at least one non-zero ability must meet its threshold
+--           (e.g. Fighter: Str 13 OR Dex 13).
+
+create table if not exists multiclass_prerequisites (
+  class_name   text primary key,
+  require_kind text not null default 'and' check (require_kind in ('and', 'or')),
+  str          int  not null default 0,
+  dex          int  not null default 0,
+  con          int  not null default 0,
+  "int"        int  not null default 0,
+  wis          int  not null default 0,
+  cha          int  not null default 0,
+  -- Proficiencies granted when taking this class as a secondary class.
+  -- Not the full starting proficiencies list (PHB multiclass table).
+  gained_proficiencies text[] not null default '{}'
+);
+
+alter table multiclass_prerequisites enable row level security;
+
+create policy "multiclass_prerequisites_select" on multiclass_prerequisites
+  for select using (auth.role() = 'authenticated');
+
+-- Seed PHB values. Artificer uses Tasha's prereq (Int 13) and grants Light
+-- armor + Tinker's Tools on multiclass.
+insert into multiclass_prerequisites (class_name, require_kind, str, dex, con, "int", wis, cha, gained_proficiencies) values
+  ('Barbarian', 'and', 13,  0, 0,  0,  0,  0, array['Shields', 'Simple Weapons', 'Martial Weapons']),
+  ('Bard',      'and',  0,  0, 0,  0,  0, 13, array['Light Armor', 'One Skill of Your Choice', 'One Musical Instrument of Your Choice']),
+  ('Cleric',    'and',  0,  0, 0,  0, 13,  0, array['Light Armor', 'Medium Armor', 'Shields']),
+  ('Druid',     'and',  0,  0, 0,  0, 13,  0, array['Light Armor', 'Medium Armor', 'Shields (non-metal)']),
+  ('Fighter',   'or',  13, 13, 0,  0,  0,  0, array['Light Armor', 'Medium Armor', 'Shields', 'Simple Weapons', 'Martial Weapons']),
+  ('Monk',      'and',  0, 13, 0,  0, 13,  0, array['Simple Weapons', 'Shortswords']),
+  ('Paladin',   'and', 13,  0, 0,  0,  0, 13, array['Light Armor', 'Medium Armor', 'Shields', 'Simple Weapons', 'Martial Weapons']),
+  ('Ranger',    'and',  0, 13, 0,  0, 13,  0, array['Light Armor', 'Medium Armor', 'Shields', 'Simple Weapons', 'Martial Weapons', 'One Skill from the Class''s Skill List']),
+  ('Rogue',     'and',  0, 13, 0,  0,  0,  0, array['Light Armor', 'One Skill from the Class''s Skill List', 'Thieves'' Tools']),
+  ('Sorcerer',  'and',  0,  0, 0,  0,  0, 13, array[]::text[]),
+  ('Warlock',   'and',  0,  0, 0,  0,  0, 13, array['Light Armor', 'Simple Weapons']),
+  ('Wizard',    'and',  0,  0, 0, 13,  0,  0, array[]::text[]),
+  ('Artificer', 'and',  0,  0, 0, 13,  0,  0, array['Light Armor', 'Medium Armor', 'Shields', 'Tinker''s Tools'])
+on conflict (class_name) do update set
+  require_kind = excluded.require_kind,
+  str = excluded.str, dex = excluded.dex, con = excluded.con,
+  "int" = excluded."int", wis = excluded.wis, cha = excluded.cha,
+  gained_proficiencies = excluded.gained_proficiencies;

--- a/supabase/migrations/20260417000008_character_spells_source_class.sql
+++ b/supabase/migrations/20260417000008_character_spells_source_class.sql
@@ -1,0 +1,12 @@
+-- Migration: character_spells_source_class
+-- Adds a source_class_id FK so a multiclass character can track which class
+-- granted each learned/prepared spell. Preparation caps and cantrips-known
+-- counts are per-class in 5e RAW, so spells need to carry their source.
+-- Nullable for existing rows; level-up writes the new class row's id going
+-- forward.
+
+alter table character_spells
+  add column if not exists source_class_id uuid references character_classes(id) on delete set null;
+
+create index if not exists character_spells_source_class_idx
+  on character_spells (source_class_id);

--- a/supabase/migrations/20260417000009_campaigns_optional_rules.sql
+++ b/supabase/migrations/20260417000009_campaigns_optional_rules.sql
@@ -1,0 +1,11 @@
+-- Migration: campaigns_optional_rules
+-- Adds a jsonb bag for optional-rules toggles on a campaign. First inhabitant:
+-- `ignore_multiclass_prereqs` for DMs running table house rules that bypass
+-- the PHB ability-score prereqs for multiclassing. Shape:
+--
+--   {
+--     "ignore_multiclass_prereqs": true
+--   }
+
+alter table campaigns
+  add column if not exists optional_rules jsonb not null default '{}'::jsonb;


### PR DESCRIPTION
Stacked on **#189** (multiclass phases 1–3). Review #189 first; I'll flip this PR's base to `main` once that chain merges.

## Summary

Addresses the two biggest punts from #189 — multiclass spell slots and the remaining label sites.

### Multiclass spell slot table

New helpers in `src/types/spell.types.ts`:

- `getCasterCategory(class)` → `full | half_down | half_up | third | pact | none`
- `getCastingAbility(class)` → `int | wis | cha | null` (groundwork for per-class spell DC in a later PR)
- `multiclassCasterLevel(classes)` — sums per PHB: full 1×, half_down `floor(L/2)` (Paladin, Ranger), half_up `ceil(L/2)` (Artificer), third `floor(L/3)` (Eldritch Knight, Arcane Trickster), pact excluded
- `getMulticlassSpellSlots(classes)` — reads the full-caster slot table at the combined level and folds in warlock pact slots. Single-class characters bypass this and keep their class-specific progression (so Artificer's round-up half-caster table stays correct).

`PlayerCharacterView` and `PlayerSpellsView` now derive `effectiveSpellSlots` via the multiclass path whenever `character_classes` rows exist; pre-backfill characters fall back to `getDefaultSpellSlots`.

### Label rewrites

Every remaining surface that rendered `member.class` / `member.level` is now multiclass-aware via a small local helper pair (`memberClassLabel` / `memberLevelDisplay`):

- `DashboardView` party roster
- `PartyTracker` character cards
- `EncounterDetail` party list. Note: `partyLevels` (fed into `calculateDifficulty`) now uses the summed total level, so encounter XP thresholds are correct for multiclass PCs.
- `FactionPartyMembersSection` roster rows

Multiclass characters display as "Fighter 5 / Wizard 3"; single-class and pre-backfill characters display unchanged.

## Explicit punts (follow-ups)

- Per-class spell save DC / attack bonus on the sheet.
- Pact slots rendered as their own row (currently folded into the matching slot level in the combined list — visually fine, mechanically accurate total).
- Features tab grouping by source class.
- Dropping legacy `party_members.class / subclass / level` columns.

## Test plan

Requires the multiclass migrations from #189.

- [ ] Single-class Wizard 5: slots unchanged (4×L1, 3×L2, 2×L3).
- [ ] Single-class Artificer 3: slots unchanged (3×L1, 2×L2).
- [ ] Paladin 4 / Wizard 3: combined caster level = 2 + 3 = 5, so 4×L1, 3×L2, 2×L3 in the sheet.
- [ ] Fighter (Eldritch Knight) 6 / Wizard 3: combined = 2 + 3 = 5, same table.
- [ ] Warlock 3 / Sorcerer 2: combined caster level from Sorc 2 = 2, so 3×L1 leveled slots; plus 2× pact slots at L2 folded in.
- [ ] Dashboard / PartyTracker / Encounter builder / Faction roster display "Fighter 5 / Wizard 3" for multiclass PCs and single-class for others.
- [ ] Encounter difficulty math: a Fighter 3 / Wizard 2 counts as total level 5 for XP threshold.
- [ ] Build + typecheck pass (`npm run build`).

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW