### PR TITLE
feat(character): alignment, personality, deity, XP + standard array & 4d6

### DIFF
--- a/src/components/play/CharacterCreateWizard.vue
+++ b/src/components/play/CharacterCreateWizard.vue
@@ -51,6 +51,51 @@
         <span class="field-label">Card Art <span class="font-fell normal-case font-normal italic text-muted-foreground">(landscape, for card printing)</span></span>
         <ImageUpload :model-value="cardArtUrl || null" aspect="landscape" placeholder="Drop card art or click to upload" @update:model-value="cardArtUrl = $event ?? ''" />
       </div>
+
+      <!-- Alignment + deity (optional, inline) -->
+      <div class="grid grid-cols-2 gap-3">
+        <label class="block">
+          <span class="field-label">Alignment</span>
+          <select v-model="f.alignment" class="field-input w-full">
+            <option value="">—</option>
+            <option v-for="a in ALIGNMENT_OPTIONS" :key="a" :value="a">{{ a }}</option>
+          </select>
+        </label>
+        <label class="block">
+          <span class="field-label">Deity <span class="font-fell normal-case font-normal italic text-muted-foreground">(if any)</span></span>
+          <input v-model="f.deity" class="field-input w-full" placeholder="Tyr, Mielikki, none…" />
+        </label>
+      </div>
+
+      <!-- Personality block (collapsible) -->
+      <div class="rounded-lg border border-border bg-card">
+        <button
+          type="button"
+          class="w-full flex items-center justify-between px-3 py-2 font-cinzel text-xs font-semibold tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+          @click="showPersonality = !showPersonality"
+        >
+          <span>PERSONALITY · IDEALS · BONDS · FLAWS</span>
+          <span class="text-base" :class="showPersonality ? '' : 'rotate-[-90deg]'">▾</span>
+        </button>
+        <div v-if="showPersonality" class="px-3 pb-3 space-y-2">
+          <label class="block">
+            <span class="field-label">Personality Traits</span>
+            <textarea v-model="f.personality_traits" rows="2" class="field-input w-full resize-y" placeholder="Two short traits that shape their behaviour." />
+          </label>
+          <label class="block">
+            <span class="field-label">Ideals</span>
+            <textarea v-model="f.ideals" rows="2" class="field-input w-full resize-y" placeholder="What drives them — justice, freedom, knowledge…" />
+          </label>
+          <label class="block">
+            <span class="field-label">Bonds</span>
+            <textarea v-model="f.bonds" rows="2" class="field-input w-full resize-y" placeholder="People, places, or artifacts they'd die for." />
+          </label>
+          <label class="block">
+            <span class="field-label">Flaws</span>
+            <textarea v-model="f.flaws" rows="2" class="field-input w-full resize-y" placeholder="One clear weakness that gets them in trouble." />
+          </label>
+        </div>
+      </div>
     </div>
 
     <!-- Step 1: Species -->
@@ -172,11 +217,11 @@
 
     <!-- Step 4: Ability Scores -->
     <div v-else-if="wizardStep === 4" class="space-y-4">
-      <div class="flex items-center gap-2 p-1 rounded-lg bg-muted w-fit">
+      <div class="flex items-center gap-2 p-1 rounded-lg bg-muted w-fit flex-wrap">
         <button type="button" v-for="mode in SCORE_MODES" :key="mode.id"
           class="px-3 py-1.5 rounded-md font-cinzel text-xs font-semibold transition-colors"
           :class="scoreMode === mode.id ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'"
-          @click="scoreMode = mode.id">
+          @click="onScoreModeChange(mode.id)">
           {{ mode.label }}
         </button>
       </div>
@@ -211,6 +256,67 @@
               {{ mod(f[stat.key]) >= 0 ? "+" : "" }}{{ mod(f[stat.key]) }}
             </span>
             <span class="font-cinzel text-[9px] text-muted-foreground">{{ POINT_BUY_COSTS[f[stat.key]] ?? 0 }} pts</span>
+          </div>
+        </div>
+
+        <div v-if="selectedSpecies?.ability_score_increases && Object.keys(selectedSpecies.ability_score_increases).length"
+          class="rounded-lg border border-primary/20 bg-primary/5 p-3">
+          <p class="font-cinzel text-[10px] font-semibold text-primary tracking-wider mb-1.5">{{ selectedSpecies.name.toUpperCase() }} BONUSES (applied at creation)</p>
+          <div class="flex flex-wrap gap-1.5">
+            <span v-for="(val, key) in selectedSpecies.ability_score_increases" :key="key"
+              class="px-2 py-0.5 rounded bg-primary/10 border border-primary/20 font-cinzel text-[11px] text-primary uppercase">
+              {{ key }} +{{ val }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Standard Array / 4d6 pool-assignment -->
+      <div v-else-if="scoreMode === 'array' || scoreMode === 'roll'" class="space-y-3">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <p class="font-fell text-sm text-muted-foreground italic">
+            <template v-if="scoreMode === 'array'">
+              Assign the standard array (15, 14, 13, 12, 10, 8) to your abilities.
+            </template>
+            <template v-else>
+              Each score is 4d6 with the lowest die dropped. Reroll until you like the pool, then assign.
+            </template>
+          </p>
+          <button
+            v-if="scoreMode === 'roll'"
+            type="button"
+            class="px-3 py-1.5 rounded-md bg-primary text-primary-foreground font-cinzel text-xs font-semibold tracking-wider hover:opacity-90 transition-opacity"
+            @click="rollAbilityScores"
+          >Reroll Pool</button>
+        </div>
+
+        <div class="flex items-center gap-1.5 flex-wrap rounded-md border border-border bg-card px-3 py-2">
+          <span class="font-cinzel text-[10px] text-muted-foreground tracking-wider mr-1">POOL</span>
+          <span
+            v-for="(val, idx) in scorePool"
+            :key="idx"
+            class="w-9 h-9 rounded-md border font-cinzel text-sm font-bold flex items-center justify-center transition-colors"
+            :class="Object.values(scoreAssignment).includes(idx)
+              ? 'border-primary/30 bg-primary/10 text-primary/60 line-through'
+              : 'border-border bg-muted/50 text-foreground'"
+          >{{ val }}</span>
+          <span v-if="scorePool.length === 0" class="font-fell text-xs text-muted-foreground italic">No pool loaded.</span>
+        </div>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div v-for="stat in ABILITY_STATS" :key="stat.key" class="rounded-lg border border-border bg-card p-3 flex flex-col items-center gap-2">
+            <span class="font-cinzel text-[10px] font-semibold text-muted-foreground tracking-wider">{{ stat.label }}</span>
+            <select
+              :value="scoreAssignment[stat.key] ?? ''"
+              class="field-input w-full text-center"
+              @change="onPoolPick(stat.key, ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="">—</option>
+              <option v-for="opt in availableForAbility(stat.key)" :key="opt.idx" :value="opt.idx">{{ opt.val }}</option>
+            </select>
+            <span class="font-cinzel text-xs font-bold" :class="mod(f[stat.key]) >= 0 ? 'text-green-500' : 'text-destructive'">
+              {{ mod(f[stat.key]) >= 0 ? "+" : "" }}{{ mod(f[stat.key]) }}
+            </span>
           </div>
         </div>
 
@@ -393,8 +499,8 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from "vue";
-import { CHARACTER_FORM_KEY, WIZARD_STEPS, ABILITY_STATS, SAVE_STATS, PROF_LEVELS, SCORE_MODES, SLOT_LEVEL_LABELS, POINT_BUY_COSTS } from "@/composables/useCharacterCreationForm";
+import { inject, ref, reactive } from "vue";
+import { CHARACTER_FORM_KEY, WIZARD_STEPS, ABILITY_STATS, SAVE_STATS, PROF_LEVELS, SCORE_MODES, SLOT_LEVEL_LABELS, POINT_BUY_COSTS, STANDARD_ARRAY, roll4d6DropLowest } from "@/composables/useCharacterCreationForm";
 import { SKILLS } from "@/types/party.types";
 import { TOOL_PROFICIENCY_GROUPS, LANGUAGE_GROUPS } from "@/lib/proficiency-lists";
 import ImageUpload from "@/components/common/ImageUpload.vue";
@@ -416,6 +522,69 @@ const {
   resetSlotsToDefault, onSpeciesSelect, onClassSelect, onBackgroundSelect,
   save,
 } = form;
+
+// ── Identity extras ──────────────────────────────────────────────────────────
+const showPersonality = ref(false);
+
+const ALIGNMENT_OPTIONS = [
+  "Lawful Good",    "Neutral Good",    "Chaotic Good",
+  "Lawful Neutral", "True Neutral",    "Chaotic Neutral",
+  "Lawful Evil",    "Neutral Evil",    "Chaotic Evil",
+  "Unaligned",
+] as const;
+
+// ── Ability score assignment: standard array + 4d6 ───────────────────────────
+type AbilityKey = "str" | "dex" | "con" | "int" | "wis" | "cha";
+
+/** The immutable pool of six values for the current mode (standard array or roll). */
+const scorePool = ref<number[]>([]);
+
+/** Which pool index is assigned to each ability. null = unassigned. */
+const scoreAssignment = reactive<Record<AbilityKey, number | null>>({
+  str: null, dex: null, con: null, int: null, wis: null, cha: null,
+});
+
+function resetPool(values: readonly number[]) {
+  scorePool.value = [...values];
+  for (const k of Object.keys(scoreAssignment) as AbilityKey[]) {
+    scoreAssignment[k] = null;
+    f[k] = 8;
+  }
+}
+
+function loadStandardArray() { resetPool(STANDARD_ARRAY); }
+
+function rollAbilityScores() {
+  const rolled = Array.from({ length: 6 }, () => roll4d6DropLowest()).sort((a, b) => b - a);
+  resetPool(rolled);
+}
+
+function availableForAbility(abilityKey: AbilityKey): { idx: number; val: number }[] {
+  const takenIdxs = new Set<number>();
+  for (const k of Object.keys(scoreAssignment) as AbilityKey[]) {
+    if (k !== abilityKey && scoreAssignment[k] !== null) takenIdxs.add(scoreAssignment[k]!);
+  }
+  return scorePool.value
+    .map((val, idx) => ({ idx, val }))
+    .filter((e) => !takenIdxs.has(e.idx));
+}
+
+function onPoolPick(abilityKey: AbilityKey, poolIdxStr: string) {
+  if (poolIdxStr === "") {
+    scoreAssignment[abilityKey] = null;
+    f[abilityKey] = 8;
+    return;
+  }
+  const idx = Number(poolIdxStr);
+  scoreAssignment[abilityKey] = idx;
+  f[abilityKey] = scorePool.value[idx] ?? 8;
+}
+
+function onScoreModeChange(mode: typeof SCORE_MODES[number]["id"]) {
+  scoreMode.value = mode;
+  if (mode === "array" && scorePool.value.length === 0) loadStandardArray();
+  if (mode === "roll" && scorePool.value.length === 0) rollAbilityScores();
+}
 </script>
 
 <style scoped>

--- a/src/components/player/PlayerSkillsTab.vue
+++ b/src/components/player/PlayerSkillsTab.vue
@@ -61,6 +61,38 @@
       </div>
     </div>
 
+    <!-- Personality (structured roleplay block) -->
+    <div
+      v-if="hasPersonality"
+      class="rounded-lg border border-border bg-card p-4 space-y-3"
+    >
+      <p class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">Personality</p>
+      <div v-if="member.alignment || member.deity" class="flex flex-wrap gap-1.5">
+        <span v-if="member.alignment" class="px-2 py-0.5 rounded bg-muted border border-border font-cinzel text-[10px] text-foreground tracking-wider">
+          {{ member.alignment }}
+        </span>
+        <span v-if="member.deity" class="px-2 py-0.5 rounded bg-muted border border-border font-cinzel text-[10px] text-foreground tracking-wider">
+          ✦ {{ member.deity }}
+        </span>
+      </div>
+      <div v-if="member.personality_traits" class="space-y-0.5">
+        <p class="font-cinzel text-[10px] text-muted-foreground tracking-wider">TRAITS</p>
+        <p class="font-fell text-sm text-foreground whitespace-pre-wrap">{{ member.personality_traits }}</p>
+      </div>
+      <div v-if="member.ideals" class="space-y-0.5">
+        <p class="font-cinzel text-[10px] text-muted-foreground tracking-wider">IDEALS</p>
+        <p class="font-fell text-sm text-foreground whitespace-pre-wrap">{{ member.ideals }}</p>
+      </div>
+      <div v-if="member.bonds" class="space-y-0.5">
+        <p class="font-cinzel text-[10px] text-muted-foreground tracking-wider">BONDS</p>
+        <p class="font-fell text-sm text-foreground whitespace-pre-wrap">{{ member.bonds }}</p>
+      </div>
+      <div v-if="member.flaws" class="space-y-0.5">
+        <p class="font-cinzel text-[10px] text-muted-foreground tracking-wider">FLAWS</p>
+        <p class="font-fell text-sm text-foreground whitespace-pre-wrap">{{ member.flaws }}</p>
+      </div>
+    </div>
+
     <!-- Notes -->
     <div v-if="member.notes" class="rounded-lg border border-border bg-card p-4">
       <p class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider mb-2">Notes</p>
@@ -114,6 +146,14 @@ function passiveScore(skillKey: keyof SkillProficiencies) {
   return 10 + skillBonusValue(skill);
 }
 const passivePerception   = computed(() => passiveScore("perception"));
+const hasPersonality = computed(() =>
+  !!(props.member.alignment
+    || props.member.deity
+    || props.member.personality_traits
+    || props.member.ideals
+    || props.member.bonds
+    || props.member.flaws),
+);
 const passiveInsight      = computed(() => passiveScore("insight"));
 const passiveInvestigation = computed(() => passiveScore("investigation"));
 

--- a/src/composables/useCharacterCreationForm.ts
+++ b/src/composables/useCharacterCreationForm.ts
@@ -58,11 +58,30 @@ export const PROF_LEVELS: { value: SkillProfLevel; label: string }[] = [
 
 export const SCORE_MODES = [
   { id: "pointbuy" as const, label: "Point Buy" },
+  { id: "array"    as const, label: "Standard Array" },
+  { id: "roll"     as const, label: "Roll 4d6" },
   { id: "manual"   as const, label: "Manual" },
 ];
 
+export type ScoreMode = (typeof SCORE_MODES)[number]["id"];
+
 export const POINT_BUY_COSTS: Record<number, number> = { 8: 0, 9: 1, 10: 2, 11: 3, 12: 4, 13: 5, 14: 7, 15: 9 };
 export const POINT_BUY_TOTAL = 27;
+
+/** Standard array per 5e PHB, highest first. */
+export const STANDARD_ARRAY = [15, 14, 13, 12, 10, 8] as const;
+
+/** Roll 4d6 and drop the lowest die. Returns the sum of the three kept dice. */
+export function roll4d6DropLowest(): number {
+  const rolls = [
+    Math.floor(Math.random() * 6) + 1,
+    Math.floor(Math.random() * 6) + 1,
+    Math.floor(Math.random() * 6) + 1,
+    Math.floor(Math.random() * 6) + 1,
+  ];
+  rolls.sort((a, b) => b - a);
+  return rolls[0] + rolls[1] + rolls[2];
+}
 
 // ── Composable ────────────────────────────────────────────────────────────────
 
@@ -116,7 +135,7 @@ export function useCharacterCreationForm() {
   const activeTab  = ref<"identity" | "stats" | "profs">("identity");
   const wizardStep = ref(0);
   const saving     = ref(false);
-  const scoreMode  = ref<"pointbuy" | "manual">("pointbuy");
+  const scoreMode  = ref<ScoreMode>("pointbuy");
 
   const portraitUrl = ref(existingMember.value?.portrait_url ?? "");
   const focalPoint  = ref<{ x: number; y: number } | null>(existingMember.value?.portrait_focal_point ?? null);
@@ -172,6 +191,13 @@ export function useCharacterCreationForm() {
     carry_capacity_override: m?.carry_capacity_override ?? null,
     class_resources: m?.class_resources ?? {},
     class_choices:   m?.class_choices ?? {},
+    alignment:          m?.alignment ?? "",
+    personality_traits: m?.personality_traits ?? "",
+    ideals:             m?.ideals ?? "",
+    bonds:              m?.bonds ?? "",
+    flaws:              m?.flaws ?? "",
+    deity:              m?.deity ?? "",
+    experience_points:  m?.experience_points ?? 0,
   });
 
   // ── Point buy ────────────────────────────────────────────────────────────────
@@ -318,6 +344,12 @@ export function useCharacterCreationForm() {
       subrace:     f.subrace || null,
       background:  f.background || null,
       notes:       f.notes || null,
+      alignment:            f.alignment || null,
+      personality_traits:   f.personality_traits || null,
+      ideals:               f.ideals || null,
+      bonds:                f.bonds || null,
+      flaws:                f.flaws || null,
+      deity:                f.deity || null,
       portrait_url:         portraitUrl.value || null,
       portrait_focal_point: focalPoint.value,
       card_art_url:         cardArtUrl.value || null,

--- a/src/types/party.types.ts
+++ b/src/types/party.types.ts
@@ -92,6 +92,15 @@ export interface PartyMember {
   card_art_url: string | null;  // landscape art for MTG Card Forge
   notes: string | null;
   sort_order: number;
+  // Roleplay / identity (all optional — new fields, may be absent on legacy rows)
+  alignment?: string | null;
+  personality_traits?: string | null;
+  ideals?: string | null;
+  bonds?: string | null;
+  flaws?: string | null;
+  deity?: string | null;
+  // Experience points (ignored when the campaign uses milestone levelling).
+  experience_points?: number;
   // Currency
   cp: number;
   sp: number;

--- a/supabase/migrations/20260417000010_party_member_identity_and_xp.sql
+++ b/supabase/migrations/20260417000010_party_member_identity_and_xp.sql
@@ -1,0 +1,20 @@
+-- Migration: party_member_identity_and_xp
+-- Adds the character-creation fields every D&D character needs but that
+-- have been living in free-text notes or nowhere at all. Alignment +
+-- personality traits / ideals / bonds / flaws are the four structured
+-- roleplay blocks from the PHB; deity is needed for Clerics/Paladins;
+-- experience_points underpins the optional XP-based levelling mode.
+
+alter table party_members
+  add column if not exists alignment           text,
+  add column if not exists personality_traits  text,
+  add column if not exists ideals              text,
+  add column if not exists bonds               text,
+  add column if not exists flaws               text,
+  add column if not exists deity               text,
+  add column if not exists experience_points   int not null default 0;
+
+comment on column party_members.alignment is
+  'Alignment string (e.g. "Chaotic Good") or free-form. Null for unaligned / not yet chosen.';
+comment on column party_members.experience_points is
+  'Total XP earned. Ignored when the campaign uses milestone levelling. Never decreases.';


### PR DESCRIPTION
Closes the character-creation completeness items from #184 §1. **Independent of the multiclass stack** (#188–#191) — branched off main, so it can land in any order.

## Summary

### Schema (one migration)

- `alignment`, `personality_traits`, `ideals`, `bonds`, `flaws`, `deity` — all nullable text. Lets players record the four PHB roleplay blocks plus faith and alignment without cramming them into the free-text `notes` column.
- `experience_points int not null default 0` — underpins the optional XP-based levelling mode (milestone campaigns simply leave it at 0).

### Creation wizard — Identity step

- Alignment dropdown (9-axis grid + "Unaligned") and an inline Deity field.
- A collapsible **Personality · Ideals · Bonds · Flaws** block with one textarea per PHB slot. Collapsed by default so the wizard's visual weight doesn't change for players who skip roleplay fields.

### Creation wizard — Ability Scores step

Two new modes alongside Point Buy and Manual:

- **Standard Array** — renders the six PHB values (15, 14, 13, 12, 10, 8) as an assignable pool.
- **Roll 4d6** — rolls 4d6 drop-lowest six times; a "Reroll Pool" button lets the player try again until they like the set.

Pool-based assignment: the six values show as chips (grey-out when taken) and each ability gets a dropdown of the remaining values. Unassigning returns the score to the pool.

### Player sheet — Skills tab

New **Personality** card renders any of the six new fields that are set — alignment + deity as chips, and Traits / Ideals / Bonds / Flaws as labelled paragraphs. Hidden entirely when none are set.

## Test plan

Requires the one new migration (`20260417000010_party_member_identity_and_xp.sql`). `supabase db push` before running.

- [ ] Create a new character. Identity step shows the Alignment dropdown + Deity input. Personality block is collapsed by default; expands on click and persists all four textareas.
- [ ] Switch the Ability Scores step to Standard Array. Six chips appear (15/14/13/12/10/8). Assigning a value to STR greys out that chip and removes it from the other abilities' dropdowns. Unassigning returns it.
- [ ] Switch to Roll 4d6. Pool is rolled automatically. Click Reroll Pool — pool changes. Assign all six, confirm totals apply.
- [ ] Finish creating the character. Sheet → Skills tab shows the new Personality card with the alignment chip, deity chip, and the four roleplay blocks.
- [ ] Leave the Personality block empty on creation; the sheet card is hidden.
- [ ] Existing characters still render (new fields are optional on the TS type + nullable in the DB).
- [ ] Build + typecheck pass (`npm run build`).

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW