### PR TITLE
feat(character): identity extras, background equipment seed, XP indicator

### DIFF
--- a/src/components/play/CharacterCreateWizard.vue
+++ b/src/components/play/CharacterCreateWizard.vue
@@ -96,6 +96,33 @@
           </label>
         </div>
       </div>
+
+      <!-- Identity extras (collapsible) -->
+      <details class="rounded-lg border border-border bg-card overflow-hidden">
+        <summary class="cursor-pointer px-3 py-2 font-cinzel text-xs font-semibold tracking-wider text-muted-foreground hover:text-foreground transition-colors select-none">
+          Details — age, gender, pronouns, description
+        </summary>
+        <div class="p-3 space-y-2">
+          <div class="grid grid-cols-3 gap-2">
+            <label class="block">
+              <span class="field-label">Age</span>
+              <input v-model="f.age" class="field-input w-full" placeholder="47, ancient…" />
+            </label>
+            <label class="block">
+              <span class="field-label">Gender</span>
+              <input v-model="f.gender" class="field-input w-full" placeholder="" />
+            </label>
+            <label class="block">
+              <span class="field-label">Pronouns</span>
+              <input v-model="f.pronouns" class="field-input w-full" placeholder="she/her" />
+            </label>
+          </div>
+          <label class="block">
+            <span class="field-label">Physical Description</span>
+            <textarea v-model="f.physical_description" class="field-input w-full resize-y" rows="2" placeholder="Hair, build, scars, anything that helps the table picture them." />
+          </label>
+        </div>
+      </details>
     </div>
 
     <!-- Step 1: Species -->
@@ -208,6 +235,18 @@
           <p v-if="bg.feature_name" class="font-fell text-xs text-muted-foreground mt-1.5 italic">{{ bg.feature_name }}</p>
           <p v-if="bg.source_title" class="font-cinzel text-[9px] text-muted-foreground/50 mt-1">{{ bg.source_title }}</p>
         </button>
+      </div>
+
+      <!-- Selected background's equipment + import opt-in -->
+      <div v-if="selectedBackground?.equipment" class="rounded-lg border border-primary/30 bg-primary/5 p-3 space-y-2">
+        <p class="font-cinzel text-xs font-semibold text-primary tracking-wider">STARTING EQUIPMENT</p>
+        <p class="font-fell text-sm text-foreground whitespace-pre-wrap">{{ selectedBackground.equipment }}</p>
+        <label class="flex items-start gap-2 cursor-pointer pt-1">
+          <input type="checkbox" v-model="importBackgroundEquipment" class="mt-0.5 h-4 w-4 rounded border-border bg-muted" />
+          <span class="font-fell text-xs text-muted-foreground">
+            Add these to my inventory automatically. Each comma-separated entry becomes a freeform inventory row you can refine in <em>/play/inventory</em>.
+          </span>
+        </label>
       </div>
 
       <p v-if="f.background_id" class="font-cinzel text-xs text-primary/70 tracking-wider text-center">
@@ -499,7 +538,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, ref, reactive } from "vue";
+import { inject, ref, reactive, computed } from "vue";
 import { CHARACTER_FORM_KEY, WIZARD_STEPS, ABILITY_STATS, SAVE_STATS, PROF_LEVELS, SCORE_MODES, SLOT_LEVEL_LABELS, POINT_BUY_COSTS, STANDARD_ARRAY, roll4d6DropLowest } from "@/composables/useCharacterCreationForm";
 import { SKILLS } from "@/types/party.types";
 import { TOOL_PROFICIENCY_GROUPS, LANGUAGE_GROUPS } from "@/lib/proficiency-lists";
@@ -521,6 +560,7 @@ const {
   mod, setSkillProf, skillBonus, toggleSave, saveBonus,
   resetSlotsToDefault, onSpeciesSelect, onClassSelect, onBackgroundSelect,
   save,
+  importBackgroundEquipment,
 } = form;
 
 // ── Identity extras ──────────────────────────────────────────────────────────
@@ -532,6 +572,10 @@ const ALIGNMENT_OPTIONS = [
   "Lawful Evil",    "Neutral Evil",    "Chaotic Evil",
   "Unaligned",
 ] as const;
+
+const selectedBackground = computed(() =>
+  (allBackgrounds.value ?? []).find((b: { id: string }) => b.id === f.background_id) ?? null,
+);
 
 // ── Ability score assignment: standard array + 4d6 ───────────────────────────
 type AbilityKey = "str" | "dex" | "con" | "int" | "wis" | "cha";

--- a/src/components/player/PlayerCharacterHeader.vue
+++ b/src/components/player/PlayerCharacterHeader.vue
@@ -34,6 +34,23 @@
               {{ [speciesName, member.subrace, classLabel].filter(Boolean).join(" · ") }}
               <span v-if="memberTotalLevel" class="font-cinzel text-[10px] text-primary not-italic ml-1">Lv {{ memberTotalLevel }}</span>
             </p>
+            <!-- XP progress (only when the campaign actually tracks XP) -->
+            <div v-if="(member.experience_points ?? 0) > 0 || readyToLevelUp" class="mt-1 flex items-center gap-1.5">
+              <span class="font-cinzel text-[9px] text-muted-foreground tracking-wider">XP</span>
+              <div class="flex-1 max-w-32 h-1 rounded-full bg-muted overflow-hidden">
+                <div class="h-full transition-all"
+                  :class="readyToLevelUp ? 'bg-primary' : 'bg-primary/50'"
+                  :style="{ width: `${xpPct}%` }" />
+              </div>
+              <span class="font-cinzel text-[9px] text-muted-foreground">
+                {{ member.experience_points ?? 0 }}<template v-if="xpToNext !== null"> / {{ xpToNext }}</template>
+              </span>
+              <RouterLink
+                v-if="readyToLevelUp && !hidePlayerActions"
+                :to="`/play/character/levelup?memberId=${member.id}`"
+                class="font-cinzel text-[9px] text-primary tracking-wider hover:opacity-80 ml-0.5"
+              >Ready ↑</RouterLink>
+            </div>
           </div>
           <div v-if="!hidePlayerActions" class="shrink-0 flex items-center gap-1 pt-0.5">
             <RouterLink
@@ -163,6 +180,7 @@ import {
   hasCheckDisadvantage,
 } from "@/lib/conditions";
 import type { PartyMember } from "@/types/party.types";
+import { xpForNextLevel, xpForLevel, levelForXp } from "@/types/party.types";
 import { abilityModifier } from "@/lib/utils";
 import { useAllSpecies } from "@/composables/useSpecies";
 import FocalImage from "@/components/common/FocalImage.vue";
@@ -265,6 +283,21 @@ const combatStats = computed(() => [
 const hpPct = computed(() => {
   if (props.member.max_hp === 0) return 0;
   return Math.max(0, Math.min(100, (props.member.current_hp / props.member.max_hp) * 100));
+});
+
+// XP progress — only meaningful when the campaign actually awards XP.
+const xpToNext = computed(() => xpForNextLevel(props.member.level));
+const xpPct = computed(() => {
+  const xp = props.member.experience_points ?? 0;
+  const floor = xpForLevel(props.member.level);
+  const next = xpToNext.value;
+  if (next === null) return 100; // Lv 20
+  if (next <= floor) return 0;
+  return Math.max(0, Math.min(100, ((xp - floor) / (next - floor)) * 100));
+});
+const readyToLevelUp = computed(() => {
+  const xp = props.member.experience_points ?? 0;
+  return levelForXp(xp) > props.member.level;
 });
 const hpColor = computed(() => {
   const p = hpPct.value;

--- a/src/components/player/PlayerSkillsTab.vue
+++ b/src/components/player/PlayerSkillsTab.vue
@@ -93,6 +93,23 @@
       </div>
     </div>
 
+    <!-- Identity (age / gender / pronouns / description) -->
+    <div v-if="hasIdentityExtras" class="rounded-lg border border-border bg-card p-4 space-y-2">
+      <p class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">Identity</p>
+      <div class="flex flex-wrap gap-1.5">
+        <span v-if="member.age" class="px-2 py-0.5 rounded bg-muted border border-border font-cinzel text-[10px] text-foreground tracking-wider">
+          Age {{ member.age }}
+        </span>
+        <span v-if="member.gender" class="px-2 py-0.5 rounded bg-muted border border-border font-cinzel text-[10px] text-foreground tracking-wider">
+          {{ member.gender }}
+        </span>
+        <span v-if="member.pronouns" class="px-2 py-0.5 rounded bg-muted border border-border font-cinzel text-[10px] text-foreground tracking-wider">
+          {{ member.pronouns }}
+        </span>
+      </div>
+      <p v-if="member.physical_description" class="font-fell text-sm text-foreground whitespace-pre-wrap">{{ member.physical_description }}</p>
+    </div>
+
     <!-- Notes -->
     <div v-if="member.notes" class="rounded-lg border border-border bg-card p-4">
       <p class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider mb-2">Notes</p>
@@ -154,6 +171,9 @@ const hasPersonality = computed(() =>
     || props.member.ideals
     || props.member.bonds
     || props.member.flaws),
+);
+const hasIdentityExtras = computed(() =>
+  !!(props.member.age || props.member.gender || props.member.pronouns || props.member.physical_description),
 );
 const passiveInsight      = computed(() => passiveScore("insight"));
 const passiveInvestigation = computed(() => passiveScore("investigation"));

--- a/src/composables/useCharacterCreationForm.ts
+++ b/src/composables/useCharacterCreationForm.ts
@@ -3,6 +3,7 @@ import { useRouter, useRoute } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
 import { useParty, useCreatePartyMember, useUpdatePartyMember } from "@/composables/useParty";
 import { useAddCharacterClass } from "@/composables/useCharacterClasses";
+import { useAddInventoryItem } from "@/composables/usePartyInventory";
 import { useCampaignMembers, useUpdateCampaignMember } from "@/composables/useCampaignMembers";
 import { SKILLS } from "@/types/party.types";
 import { useAllSystemClasses, useAllCustomClasses } from "@/composables/useCustomClasses";
@@ -122,6 +123,7 @@ export function useCharacterCreationForm() {
   const { mutateAsync: create }               = useCreatePartyMember();
   const { mutateAsync: update }               = useUpdatePartyMember();
   const { mutateAsync: addCharacterClass }    = useAddCharacterClass();
+  const { mutateAsync: addInventoryItem }     = useAddInventoryItem();
   const { mutateAsync: updateCampaignMember } = useUpdateCampaignMember();
 
   const editMemberId = computed(() =>
@@ -200,7 +202,16 @@ export function useCharacterCreationForm() {
     flaws:              m?.flaws ?? "",
     deity:              m?.deity ?? "",
     experience_points:  m?.experience_points ?? 0,
+    age:                  m?.age ?? "",
+    gender:               m?.gender ?? "",
+    pronouns:             m?.pronouns ?? "",
+    physical_description: m?.physical_description ?? "",
   });
+
+  // Whether to import the chosen background's equipment text into inventory
+  // on creation. Defaults to true so new characters don't end up empty-handed;
+  // the player can untick it on the Background step.
+  const importBackgroundEquipment = ref(true);
 
   // ── Point buy ────────────────────────────────────────────────────────────────
 
@@ -352,6 +363,10 @@ export function useCharacterCreationForm() {
       bonds:                f.bonds || null,
       flaws:                f.flaws || null,
       deity:                f.deity || null,
+      age:                  f.age || null,
+      gender:               f.gender || null,
+      pronouns:             f.pronouns || null,
+      physical_description: f.physical_description || null,
       portrait_url:         portraitUrl.value || null,
       portrait_focal_point: focalPoint.value,
       card_art_url:         cardArtUrl.value || null,
@@ -388,6 +403,36 @@ export function useCharacterCreationForm() {
           sort_order:      0,
         });
       }
+
+      // Seed inventory from the chosen background's free-text equipment.
+      // Each comma- (or "and"-) separated entry becomes a freeform inventory
+      // row carried by the new character. Quantities embedded in entries
+      // (e.g. "10 gp", "two daggers") are kept verbatim — refining is the
+      // player's job in /play/inventory.
+      if (importBackgroundEquipment.value && f.background_id) {
+        const bg = (allBackgrounds.value ?? []).find((b) => b.id === f.background_id);
+        const entries = parseEquipmentList(bg?.equipment ?? "");
+        for (const entry of entries) {
+          await addInventoryItem({
+            item_id: null,
+            name: entry,
+            quantity: 1,
+            carried_by: created.id,
+            location: "backpack",
+            slot: null,
+            is_container: false,
+            container_id: null,
+            is_attuned: false,
+            is_equipped: false,
+            notes: null,
+            current_charges: null,
+            is_identified: true,
+            is_ruined: false,
+            sort_order: 0,
+          });
+        }
+      }
+
       await auth.refreshMembership();
       saving.value = false;
       if (f.level > 1) {
@@ -398,6 +443,20 @@ export function useCharacterCreationForm() {
     }
   }
 
+  /**
+   * Split a free-text equipment list into individual entries. Open5e ships
+   * background equipment as prose: "a holy symbol, a prayer book, vestments,
+   * a set of common clothes, and a belt pouch containing 15 gp".
+   * We split on commas + " and " (case-insensitive), trim, and drop empties.
+   */
+  function parseEquipmentList(prose: string): string[] {
+    if (!prose.trim()) return [];
+    return prose
+      .split(/,| and /i)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+
   return {
     // router
     router,
@@ -406,6 +465,7 @@ export function useCharacterCreationForm() {
     // form state
     f, activeTab, wizardStep, saving, scoreMode,
     portraitUrl, focalPoint, cardArtUrl, spellSlotMaxes,
+    importBackgroundEquipment,
     // computed
     isEditMode, existingMember, backRoute,
     allSpecies, allBackgrounds,

--- a/src/types/party.types.ts
+++ b/src/types/party.types.ts
@@ -99,7 +99,12 @@ export interface PartyMember {
   bonds?: string | null;
   flaws?: string | null;
   deity?: string | null;
-  // Experience points (ignored when the campaign uses milestone levelling).
+  // Identity extras (optional — wizard collects these on the Identity step)
+  age?: string | null;
+  gender?: string | null;
+  pronouns?: string | null;
+  physical_description?: string | null;
+  // Experience points (optional — campaigns using milestone levelling leave it 0)
   experience_points?: number;
   // Currency
   cp: number;
@@ -135,3 +140,52 @@ export type PartyMemberUpdate = Partial<PartyMemberInsert>;
 // Conditions + helpers now live in `@/lib/conditions`. Re-exported here so
 // existing imports from `@/types/party.types` keep working.
 export { CONDITIONS, ATTACK_DIS_CONDITIONS, CHECK_DIS_CONDITIONS } from "@/lib/conditions";
+
+// ── XP-per-level table (D&D 5e PHB) ──────────────────────────────────────────
+// Total XP required to reach each level. Index 0 → Lv 1, index 19 → Lv 20.
+// At level N, you need LEVEL_XP_THRESHOLDS[N-1] total XP; the next level
+// unlocks at LEVEL_XP_THRESHOLDS[N].
+export const LEVEL_XP_THRESHOLDS: number[] = [
+  0,        // 1
+  300,      // 2
+  900,      // 3
+  2_700,    // 4
+  6_500,    // 5
+  14_000,   // 6
+  23_000,   // 7
+  34_000,   // 8
+  48_000,   // 9
+  64_000,   // 10
+  85_000,   // 11
+  100_000,  // 12
+  120_000,  // 13
+  140_000,  // 14
+  165_000,  // 15
+  195_000,  // 16
+  225_000,  // 17
+  265_000,  // 18
+  305_000,  // 19
+  355_000,  // 20
+];
+
+/** Highest level whose XP requirement <= the given total. */
+export function levelForXp(xp: number): number {
+  let lvl = 1;
+  for (let i = 0; i < LEVEL_XP_THRESHOLDS.length; i++) {
+    if (xp >= LEVEL_XP_THRESHOLDS[i]) lvl = i + 1;
+    else break;
+  }
+  return lvl;
+}
+
+/** XP required to reach the next level after the given total level. Null at 20. */
+export function xpForNextLevel(currentLevel: number): number | null {
+  if (currentLevel >= 20) return null;
+  return LEVEL_XP_THRESHOLDS[currentLevel] ?? null;
+}
+
+/** Total XP required to reach `level` (the floor of that level's bracket). */
+export function xpForLevel(level: number): number {
+  const idx = Math.max(1, Math.min(20, level)) - 1;
+  return LEVEL_XP_THRESHOLDS[idx];
+}

--- a/supabase/migrations/20260417000020_party_member_identity_extras.sql
+++ b/supabase/migrations/20260417000020_party_member_identity_extras.sql
@@ -1,0 +1,21 @@
+-- Migration: party_member_identity_extras
+-- Adds the small character-creation fields that round out Identity: age,
+-- gender (free-form to accommodate non-binary / unique entries), pronouns
+-- (e.g. "she/her", "they/them"), and a physical description.
+--
+-- All four are optional — the player can leave them blank and the sheet
+-- hides them. They're additive to the alignment/personality block from
+-- the previous identity migration.
+
+alter table party_members
+  add column if not exists age                  text,
+  add column if not exists gender               text,
+  add column if not exists pronouns             text,
+  add column if not exists physical_description text,
+  -- experience_points also lands in PR #192 (alignment + personality bundle).
+  -- Both add it via `if not exists` so whichever migration runs first wins
+  -- and the second is a no-op.
+  add column if not exists experience_points    int not null default 0;
+
+comment on column party_members.age is
+  'Free-form age — could be a number ("47") or descriptive ("ancient", "young adult"). Stored as text so non-numeric ages aren''t lossy.';


### PR DESCRIPTION
Closes the remaining character lifecycle items from #184 — identity extras, background-driven starting equipment, and an XP progression indicator. **Independent of the multiclass and combat-fidelity stacks** — branched off main, so it can land in any order.

## Summary

### Schema (one migration)

- `age`, `gender`, `pronouns`, `physical_description` on `party_members` — all optional text. `age` is stored as text so descriptive entries ("ancient", "young adult") aren't lossy.
- `experience_points int default 0` — also lands in **#192** with `if not exists`, so whichever PR merges first wins and the other is a no-op.

### 5e XP table

`LEVEL_XP_THRESHOLDS` constant + helpers (`xpForLevel`, `xpForNextLevel`, `levelForXp`) in `@/types/party.types` so any sheet / wizard surface can compute progression without re-deriving the table.

### Creation wizard

- **Identity step** — new collapsible Details block (age / gender / pronouns / physical description). Collapsed by default so the wizard's visual weight doesn't change for players who skip these.
- **Background step** — when a background is selected, its `equipment` text renders below the picker with an "Add to inventory automatically" checkbox (default on). On confirm, the prose is split on commas and `" and "` and each entry becomes a freeform `party_inventory` row carried by the new character. Players can refine in `/play/inventory` (e.g. link to vault items, adjust quantities).

### Player sheet

- **Header** — thin XP progress bar + **Ready ↑** link to the level-up wizard when the player crosses an XP threshold. Hidden when the character has 0 XP so milestone-levelling campaigns stay visually quiet.
- **Skills tab** — small Identity card showing whichever of age / gender / pronouns / description are set. Hidden when none are.

## Test plan

Requires the new migration (`supabase db push`).

- [ ] Create a new character. Identity step's Details block expands; all four fields persist.
- [ ] On the Background step, pick Acolyte (Open5e). Equipment text renders ("a holy symbol, a prayer book, 5 gp, a set of common clothes…"). Submit the wizard.
- [ ] Open `/play/inventory`. Each comma-separated entry is a freeform inventory row on the new character.
- [ ] Uncheck the import box, create another character. No inventory rows are seeded.
- [ ] Edit the character and set `experience_points` to 350 (via the party tracker editor). Sheet header now shows the XP bar progressing toward 900. No "Ready ↑" link yet.
- [ ] Bump XP to 900. "Ready ↑" link appears; clicking routes to the level-up wizard.
- [ ] Skills tab shows the Identity card only when at least one of the four fields is set.
- [ ] Build + typecheck pass (`npm run build`).

## Known punt

Starting equipment from **classes** is a separate and larger effort (classes declare starting equipment options, not a flat list). Out of scope for this PR.

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW