### PR TITLE
feat(combat): legendary actions, lair actions, surprise round

### DIFF
--- a/src/components/encounters/EncounterDetail.vue
+++ b/src/components/encounters/EncounterDetail.vue
@@ -327,6 +327,35 @@
           :excluded-monster-ids="excludedMonsterIds"
           @hide-monster="toggleHideMonster"
         />
+
+        <!-- Boss Mechanics (legendary/lair) -->
+        <div class="rounded-lg border border-border bg-card p-5 flex flex-col gap-4">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <h2 class="font-cinzel text-sm font-bold text-foreground tracking-wider uppercase">Boss Mechanics</h2>
+              <p class="font-fell text-xs text-muted-foreground mt-1">
+                Lair actions fire at initiative 20 each round. Legendary actions auto-enable on any combatant whose stat block has them.
+              </p>
+            </div>
+            <label class="flex items-center gap-2 cursor-pointer shrink-0">
+              <input type="checkbox" v-model="form.lair_enabled" class="h-4 w-4 rounded border-border bg-muted" />
+              <span class="font-cinzel text-xs font-semibold text-foreground tracking-wide">Lair Actions</span>
+            </label>
+          </div>
+          <div v-if="form.lair_enabled" class="flex flex-col gap-2">
+            <label class="font-cinzel text-[10px] font-semibold text-muted-foreground tracking-wider">LAIR OWNER</label>
+            <select
+              v-model="form.lair_owner_def_id"
+              class="w-full bg-muted border border-border rounded-md px-3 py-2 font-fell text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              <option :value="null">— pick an owner —</option>
+              <option v-for="opt in lairOwnerOptions" :key="opt.id" :value="opt.id">{{ opt.label }}</option>
+            </select>
+            <p v-if="form.lair_enabled && !form.lair_owner_def_id" class="font-fell text-[11px] text-amber-500/80 italic">
+              Pick a combatant whose stat block has Lair Actions. Without one, the runner won't show the lair card.
+            </p>
+          </div>
+        </div>
       </div>
 
       <!-- Right column -->
@@ -492,6 +521,21 @@ function onCancel() {
 }
 const campaign = useCampaignStore();
 const { data: monsters } = useAllMonsters();
+
+/** Combatants eligible as lair owners — any monster/NPC slot in this encounter.
+ *  Shows an indicator next to entries whose stat block already has lair_actions. */
+const lairOwnerOptions = computed(() => {
+  return form.combatants.map((c) => {
+    const monster = c.monster_id ? (monsters.value ?? []).find((m) => m.id === c.monster_id) : null;
+    const hasLairActions = !!(monster?.stat_block?.lair_actions?.length);
+    const baseName = c.custom_name ?? monster?.name ?? (c.npc_id ? "NPC" : "Combatant");
+    return {
+      id: c.id,
+      label: hasLairActions ? `${baseName} ★ (has lair actions)` : baseName,
+    };
+  });
+});
+
 const { data: party, isLoading: partyLoading } = useParty();
 const { data: companions } = useCompanions();
 const { data: npcs } = useNpcs();
@@ -566,6 +610,8 @@ const form = reactive({
     ...(props.encounter?.art_objects ?? []),
   ] as import("@/types/encounter.types").ArtObject[],
   events: [...(props.encounter?.events ?? [])] as EncounterEvent[],
+  lair_enabled: props.encounter?.lair_enabled ?? false,
+  lair_owner_def_id: props.encounter?.lair_owner_def_id ?? (null as string | null),
 });
 
 // For new encounters, auto-select all party members once the party data loads
@@ -821,6 +867,8 @@ async function buildPayload() {
     art_objects: form.art_objects,
     is_finished: props.encounter?.is_finished ?? false,
     events: form.events,
+    lair_enabled: form.lair_enabled,
+    lair_owner_def_id: form.lair_enabled ? form.lair_owner_def_id : null,
   };
 }
 

--- a/src/components/encounters/EncounterRunner.vue
+++ b/src/components/encounters/EncounterRunner.vue
@@ -63,6 +63,8 @@
     <div class="runner-body-wrap">
       <!-- Initiative list -->
       <div class="runner-body">
+        <!-- Boss mechanics panel (lair actions + legendary actions + surprise) -->
+        <RunnerBossMechanics />
         <RunnerCombatantList
           :selected-id="selectedId"
           @select="selectedId = $event"
@@ -103,6 +105,7 @@ import { useAuthStore } from "@/stores/auth";
 import RunnerCombatantList from "./RunnerCombatantList.vue";
 import RunnerEntityDetail from "./RunnerEntityDetail.vue";
 import RunnerDmTools from "./RunnerDmTools.vue";
+import RunnerBossMechanics from "./RunnerBossMechanics.vue";
 
 const store = useEncounterRunStore();
 const router = useRouter();

--- a/src/components/encounters/RunnerBossMechanics.vue
+++ b/src/components/encounters/RunnerBossMechanics.vue
@@ -1,0 +1,176 @@
+<template>
+  <!-- Pre-combat: Mark surprised combatants -->
+  <div
+    v-if="!store.started && hasAnyCombatants"
+    class="rounded-lg border border-dashed border-amber-500/40 bg-amber-500/5 px-3 py-2 mb-2"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <span class="font-cinzel text-xs font-semibold text-amber-500 tracking-wider">
+        SURPRISE — Optional
+      </span>
+      <button
+        type="button"
+        class="font-cinzel text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+        @click="showSurprise = !showSurprise"
+      >{{ showSurprise ? 'Hide' : 'Mark surprised' }}</button>
+    </div>
+    <p v-if="!showSurprise && surprisedCount === 0" class="font-fell text-[11px] text-muted-foreground italic mt-0.5">
+      Mark creatures that are surprised — they'll skip their first turn.
+    </p>
+    <div v-else-if="showSurprise" class="mt-2 flex flex-wrap gap-1.5">
+      <button
+        v-for="c in store.combatants"
+        :key="c.instance_id"
+        type="button"
+        class="px-2 py-0.5 rounded font-cinzel text-[10px] tracking-wider border transition-colors"
+        :class="c.surprised
+          ? 'bg-amber-500/20 border-amber-500/60 text-amber-400'
+          : 'bg-card border-border text-muted-foreground hover:border-amber-500/40'"
+        @click="store.toggleSurprised(c.instance_id)"
+      >{{ c.name }}{{ c.surprised ? ' ✦' : '' }}</button>
+    </div>
+    <p v-if="!showSurprise && surprisedCount > 0" class="font-fell text-[11px] text-amber-400 mt-0.5">
+      {{ surprisedCount }} surprised creature{{ surprisedCount > 1 ? 's' : '' }}.
+    </p>
+  </div>
+
+  <!-- Lair Actions — persistent card when round > 0 and enabled -->
+  <div
+    v-if="store.started && store.lairEnabled && store.lairOwnerInstanceId"
+    class="rounded-lg border bg-card px-3 py-2 mb-2"
+    :class="store.lairCanFireThisRound ? 'border-violet-500/60 bg-violet-500/5' : 'border-border opacity-70'"
+  >
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="font-cinzel text-xs font-semibold tracking-wider"
+        :class="store.lairCanFireThisRound ? 'text-violet-400' : 'text-muted-foreground'"
+      >✦ INIT 20 — LAIR ACTION</span>
+      <span class="font-fell text-[11px] text-muted-foreground flex-1">
+        <template v-if="!store.lairCanFireThisRound">Fired this round. Resets on round rollover.</template>
+        <template v-else-if="lairActions.length === 0">Owner's stat block has no Lair Actions — check the monster entry.</template>
+        <template v-else>Click an action to fire it for this round.</template>
+      </span>
+    </div>
+    <div v-if="store.lairCanFireThisRound && lairActions.length > 0" class="mt-2 flex flex-wrap gap-1.5">
+      <button
+        v-for="(action, idx) in lairActions"
+        :key="idx"
+        type="button"
+        class="px-2 py-1 rounded-md border border-violet-500/30 bg-violet-500/10 text-violet-300 font-cinzel text-[10px] tracking-wider hover:bg-violet-500/20 hover:border-violet-500/60 transition-colors"
+        :title="action.description"
+        @click="fireLairAction(action)"
+      >{{ action.name }}</button>
+    </div>
+  </div>
+
+  <!-- Legendary Action menu — shown when active combatant is NOT the
+       legendary creature, and the legendary creature still has uses. -->
+  <div
+    v-for="legendary in activeLegendaryOthers"
+    :key="legendary.instance_id"
+    class="rounded-lg border border-rose-500/40 bg-rose-500/5 px-3 py-2 mb-2"
+  >
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="font-cinzel text-xs font-semibold text-rose-400 tracking-wider">
+        ⚔ {{ legendary.name.toUpperCase() }} — LEGENDARY ACTIONS
+      </span>
+      <span class="font-cinzel text-[10px] text-muted-foreground">
+        {{ legendary.legendary_actions_remaining }} / {{ legendary.legendary_action_cap }} remaining
+      </span>
+    </div>
+    <div class="mt-2 flex flex-wrap gap-1.5">
+      <button
+        v-for="(action, idx) in getLegendaryActions(legendary.monster_id)"
+        :key="idx"
+        type="button"
+        class="px-2 py-1 rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-300 font-cinzel text-[10px] tracking-wider hover:bg-rose-500/20 hover:border-rose-500/60 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        :title="action.description"
+        :disabled="actionCost(action.name) > (legendary.legendary_actions_remaining ?? 0)"
+        @click="fireLegendaryAction(legendary.instance_id, legendary.name, action)"
+      >{{ action.name }}<span v-if="actionCost(action.name) > 1" class="ml-1 text-muted-foreground">(×{{ actionCost(action.name) }})</span></button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useEncounterRunStore } from "@/stores/encounterRun";
+import { supabase } from "@/lib/supabase";
+import { useCampaignStore } from "@/stores/campaign";
+import { useAuthStore } from "@/stores/auth";
+
+const store = useEncounterRunStore();
+const campaign = useCampaignStore();
+const auth = useAuthStore();
+
+const showSurprise = ref(false);
+const surprisedCount = computed(() => store.combatants.filter((c) => c.surprised).length);
+const hasAnyCombatants = computed(() => store.combatants.length > 0);
+
+/** Lair actions sourced from the owner's monster stat block. */
+const lairActions = computed(() => {
+  const ownerId = store.lairOwnerInstanceId;
+  if (!ownerId) return [];
+  const owner = store.combatants.find((c) => c.instance_id === ownerId);
+  if (!owner?.monster_id) return [];
+  const monster = store.availableMonsters.find((m) => m.id === owner.monster_id);
+  return monster?.stat_block?.lair_actions ?? [];
+});
+
+/** Legendary creatures in the fight, other than the currently active combatant. */
+const activeLegendaryOthers = computed(() => {
+  const activeId = store.activeCombatant?.instance_id;
+  return store.combatants.filter((c) =>
+    c.monster_id
+      && typeof c.legendary_actions_remaining === "number"
+      && (c.legendary_actions_remaining ?? 0) > 0
+      && c.hp > 0
+      && c.instance_id !== activeId,
+  );
+});
+
+function getLegendaryActions(monsterId: string | undefined) {
+  if (!monsterId) return [];
+  const monster = store.availableMonsters.find((m) => m.id === monsterId);
+  return monster?.stat_block?.legendary_actions ?? [];
+}
+
+/**
+ * Parse "(Costs 2 Actions)" from an action name and return the cost.
+ * 5e monster stat blocks encode cost in the action name, per MM.
+ */
+function actionCost(name: string): number {
+  const match = name.match(/costs (\d+) actions?/i);
+  return match ? parseInt(match[1], 10) : 1;
+}
+
+async function postToChat(message: string, senderName: string) {
+  if (!campaign.activeCampaignId || !auth.user?.id) return;
+  try {
+    await supabase.from("campaign_messages").insert({
+      campaign_id: campaign.activeCampaignId,
+      user_id: auth.user.id,
+      recipient_user_id: null,
+      sender_name: senderName,
+      message,
+      type: "system",
+      metadata: null,
+    });
+  } catch {
+    // Chat posting is best-effort from the runner.
+  }
+}
+
+async function fireLairAction(action: { name: string; description: string }) {
+  const owner = store.combatants.find((c) => c.instance_id === store.lairOwnerInstanceId);
+  if (!owner) return;
+  store.markLairFired();
+  await postToChat(`uses Lair Action: ${action.name}`, `⚔ ${owner.name} (lair)`);
+}
+
+async function fireLegendaryAction(instanceId: string, name: string, action: { name: string; description: string }) {
+  const cost = actionCost(action.name);
+  const spent = store.spendLegendaryActions(instanceId, cost);
+  if (spent === 0) return;
+  await postToChat(`uses legendary action: ${action.name}`, `⚔ ${name}`);
+}
+</script>

--- a/src/components/encounters/RunnerCombatantList.vue
+++ b/src/components/encounters/RunnerCombatantList.vue
@@ -84,6 +84,7 @@
       <span class="type-badge" :class="combatant.type">{{ combatant.type === 'player' ? 'PC' : combatant.npc_id ? 'NPC' : 'Monster' }}</span>
       <span v-if="combatant.wildshape" class="wildshape-row-badge" title="Wildshaping">🐺 {{ combatant.wildshape.beast_name }}</span>
       <span v-if="combatant.hp === 0 && combatant.type === 'monster'" class="dead-badge">☠</span>
+      <span v-if="combatant.surprised" class="surprised-badge" title="Surprised — cannot act on first turn">✦ Surprised</span>
     </div>
 
     <!-- HP -->
@@ -670,6 +671,10 @@ function quickTemp(instanceId: string) {
 
 .wildshape-row-badge {
   @apply font-fell text-[10px] text-amber-400 italic ml-1;
+}
+
+.surprised-badge {
+  @apply font-cinzel text-[9px] text-amber-500 tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 border border-amber-500/30 ml-1;
 }
 
 .hp-cell {

--- a/src/stores/encounterRun.ts
+++ b/src/stores/encounterRun.ts
@@ -20,6 +20,13 @@ export const useEncounterRunStore = defineStore("encounterRun", () => {
   const availableNpcs = ref<Npc[]>([]);
   const pendingBroadcasts = ref<string[]>([]);
 
+  // Boss-fight mechanics state
+  const lairEnabled = ref(false);
+  /** instance_id of the combatant whose stat_block.lair_actions should fire at init 20. */
+  const lairOwnerInstanceId = ref<string | null>(null);
+  /** Rounds in which a lair action has already been used. Keyed by round number. */
+  const lairFiredRounds = ref<Set<number>>(new Set());
+
   // Sorted by initiative desc, dex_mod desc (tiebreaker: players first)
   const sortedCombatants = computed(() =>
     [...combatants.value].sort((a, b) => {
@@ -63,8 +70,13 @@ export const useEncounterRunStore = defineStore("encounterRun", () => {
     const aliveSorted = sorted.filter((c) => c.hp > 0 || c.type === "player");
     if (!aliveSorted.length) return;
 
+    // Clear surprise on the combatant whose turn is ending — surprised creatures
+    // can't act on their first turn, but the flag lifts at its end per 5e RAW.
+    const endingCombatant = sorted[activeIndex.value];
+    if (endingCombatant?.surprised) endingCombatant.surprised = false;
+
     // Find current active in sorted list
-    const currentId = sorted[activeIndex.value]?.instance_id;
+    const currentId = endingCombatant?.instance_id;
     const currentPosInAlive = aliveSorted.findIndex((c) => c.instance_id === currentId);
     const nextInAlive = (currentPosInAlive + 1) % aliveSorted.length;
     const nextId = aliveSorted[nextInAlive].instance_id;
@@ -72,6 +84,12 @@ export const useEncounterRunStore = defineStore("encounterRun", () => {
 
     if (nextInAlive === 0) round.value++;
     activeIndex.value = nextIndexInSorted;
+
+    // Refresh legendary action pool at the start of that creature's turn.
+    const nextCombatant = sorted[nextIndexInSorted];
+    if (nextCombatant && typeof nextCombatant.legendary_action_cap === "number") {
+      nextCombatant.legendary_actions_remaining = nextCombatant.legendary_action_cap;
+    }
     checkEvents();
   }
 
@@ -342,6 +360,58 @@ export const useEncounterRunStore = defineStore("encounterRun", () => {
     availableMonsters.value = [];
     availableNpcs.value = [];
     pendingBroadcasts.value = [];
+    lairEnabled.value = false;
+    lairOwnerInstanceId.value = null;
+    lairFiredRounds.value = new Set();
+  }
+
+  // ── Boss mechanics ───────────────────────────────────────────────────────────
+
+  function setBossMechanics(opts: { lairEnabled: boolean; lairOwnerInstanceId: string | null }) {
+    lairEnabled.value = opts.lairEnabled;
+    lairOwnerInstanceId.value = opts.lairOwnerInstanceId;
+  }
+
+  function toggleSurprised(instanceId: string) {
+    const c = combatants.value.find((x) => x.instance_id === instanceId);
+    if (!c) return;
+    c.surprised = !c.surprised;
+  }
+
+  /** Seed legendary-action state on every combatant whose monster has a
+   *  non-empty `legendary_actions` array. Called once at combat start after
+   *  monsters are loaded so the runner knows who gets a pool. */
+  function primeLegendaryActions(caps: Record<string, number>) {
+    // caps: instance_id → cap (typically 3). Missing entries get no pool.
+    for (const c of combatants.value) {
+      const cap = caps[c.instance_id];
+      if (cap && cap > 0) {
+        c.legendary_action_cap = cap;
+        c.legendary_actions_remaining = cap;
+      }
+    }
+  }
+
+  /** Spend N legendary actions from `instanceId` — clamped at zero. Returns
+   *  the actual amount spent (0 if there weren't enough). */
+  function spendLegendaryActions(instanceId: string, cost: number): number {
+    const c = combatants.value.find((x) => x.instance_id === instanceId);
+    if (!c || typeof c.legendary_actions_remaining !== "number") return 0;
+    const available = c.legendary_actions_remaining;
+    const spent = Math.min(available, cost);
+    c.legendary_actions_remaining = available - spent;
+    return spent;
+  }
+
+  const lairCanFireThisRound = computed(() =>
+    lairEnabled.value
+      && lairOwnerInstanceId.value !== null
+      && !lairFiredRounds.value.has(round.value)
+      && (combatants.value.find((c) => c.instance_id === lairOwnerInstanceId.value)?.hp ?? 0) > 0,
+  );
+
+  function markLairFired() {
+    lairFiredRounds.value = new Set([...lairFiredRounds.value, round.value]);
   }
 
   function hydrateFromLive(state: {
@@ -381,6 +451,10 @@ export const useEncounterRunStore = defineStore("encounterRun", () => {
     availableMonsters,
     availableNpcs,
     pendingBroadcasts,
+    // Boss mechanics state
+    lairEnabled,
+    lairOwnerInstanceId,
+    lairCanFireThisRound,
     sortedCombatants,
     activeCombatant,
     rollInitiative,
@@ -407,5 +481,11 @@ export const useEncounterRunStore = defineStore("encounterRun", () => {
     clearPendingBroadcast,
     reset,
     hydrateFromLive,
+    // Boss mechanics helpers
+    setBossMechanics,
+    toggleSurprised,
+    primeLegendaryActions,
+    spendLegendaryActions,
+    markLairFired,
   };
 });

--- a/src/types/encounter.types.ts
+++ b/src/types/encounter.types.ts
@@ -53,6 +53,10 @@ export interface Encounter {
   location_id: string | null;
   is_finished: boolean;
   events?: EncounterEvent[];
+  // Boss-fight mechanics
+  lair_enabled: boolean;
+  /** References a CombatantDef.id in `combatants[]`. Null = no owner chosen yet. */
+  lair_owner_def_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -139,6 +143,14 @@ export interface RunCombatant {
     startedRound: number | null;
     appliedEffectIds: string[];
   } | null;
+  // Surprise — true on round 1 if the DM flagged this combatant as surprised
+  // at combat start. Cleared automatically when they finish their first turn.
+  surprised?: boolean;
+  // Legendary actions — populated for combatants whose monster stat block has
+  // a `legendary_actions` array. Max pool resets at the start of this
+  // combatant's turn; other combatants' turns can spend actions from here.
+  legendary_action_cap?: number;
+  legendary_actions_remaining?: number;
 }
 
 // ── XP / CR tables (D&D 5e) ──────────────────────────────────────────────────

--- a/src/views/encounters/EncounterRunView.vue
+++ b/src/views/encounters/EncounterRunView.vue
@@ -71,6 +71,16 @@ watch(
       });
       store.availableMonsters = mons;
       store.availableNpcs = npcList as Npc[];
+      // Re-prime boss mechanics from the encounter definition on rehydrate.
+      // Legendary pools live on the combatant rows already (persisted in
+      // combatants_live) so we don't re-prime them here.
+      const lairOwnerInstanceId = enc.lair_enabled && enc.lair_owner_def_id
+        ? live.combatants_live.find((c) => c.def_id === enc.lair_owner_def_id)?.instance_id ?? null
+        : null;
+      store.setBossMechanics({
+        lairEnabled: enc.lair_enabled,
+        lairOwnerInstanceId,
+      });
       return;
     }
 
@@ -220,5 +230,31 @@ function initStore(enc: Encounter, mons: Monster[], par: PartyMember[], npcList:
   store.events = enc.events ?? [];
   store.eventsFired = [];
   store.traps = traps;
+
+  // Boss mechanics: prime legendary action caps on any monster whose stat
+  // block declares legendary_actions. Default cap is 3 per 5e RAW. If a
+  // stat block declares `legendary_action_uses` in future, we'd read that
+  // — for now the hard default keeps things simple.
+  const legendaryCaps: Record<string, number> = {};
+  for (const c of combatants) {
+    if (!c.monster_id) continue;
+    const monster = mons.find((m) => m.id === c.monster_id);
+    if (monster?.stat_block?.legendary_actions?.length) {
+      legendaryCaps[c.instance_id] = 3;
+    }
+  }
+  if (Object.keys(legendaryCaps).length > 0) {
+    store.primeLegendaryActions(legendaryCaps);
+  }
+
+  // Wire lair actions. The encounter references a CombatantDef.id; look up
+  // the first live instance with that def_id to get the runtime instance_id.
+  const lairOwnerInstanceId = enc.lair_enabled && enc.lair_owner_def_id
+    ? combatants.find((c) => c.def_id === enc.lair_owner_def_id)?.instance_id ?? null
+    : null;
+  store.setBossMechanics({
+    lairEnabled: enc.lair_enabled,
+    lairOwnerInstanceId,
+  });
 }
 </script>

--- a/supabase/migrations/20260417000011_encounters_boss_mechanics.sql
+++ b/supabase/migrations/20260417000011_encounters_boss_mechanics.sql
@@ -1,0 +1,16 @@
+-- Migration: encounters_boss_mechanics
+-- Adds DM-authored boss-fight settings to encounters. Lair actions fire at
+-- initiative 20 each round when enabled, sourced from the lair owner's
+-- monster stat_block.lair_actions array.
+--
+-- `lair_owner_def_id` references one of this encounter's combatant defs
+-- (the `id` field inside encounters.combatants[]). We store it as plain
+-- text rather than a FK — combatant defs live inside a jsonb array, not
+-- in their own table.
+
+alter table encounters
+  add column if not exists lair_enabled       boolean not null default false,
+  add column if not exists lair_owner_def_id  text;
+
+comment on column encounters.lair_owner_def_id is
+  'References encounters.combatants[*].id — which combatant in this encounter owns the lair. Null means the DM has enabled lair actions but not yet picked an owner; the runner hides the lair card until set.';


### PR DESCRIPTION
Adds the three flagship boss-fight mechanics from #184 §4 to the encounter runner. **Independent of the multiclass / creation stacks** — branched off main.

## Summary

### Schema

One migration — `encounters.lair_enabled boolean` + `encounters.lair_owner_def_id text` (references a `CombatantDef.id` in the encounter's own `combatants` jsonb array, so it survives renames of the underlying monster def).

### Encounter builder

New **Boss Mechanics** card in `EncounterDetail`:
- `Lair Actions` toggle.
- Owner dropdown populated from the encounter's combatants. Entries are marked with ★ when their monster stat block already has `lair_actions`.

### Runner

New `RunnerBossMechanics.vue` renders three pieces above the initiative list:

1. **Surprise marker (pre-combat only)** — collapsed chip that expands to a click-to-toggle list over current combatants. Surprised combatants get a badge on their row and automatically lose the flag at the end of their first turn (5e RAW).
2. **Lair Actions card at initiative 20** — appears when `lair_enabled && lair_owner alive`. Lists the owner's `stat_block.lair_actions` as clickable buttons; firing one posts a system message to chat and disables the card until round rollover.
3. **Legendary Actions menu** — one card per legendary creature other than the active combatant. Reads the creature's `stat_block.legendary_actions`, parses `"(Costs N Actions)"` from action names, disables options the pool can't afford. Pool resets when that creature's own turn starts. Default cap is 3 per PHB.

### Store changes

`useEncounterRunStore` gains:
- `lairEnabled`, `lairOwnerInstanceId`, `lairCanFireThisRound` (computed)
- `setBossMechanics`, `toggleSurprised`, `primeLegendaryActions`, `spendLegendaryActions`, `markLairFired`
- `nextTurn` now clears `surprised` at end of the ending combatant's turn, and refreshes `legendary_actions_remaining` at the start of the incoming combatant's turn.

`EncounterRunView` seeds the legendary cap on any monster whose `stat_block.legendary_actions` is non-empty (default 3) and wires the lair owner's `instance_id` from the encounter's def_id.

## Known punts (follow-ups)

- `lair_fired_rounds` isn't persisted to `encounter_state` — DMs who reload mid-fight can re-trigger the lair for that round.
- Reactions tracker, environmental hazards, and in-combat loadout swap remain for a later combat-fidelity PR.
- Legendary action "Costs N" parsing relies on the action name containing the parenthetical. Open5e stat blocks follow this convention; homebrew entries may need a normalizer later.

## Test plan

Requires the new migration (`supabase db push`).

- [ ] Open an encounter, enable Lair Actions, pick an owner whose stat block has lair actions. Save.
- [ ] Run the encounter. Start combat.
- [ ] Pre-combat: click "Mark surprised", select a goblin. Row gets a Surprised badge. Advance turns until the goblin acts — after its first `Next Turn`, the badge disappears.
- [ ] Round 1: Lair Actions card is violet + active. Click one. Chat shows "⚔ X (lair) uses Lair Action: …". Card dims until next round.
- [ ] Round 2: card re-enables.
- [ ] On a non-dragon's turn, the Dragon's legendary-action card shows with `3/3 remaining`. Click "Wing Attack (Costs 2 Actions)" → pool drops to `1/3`. Click a 1-cost action → `0/3`. Remaining buttons disable.
- [ ] On the Dragon's own turn, the legendary menu disappears and the pool resets to `3/3` on its next turn.
- [ ] Build + typecheck pass (`npm run build`).

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW