### PR TITLE
feat(multiclassing): per-class spell DC/attack + heterogeneous hit dice

### DIFF
--- a/src/components/player/PlayerCharacterHeader.vue
+++ b/src/components/player/PlayerCharacterHeader.vue
@@ -227,6 +227,38 @@ const memberIdRef = computed(() => props.member.id);
 const { data: characterClasses } = useCharacterClasses(memberIdRef);
 
 /**
+ * Hit dice composition by die size. For a single-class character this is
+ * always `[{ die: 10, count: 5 }]`. A Fighter 5 / Wizard 3 returns
+ * `[{ die: 10, count: 5 }, { die: 6, count: 3 }]`.
+ */
+const hitDicePool = computed<{ die: number; count: number }[]>(() => {
+  const list = characterClasses.value ?? [];
+  if (list.length === 0) {
+    return [{ die: hitDie.value, count: props.member.level }];
+  }
+  const byDie = new Map<number, number>();
+  for (const c of list) {
+    const d = getHitDie(c.class_name);
+    byDie.set(d, (byDie.get(d) ?? 0) + c.levels);
+  }
+  return Array.from(byDie.entries())
+    .map(([die, count]) => ({ die, count }))
+    .sort((a, b) => b.die - a.die);
+});
+
+/**
+ * Compact label for the HD chip. Single-class shows the bare die size
+ * ("d10") so the count can be read from the HD chip value. Multiclass
+ * shows the full heterogeneous pool ("5d10+3d6") since the single count
+ * no longer tells the full story.
+ */
+const hitDicePoolLabel = computed(() => {
+  const pool = hitDicePool.value;
+  if (pool.length <= 1) return `d${pool[0]?.die ?? hitDie.value}`;
+  return pool.map((p) => `${p.count}d${p.die}`).join("+");
+});
+
+/**
  * Total character level. Sum of `character_classes` rows if populated;
  * otherwise falls back to the legacy single `party_members.level`.
  */
@@ -259,7 +291,7 @@ const combatStats = computed(() => [
   { label: "SPD",  value: props.member.speed, suffix: "ft" },
   { label: "INIT", value: abilityModifier(props.member.dex), suffix: "" },
   { label: "PROF", value: `+${props.member.proficiency_bonus}`, suffix: "" },
-  { label: "HD",   value: `${hitDiceRemaining.value}/${memberTotalLevel.value}`, suffix: `d${hitDie.value}` },
+  { label: "HD",   value: `${hitDiceRemaining.value}/${memberTotalLevel.value}`, suffix: hitDicePoolLabel.value },
 ]);
 
 const hpPct = computed(() => {

--- a/src/components/spells/PlayerMySpells.vue
+++ b/src/components/spells/PlayerMySpells.vue
@@ -113,15 +113,15 @@
               class="shrink-0 font-cinzel text-[10px] tracking-wider text-primary/70 border border-primary/30 rounded px-1"
             >C</span>
 
-            <!-- Attack / save info -->
+            <!-- Attack / save info (multiclass-aware via source class) -->
             <span
-              v-if="isCastable(entry) && spellAttackBonus !== null && (entry.spell.attack_type === 'ranged_spell' || entry.spell.attack_type === 'melee_spell')"
+              v-if="isCastable(entry) && attackBonusFor(entry) !== null && (entry.spell.attack_type === 'ranged_spell' || entry.spell.attack_type === 'melee_spell')"
               class="shrink-0 font-cinzel text-[10px] text-muted-foreground"
-            >Atk {{ signedNum(spellAttackBonus) }}</span>
+            >Atk {{ signedNum(attackBonusFor(entry)!) }}</span>
             <span
-              v-else-if="isCastable(entry) && spellSaveDc !== null && entry.spell.attack_type === 'save'"
+              v-else-if="isCastable(entry) && saveDcFor(entry) !== null && entry.spell.attack_type === 'save'"
               class="shrink-0 font-cinzel text-[10px] text-muted-foreground"
-            >DC {{ spellSaveDc }}</span>
+            >DC {{ saveDcFor(entry) }}</span>
 
             <!-- Cast button (castable spells) -->
             <button
@@ -196,6 +196,7 @@ import { useUiStore } from "@/stores/ui";
 import { SCHOOL_COLORS } from "@/types/spell.types";
 import type { CasterType, CharacterSpellEntry, Spell } from "@/types/spell.types";
 import type { SpellSlotEntry } from "@/types/party.types";
+import { pickSpellcastingStats, type SpellcastingClassStats } from "@/types/multiclass.types";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import PlayerSpellModal from "@/components/spells/PlayerSpellModal.vue";
 
@@ -209,6 +210,12 @@ const props = defineProps<{
   spellSlots: SpellSlotEntry[];
   spellAttackBonus: number | null;
   spellSaveDc: number | null;
+  /**
+   * Per-class spellcasting stats. Each spell entry picks the stats for its
+   * source class (falling back to the first entry). Empty array → fall
+   * back to the single-class spellAttackBonus / spellSaveDc props.
+   */
+  spellcastingByClass?: SpellcastingClassStats[];
   /**
    * "spellbook" — show all character_spells (Wizard spellbook tab + Known tab for known casters)
    * "prepared"  — show only is_prepared = true (Wizard/Cleric/etc. prepared tab)
@@ -284,6 +291,17 @@ function castButtonTitle(entry: CharacterSpellEntry): string {
   const slot = slotForLevel(entry.spell.level);
   if (slot && slot.used >= slot.max) return "No slots remaining";
   return `Cast — spend one ${SLOT_LEVEL_LABELS[entry.spell.level - 1]}-level slot`;
+}
+
+/** Pick spellcasting stats for a spell entry — multiclass-aware via source_class_id. */
+function statsFor(entry: CharacterSpellEntry): SpellcastingClassStats | null {
+  return pickSpellcastingStats(props.spellcastingByClass ?? [], entry.source_class_id);
+}
+function attackBonusFor(entry: CharacterSpellEntry): number | null {
+  return statsFor(entry)?.attack ?? props.spellAttackBonus;
+}
+function saveDcFor(entry: CharacterSpellEntry): number | null {
+  return statsFor(entry)?.dc ?? props.spellSaveDc;
 }
 
 function signedNum(n: number): string {

--- a/src/types/multiclass.types.ts
+++ b/src/types/multiclass.types.ts
@@ -96,6 +96,67 @@ export function totalLevel(classes: CharacterClass[]): number {
   return classes.reduce((s, c) => s + c.levels, 0);
 }
 
+/**
+ * Per-class spellcasting stats (DC and attack bonus). A multiclass character
+ * has one entry per casting class — e.g. a Paladin 3 / Wizard 5 casts Paladin
+ * spells off CHA and Wizard spells off INT, so each spell uses its own
+ * class's DC.
+ */
+export interface SpellcastingClassStats {
+  /** character_classes row id — matches character_spells.source_class_id */
+  classId: string;
+  className: string;
+  castingAbility: "int" | "wis" | "cha";
+  dc: number;
+  attack: number;
+}
+
+import { getCastingAbility } from "@/types/spell.types";
+
+/**
+ * Compute per-class spell DC and attack bonus from a character's ability
+ * scores + classes. Non-casters are omitted. Proficiency bonus comes from
+ * the character (single value, shared across classes per 5e RAW).
+ */
+export function computeSpellcastingPerClass(
+  member: AbilityScores & { proficiency_bonus: number },
+  classes: CharacterClass[],
+): SpellcastingClassStats[] {
+  const out: SpellcastingClassStats[] = [];
+  for (const c of classes) {
+    const ability = getCastingAbility(c.class_name);
+    if (!ability) continue;
+    const mod = Math.floor((member[ability] - 10) / 2);
+    const dc = 8 + member.proficiency_bonus + mod;
+    out.push({
+      classId: c.id,
+      className: c.class_name,
+      castingAbility: ability,
+      dc,
+      attack: dc - 8,
+    });
+  }
+  return out;
+}
+
+/**
+ * Pick the spellcasting stats for a specific spell entry. Uses
+ * `source_class_id` when present; falls back to the first caster class,
+ * which gracefully handles pre-backfill characters and spells the player
+ * learned before source-class tracking landed.
+ */
+export function pickSpellcastingStats(
+  entries: SpellcastingClassStats[],
+  sourceClassId: string | null | undefined,
+): SpellcastingClassStats | null {
+  if (entries.length === 0) return null;
+  if (sourceClassId) {
+    const match = entries.find((e) => e.classId === sourceClassId);
+    if (match) return match;
+  }
+  return entries[0];
+}
+
 /** Returns the primary class entry, or null if none marked. */
 export function primaryClass(classes: CharacterClass[]): CharacterClass | null {
   return classes.find((c) => c.is_primary) ?? classes[0] ?? null;

--- a/src/types/spell.types.ts
+++ b/src/types/spell.types.ts
@@ -245,6 +245,8 @@ export interface CharacterSpell {
   spell_id: string;
   is_known: boolean;
   is_prepared: boolean;
+  /** FK to character_classes — which class granted this spell. Null for legacy rows. */
+  source_class_id: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/views/play/PlayerCharacterView.vue
+++ b/src/views/play/PlayerCharacterView.vue
@@ -81,6 +81,7 @@
         :spell-slots="effectiveSpellSlots"
         :spell-attack-bonus="spellAttackBonus"
         :spell-save-dc="spellSaveDc"
+        :spellcasting-by-class="spellcastingByClass"
         :max-prepared="maxPrepared"
         :view-mode="casterType === 'known' ? 'spellbook' : 'prepared'"
       />
@@ -115,6 +116,7 @@ import { useParty } from "@/composables/useParty";
 import { getCasterType, getDefaultSpellSlots, getMulticlassSpellSlots, computeMaxPrepared } from "@/types/spell.types";
 import { useClassByName } from "@/composables/useCustomClasses";
 import { useCharacterClasses } from "@/composables/useCharacterClasses";
+import { computeSpellcastingPerClass } from "@/types/multiclass.types";
 import { hasAttackDisadvantage, hasCheckDisadvantage } from "@/lib/conditions";
 import type { SpellSlotEntry, PartyMember } from "@/types/party.types";
 import { useRules, usePlayerVisibleRules } from "@/composables/useRules";
@@ -235,6 +237,19 @@ const spellSaveDc = computed(() => {
 const spellAttackBonus = computed(() => {
   const dc = spellSaveDc.value;
   return dc !== null ? dc - 8 : null;
+});
+
+/**
+ * Per-class spellcasting stats for the current member. Multiclass casters
+ * get one entry per casting class — PlayerMySpells uses `source_class_id`
+ * on each spell entry to show the correct DC / attack.
+ */
+const spellcastingByClass = computed(() => {
+  const m = member.value;
+  if (!m) return [];
+  const list = characterClasses.value ?? [];
+  if (list.length === 0) return [];
+  return computeSpellcastingPerClass(m, list);
 });
 
 // ── Roll toast (shared across all rolling children) ───────────────────────────


### PR DESCRIPTION
Stacked on **#190**. Review #190 first; I'll rebase this chain onto `main` as the earlier PRs merge.

## Summary

Closes the per-class spellcasting and heterogeneous hit dice items flagged in #190.

### Per-class spell DC / attack

Every spell on the player sheet now computes its DC and attack bonus from **the class that granted it**, not from a single primary-caster number. A Paladin 3 / Wizard 5 sees Paladin spells at CHA-based DC and Wizard spells at INT-based DC automatically.

- `computeSpellcastingPerClass(member, classes)` in `multiclass.types.ts` returns one `SpellcastingClassStats` row per casting class: `{ classId, className, castingAbility, dc, attack }`.
- `pickSpellcastingStats(entries, sourceClassId)` resolves the right row for a spell via `character_spells.source_class_id`, falling back to the first entry for rows without a source (pre-backfill spells, DM-granted spells).
- `PlayerMySpells` now takes an optional `spellcastingByClass` prop and renders each spell's `Atk` / `DC` badge from the matching row. If the prop is missing or a spell has no `source_class_id`, it falls through to the existing `spellAttackBonus` / `spellSaveDc` props unchanged.
- `CharacterSpell` type gains the `source_class_id` field (the DB FK already landed in #189).

### Heterogeneous hit dice pool

The header chip now reflects the actual dice composition for multiclass characters:

- **Single-class** (unchanged): `HD 3/5 d10` — the bare `d10` suffix keeps the compact old look.
- **Multiclass**: `HD 6/8 5d10+3d6` — a Fighter 5 / Wizard 3 sees both die types. Sorting is largest-die-first, so the die the player is most likely to spend leads.

Spend tracking is still a single `hit_dice_remaining` counter. Proper per-die-type spend (let the player pick which die to roll on short rest) will follow once the rest dialog becomes multiclass-aware — flagging that as the next follow-up.

## Out of scope (still pending)

- Pact slots rendered as their own row (currently merged into the matching leveled slot in the combined list).
- Features tab grouping by source class.
- Per-class hit-die spend on short rest (rest dialog rewrite).
- Removing the legacy `party_members.class / subclass / level` columns (Phase 7).

## Test plan

Requires migrations from #189.

- [ ] Single-class Wizard 5: `Atk` and `DC` on all spells use INT; HD suffix shows `d6`. Unchanged from main.
- [ ] Single-class Paladin 5: spells use CHA; HD suffix shows `d10`.
- [ ] Paladin 3 / Wizard 5 multiclass (created by level-up): Paladin-granted spells show CHA-based DC; Wizard spells show INT-based DC. HD chip shows `8/8 5d6+3d10`.
- [ ] Build + typecheck pass (`npm run build`).

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW