### PR TITLE
feat(sheet): loadout shortcut on the combat tab

### DIFF
--- a/src/components/player/PlayerCombatTab.vue
+++ b/src/components/player/PlayerCombatTab.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="space-y-3">
+    <!-- Loadout shortcut -->
+    <PlayerLoadout :member-id="member.id" />
+
     <!-- Equipped weapon list -->
     <div v-if="equippedWeapons.length" class="rounded-lg border border-border bg-card overflow-hidden divide-y divide-border">
       <div v-for="{ inv, item } in equippedWeapons" :key="inv.id" class="px-4 py-3">
@@ -98,6 +101,7 @@ import { usePartyInventory } from "@/composables/usePartyInventory";
 import { useItems } from "@/composables/useItems";
 import { useCampaignMessages } from "@/composables/useCampaignMessages";
 import { usePromptedRoll } from "@/composables/usePromptedRoll";
+import PlayerLoadout from "@/components/player/PlayerLoadout.vue";
 import type { PartyMember } from "@/types/party.types";
 import type { PartyInventoryItem } from "@/types/inventory.types";
 import type { Item } from "@/types/item.types";

--- a/src/components/player/PlayerLoadout.vue
+++ b/src/components/player/PlayerLoadout.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="rounded-lg border border-border bg-card px-4 py-3 space-y-2">
+    <div class="flex items-center justify-between">
+      <span class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">LOADOUT</span>
+      <RouterLink
+        to="/play/inventory"
+        class="flex items-center gap-1 font-cinzel text-[10px] text-primary tracking-wider hover:opacity-80 transition-opacity"
+      >
+        <Backpack class="h-3 w-3" />
+        Manage
+      </RouterLink>
+    </div>
+
+    <div v-if="equippedBySlot.length" class="flex flex-wrap gap-1.5">
+      <span
+        v-for="entry in equippedBySlot"
+        :key="entry.inv.id"
+        class="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 pl-2 pr-1 py-0.5 max-w-full"
+        :title="`${entry.inv.name} — ${SLOT_LABELS[entry.slot] ?? entry.slot}`"
+      >
+        <span class="font-cinzel text-[9px] text-muted-foreground tracking-wider shrink-0 uppercase">{{ SLOT_LABELS[entry.slot] ?? entry.slot }}</span>
+        <span class="font-fell text-xs text-foreground truncate">{{ entry.inv.name }}</span>
+        <span
+          v-if="(entry.inv.quantity ?? 1) > 1"
+          class="font-cinzel text-[9px] text-muted-foreground shrink-0"
+        >×{{ entry.inv.quantity }}</span>
+        <button
+          type="button"
+          class="shrink-0 flex items-center justify-center w-4 h-4 rounded text-muted-foreground/60 hover:text-destructive hover:bg-destructive/10 transition-colors"
+          title="Unequip"
+          :disabled="isUnequipping"
+          @click="unequip(entry.inv)"
+        >
+          <X class="h-3 w-3" />
+        </button>
+      </span>
+    </div>
+    <p v-else class="font-fell text-xs text-muted-foreground italic">
+      Nothing equipped. <RouterLink to="/play/inventory" class="text-primary hover:opacity-80">Equip items in inventory →</RouterLink>
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { RouterLink } from "vue-router";
+import { Backpack, X } from "lucide-vue-next";
+import { usePartyInventory, useUpdateInventoryItem } from "@/composables/usePartyInventory";
+import type { PartyInventoryItem, InventorySlot } from "@/types/inventory.types";
+
+const props = defineProps<{ memberId: string }>();
+
+const { data: inventory } = usePartyInventory();
+const { mutateAsync: updateItem, isPending: isUnequipping } = useUpdateInventoryItem();
+
+/**
+ * Short labels for each slot. Kept compact so the chip row doesn't wrap
+ * awkwardly on mobile. "main" / "off" chosen over MH/OH since those can
+ * read as keyboard shortcuts.
+ */
+const SLOT_LABELS: Record<InventorySlot, string> = {
+  head: "HEAD",
+  neck: "NECK",
+  shoulders: "SHL",
+  body: "BODY",
+  clothes: "WORN",
+  hands: "HAND",
+  ring: "RING",
+  waist: "BELT",
+  feet: "FEET",
+  main_hand: "MAIN",
+  off_hand: "OFF",
+  other: "MISC",
+};
+
+/**
+ * Priority order for slot rendering — head-to-toe for armor, then weapons,
+ * then accessories. Unknown slots fall to the end.
+ */
+const SLOT_ORDER: InventorySlot[] = [
+  "head", "neck", "shoulders", "body", "clothes",
+  "hands", "ring", "waist", "feet",
+  "main_hand", "off_hand", "other",
+];
+
+const equippedBySlot = computed(() => {
+  const mine = (inventory.value ?? []).filter(
+    (i) => i.carried_by === props.memberId && i.location === "equipped",
+  );
+  const orderIdx = (slot: InventorySlot | null) =>
+    slot ? SLOT_ORDER.indexOf(slot) : 999;
+  return mine
+    .filter((i) => i.slot !== null)
+    .sort((a, b) => orderIdx(a.slot) - orderIdx(b.slot))
+    .map((inv) => ({ inv, slot: inv.slot as InventorySlot }));
+});
+
+async function unequip(inv: PartyInventoryItem) {
+  // Move back to the backpack. Slot is cleared (required for non-equipped rows).
+  await updateItem({
+    id: inv.id,
+    update: { location: "backpack", slot: null, is_equipped: false },
+  });
+}
+</script>


### PR DESCRIPTION
Closes the "equipped-loadout shortcut on the sheet" item from #184. **Independent of the stack** — branched off main.

## Summary

New **Loadout** card at the top of the Combat tab:

- One chip per equipped item showing the slot label (HEAD, NECK, BODY, MAIN, OFF, etc.), item name, and quantity if > 1.
- Slots render head-to-toe for armor, then weapons, then accessories, then `other`.
- Each chip has a one-click **×** to unequip — routes the item back to `location: "backpack"` with slot cleared.
- **Manage** link (top-right) goes to `/play/inventory` for full paper-doll editing.
- Empty state tells the player the loadout is empty and links out to inventory, so new characters aren't stuck wondering where gear lives.

## Scope

This is a read-mostly shortcut — the full equip/swap UX stays in `/play/inventory` where the paper doll lives. The goal is to keep the Combat tab self-contained for the common case (check what I'm wearing, quick-unequip a cursed item) without duplicating the vault lookup + slot validation logic.

## Test plan

- [ ] Equip a sword, shield, and ring on a character via `/play/inventory`.
- [ ] Open the player sheet → Combat tab. The Loadout card shows three chips: MAIN Sword, OFF Shield, RING …, in that order.
- [ ] Click the × on the ring chip. The ring is now in the backpack; the chip disappears.
- [ ] Unequip everything. The card shows the empty-state prompt.
- [ ] Click **Manage** — lands on `/play/inventory`.
- [ ] Build + typecheck pass (`npm run build`).

https://claude.ai/code/session_01499G1qu3DNfvLH9mf2YkoW