### PR TITLE
feat(scriptorium): classic PHB 2014 theme + CSS-variable palette refactor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -296,6 +296,7 @@
 ### Scriptorium
 
 - [x] **Two-column layout** — Columns2 toolbar button toggles `column-count: 2` on both the editor and the Scriptorium preview; persisted per document in DB (`is_two_column`); H1/H2 span both columns in preview
+- [x] **Per-document theme: OneDnD 2024 ↔ Classic PHB 2014** (irongollem/grimoire#222) — palette refactored to CSS custom properties on `.phb-body` / `.phb-page` (shared contract: `--sc-ink`, `--sc-accent`, `--sc-accent-contrast`, `--sc-page-bg`, `--sc-callout-bg`, `--sc-callout-border`, `--sc-code-bg`, `--sc-col-rule`, `--sc-heading-font`, `--sc-body-font`, plus per-block `--sc-h1-*` / `--sc-title-bar-*` knobs). Defaults render OneDnD 2024 (teal); `.theme-phb2014` override swaps to classic palette (deep red-brown ink `#58180d`, cream parchment `#eeeadf`, olive callouts `#e0e5c1`) and replaces the filled-bar H1 with double-ruled red title on parchment. Segmented "2024 | Classic" toggle in the editor toolbar; persisted as `scriptorium_documents.theme`. Preview and `useScriptoriumPdf` both receive the same theme class on their page elements so export matches WYSIWYG. Every subsequent scriptorium block added for Homebrewery parity (#221 tracking) will consume this variable contract rather than adding new literal palettes.
 
 ### Tokens & VTT Integration
 

--- a/src/components/scriptorium/ScriptoriumEditor.vue
+++ b/src/components/scriptorium/ScriptoriumEditor.vue
@@ -331,6 +331,44 @@
             >
               <Columns2 class="h-3.5 w-3.5" />
             </button>
+
+            <!-- Theme -->
+            <div
+              role="radiogroup"
+              aria-label="Preview theme"
+              class="ml-1 inline-flex rounded border border-border overflow-hidden shrink-0"
+            >
+              <button
+                type="button"
+                role="radio"
+                :aria-checked="theme === 'onednd2024'"
+                title="OneDnD 2024 theme"
+                class="px-2 h-[26px] font-cinzel text-[9px] font-semibold tracking-wider uppercase transition-colors"
+                :class="
+                  theme === 'onednd2024'
+                    ? 'bg-primary/20 text-primary'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                "
+                @click="theme = 'onednd2024'"
+              >
+                2024
+              </button>
+              <button
+                type="button"
+                role="radio"
+                :aria-checked="theme === 'phb2014'"
+                title="Classic PHB (2014) theme"
+                class="px-2 h-[26px] font-cinzel text-[9px] font-semibold tracking-wider uppercase transition-colors border-l border-border"
+                :class="
+                  theme === 'phb2014'
+                    ? 'bg-primary/20 text-primary'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                "
+                @click="theme = 'phb2014'"
+              >
+                Classic
+              </button>
+            </div>
           </template>
         </div>
 
@@ -364,7 +402,7 @@
           <p
             class="font-cinzel text-xs font-semibold text-muted-foreground uppercase tracking-widest"
           >
-            Preview — OneDnD 2024
+            Preview — {{ themeLabel }}
           </p>
           <div class="flex items-center gap-2">
             <span
@@ -394,13 +432,14 @@
             v-for="(pageHtml, pageIndex) in pages"
             :key="pageIndex"
             class="phb-page"
+            :class="themeClass"
           >
             <div v-if="pageIndex === 0" class="phb-title-bar">
               {{ title || "Untitled Document" }}
             </div>
             <div
               class="phb-body"
-              :class="{ 'phb-two-col': isTwoColumn }"
+              :class="[themeClass, { 'phb-two-col': isTwoColumn }]"
               v-html="pageHtml"
             />
           </div>
@@ -455,6 +494,7 @@ import { useScriptoriumPdf } from "@/composables/useScriptoriumPdf";
 import type {
   ScriptoriumDocument,
   ScriptoriumDocType,
+  ScriptoriumTheme,
 } from "@/types/scriptorium.types";
 import PdfPreviewDialog from "@/components/scriptorium/PdfPreviewDialog.vue";
 import AssetInsertPanel from "@/components/scriptorium/AssetInsertPanel.vue";
@@ -534,7 +574,15 @@ const title = ref(props.doc?.title ?? "");
 const docType = ref<ScriptoriumDocType>(props.doc?.doc_type ?? "custom");
 const isPublished = ref(props.doc?.is_published ?? false);
 const isTwoColumn = ref(props.doc?.is_two_column ?? false);
+const theme = ref<ScriptoriumTheme>(props.doc?.theme ?? "onednd2024");
 const tags = ref<string[]>(props.doc?.tags ?? []);
+
+const themeClass = computed(() =>
+  theme.value === "phb2014" ? "theme-phb2014" : "theme-onednd2024",
+);
+const themeLabel = computed(() =>
+  theme.value === "phb2014" ? "Classic PHB (2014)" : "OneDnD 2024",
+);
 
 // Editor
 const previewHtml = ref("");
@@ -636,6 +684,7 @@ async function save() {
       tags: tags.value,
       is_published: isPublished.value,
       is_two_column: isTwoColumn.value,
+      theme: theme.value,
       word_count: wordCount.value,
     };
     if (props.doc) {
@@ -668,7 +717,7 @@ const {
   exportPdf,
   savePdf,
   closePdfPreview,
-} = useScriptoriumPdf(pages, title);
+} = useScriptoriumPdf(pages, title, theme);
 
 onUnmounted(() => editor.value?.destroy());
 </script>
@@ -727,7 +776,62 @@ onUnmounted(() => editor.value?.destroy());
   object-fit: cover;
 }
 
-/* ── PHB Preview (OneDnD 2024 output style) ───────────────────── */
+/* ── PHB Preview (themed output) ──────────────────────────────── */
+/*
+ * Palette + typography contract used by every .phb-* block below.
+ * The two themes override this contract; every new scriptorium block
+ * type added in future parity tickets MUST consume these vars rather
+ * than hex literals so both themes stay in sync.
+ *
+ * Defaults = OneDnD 2024 (teal). Classic overrides are in
+ * `.phb-body.theme-phb2014` below.
+ *
+ * TODO: swap the web-safe serif fallback for licensed Bookinsanity /
+ * Mr Eaves faces once licensing is sorted.
+ */
+.phb-body.theme-onednd2024,
+.phb-body.theme-phb2014,
+.phb-page.theme-onednd2024,
+.phb-page.theme-phb2014 {
+  /* Typography */
+  --sc-heading-font: "Cinzel", Georgia, serif;
+  --sc-body-font: Georgia, "Times New Roman", serif;
+
+  /* Palette */
+  --sc-ink: #1a1a1a;
+  --sc-accent: #1b3a4b;
+  --sc-accent-contrast: #f9f6ef;
+  --sc-page-bg: #f9f6ef;
+  --sc-callout-bg: #e8f4f8;
+  --sc-callout-border: var(--sc-accent);
+  --sc-code-bg: #e4ddd0;
+  --sc-col-rule: #c9b99a;
+
+  /* Per-block treatments (themes override these to swap filled-bar H1
+     for ruled H1 without rewriting every selector below) */
+  --sc-h1-bg: var(--sc-accent);
+  --sc-h1-color: var(--sc-accent-contrast);
+  --sc-h1-border-b: none;
+  --sc-h1-padding: 0.35rem 1rem;
+  --sc-title-bar-bg: var(--sc-accent);
+  --sc-title-bar-color: var(--sc-accent-contrast);
+}
+
+.phb-body.theme-phb2014,
+.phb-page.theme-phb2014 {
+  --sc-body-font: Georgia, "Palatino Linotype", "Book Antiqua", serif;
+  --sc-accent: #58180d; /* deep red-brown, classic PHB ink */
+  --sc-accent-contrast: #eeeadf;
+  --sc-page-bg: #eeeadf;
+  --sc-callout-bg: #e0e5c1; /* light olive/cream */
+
+  /* Classic H1: no filled bar — red title on parchment with double rule below */
+  --sc-h1-bg: transparent;
+  --sc-h1-color: var(--sc-accent);
+  --sc-h1-border-b: 3px double var(--sc-accent);
+  --sc-h1-padding: 0.35rem 0 0.25rem;
+}
+
 /* Parchment-gray canvas between pages */
 .phb-bg {
   background: #a09a90;
@@ -738,11 +842,10 @@ onUnmounted(() => editor.value?.destroy());
   gap: 1.5rem;
 }
 
-/* Each A4 page card */
 .phb-two-col {
   column-count: 2;
   column-gap: 1.5rem;
-  column-rule: 1px solid #c9b99a;
+  column-rule: 1px solid var(--sc-col-rule);
 }
 .phb-two-col :deep(h1),
 .phb-two-col :deep(h2) {
@@ -758,19 +861,19 @@ onUnmounted(() => editor.value?.destroy());
     no-repeat;
   padding: 2.5rem 2.5rem 2rem;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
-  font-family: Georgia, "Times New Roman", serif;
-  color: #1a1a1a;
+  font-family: var(--sc-body-font);
+  color: var(--sc-ink);
   line-height: 1.65;
   font-size: 0.9375rem;
   overflow: visible;
 }
 
 .phb-title-bar {
-  font-family: "Cinzel", Georgia, serif;
+  font-family: var(--sc-heading-font);
   font-size: 1.6rem;
   font-weight: 700;
-  color: #f9f6ef;
-  background: #1b3a4b;
+  color: var(--sc-title-bar-color);
+  background: var(--sc-title-bar-bg);
   padding: 0.6rem 2.5rem;
   margin: -2.5rem -2.5rem 1.75rem;
   letter-spacing: 0.04em;
@@ -787,31 +890,32 @@ onUnmounted(() => editor.value?.destroy());
 }
 
 .phb-body :deep(h1) {
-  font-family: "Cinzel", Georgia, serif;
+  font-family: var(--sc-heading-font);
   font-size: 1.25rem;
   font-weight: 700;
-  color: #f9f6ef;
-  background: #1b3a4b;
-  padding: 0.35rem 1rem;
+  color: var(--sc-h1-color);
+  background: var(--sc-h1-bg);
+  border-bottom: var(--sc-h1-border-b);
+  padding: var(--sc-h1-padding);
   margin: 1.5rem -1rem 1rem;
   letter-spacing: 0.03em;
 }
 .phb-body :deep(h2) {
-  font-family: "Cinzel", Georgia, serif;
+  font-family: var(--sc-heading-font);
   font-size: 1.05rem;
   font-weight: 700;
-  color: #1b3a4b;
-  border-bottom: 2px solid #1b3a4b;
+  color: var(--sc-accent);
+  border-bottom: 2px solid var(--sc-accent);
   padding-bottom: 0.2rem;
   margin: 1.25rem 0 0.6rem;
   letter-spacing: 0.02em;
 }
 .phb-body :deep(h3) {
-  font-family: "Cinzel", Georgia, serif;
+  font-family: var(--sc-heading-font);
   font-size: 0.9375rem;
   font-weight: 600;
   font-style: italic;
-  color: #1b3a4b;
+  color: var(--sc-accent);
   margin: 1rem 0 0.35rem;
 }
 .phb-body :deep(p) {
@@ -826,8 +930,8 @@ onUnmounted(() => editor.value?.destroy());
   margin: 0.2rem 0;
 }
 .phb-body :deep(blockquote) {
-  border-left: 4px solid #1b3a4b;
-  background: #e8f4f8;
+  border-left: 4px solid var(--sc-callout-border);
+  background: var(--sc-callout-bg);
   padding: 0.6rem 0.875rem;
   margin: 0.875rem 0;
   border-radius: 0 4px 4px 0;
@@ -847,15 +951,15 @@ onUnmounted(() => editor.value?.destroy());
   display: none;
 }
 .phb-body :deep(code) {
-  background: #e4ddd0;
+  background: var(--sc-code-bg);
   padding: 0.1em 0.35em;
   border-radius: 2px;
   font-family: "Courier New", monospace;
   font-size: 0.875em;
 }
 .phb-body :deep(pre) {
-  background: #1b3a4b;
-  color: #e8f4f8;
+  background: var(--sc-accent);
+  color: var(--sc-accent-contrast);
   padding: 0.875rem;
   border-radius: 4px;
   overflow-x: auto;

--- a/src/composables/useScriptoriumPdf.ts
+++ b/src/composables/useScriptoriumPdf.ts
@@ -2,36 +2,84 @@ import { ref, onUnmounted } from "vue";
 import type { ComputedRef, Ref } from "vue";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
+import type { ScriptoriumTheme } from "@/types/scriptorium.types";
 
-// Pixel-unit styles for html2canvas rendering (A4 @ 96dpi = 794×1123px)
+/*
+ * Pixel-unit styles for html2canvas rendering (A4 @ 96dpi = 794×1123px).
+ *
+ * Palette and typography are driven by CSS custom properties — the same
+ * contract as the preview (see ScriptoriumEditor.vue). The theme class
+ * (`theme-onednd2024` | `theme-phb2014`) is applied to each `.phb-page`
+ * element so the variables resolve correctly in the rendered canvas.
+ *
+ * TODO: upgrade the web-safe serif fallback to licensed faces once sorted.
+ */
 const RENDER_CSS = `
 * { box-sizing: border-box; }
-.phb-page { position:relative; width:794px; height:1123px; background:#F9F6EF; padding:60px 68px 53px; overflow:hidden; font-family:Georgia,'Times New Roman',serif; color:#1a1a1a; line-height:1.65; font-size:15px; }
+.phb-page.theme-onednd2024,
+.phb-page.theme-phb2014 {
+  --sc-heading-font: 'Cinzel', Georgia, serif;
+  --sc-body-font: Georgia, 'Times New Roman', serif;
+  --sc-ink: #1a1a1a;
+  --sc-accent: #1B3A4B;
+  --sc-accent-contrast: #F9F6EF;
+  --sc-page-bg: #F9F6EF;
+  --sc-callout-bg: #E8F4F8;
+  --sc-callout-border: var(--sc-accent);
+  --sc-code-bg: #e4ddd0;
+  --sc-h1-bg: var(--sc-accent);
+  --sc-h1-color: var(--sc-accent-contrast);
+  --sc-h1-border-b: none;
+  --sc-h1-padding: 5px 14px;
+  --sc-title-bar-bg: var(--sc-accent);
+  --sc-title-bar-color: var(--sc-accent-contrast);
+}
+.phb-page.theme-phb2014 {
+  --sc-body-font: Georgia, 'Palatino Linotype', 'Book Antiqua', serif;
+  --sc-accent: #58180D;
+  --sc-accent-contrast: #EEEADF;
+  --sc-page-bg: #EEEADF;
+  --sc-callout-bg: #E0E5C1;
+  --sc-h1-bg: transparent;
+  --sc-h1-color: var(--sc-accent);
+  --sc-h1-border-b: 3px double var(--sc-accent);
+  --sc-h1-padding: 5px 0 4px;
+}
+.phb-page { position:relative; width:794px; height:1123px; background:var(--sc-page-bg); padding:60px 68px 53px; overflow:hidden; font-family:var(--sc-body-font); color:var(--sc-ink); line-height:1.65; font-size:15px; }
 .phb-border { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; opacity:.65; }
-.phb-title-bar { font-family:'Cinzel',Georgia,serif; font-size:26px; font-weight:700; color:#F9F6EF; background:#1B3A4B; padding:9px 68px; margin:-60px -68px 28px; letter-spacing:.04em; line-height:1.25; }
-h1 { font-family:'Cinzel',Georgia,serif; font-size:19px; font-weight:700; color:#F9F6EF; background:#1B3A4B; padding:5px 14px; margin:19px -5px 11px; }
-h2 { font-family:'Cinzel',Georgia,serif; font-size:16px; font-weight:700; color:#1B3A4B; border-bottom:2px solid #1B3A4B; padding-bottom:3px; margin:16px 0 7px; }
-h3 { font-family:'Cinzel',Georgia,serif; font-size:15px; font-weight:600; font-style:italic; color:#1B3A4B; margin:13px 0 4px; }
+.phb-title-bar { font-family:var(--sc-heading-font); font-size:26px; font-weight:700; color:var(--sc-title-bar-color); background:var(--sc-title-bar-bg); padding:9px 68px; margin:-60px -68px 28px; letter-spacing:.04em; line-height:1.25; }
+h1 { font-family:var(--sc-heading-font); font-size:19px; font-weight:700; color:var(--sc-h1-color); background:var(--sc-h1-bg); border-bottom:var(--sc-h1-border-b); padding:var(--sc-h1-padding); margin:19px -5px 11px; }
+h2 { font-family:var(--sc-heading-font); font-size:16px; font-weight:700; color:var(--sc-accent); border-bottom:2px solid var(--sc-accent); padding-bottom:3px; margin:16px 0 7px; }
+h3 { font-family:var(--sc-heading-font); font-size:15px; font-weight:600; font-style:italic; color:var(--sc-accent); margin:13px 0 4px; }
 p { margin:0 0 7px; } ul,ol { padding-left:19px; margin:4px 0 7px; } li { margin:2px 0; }
-blockquote { border-left:4px solid #1B3A4B; background:#E8F4F8; padding:8px 11px; margin:11px 0; border-radius:0 4px 4px 0; font-style:italic; }
+blockquote { border-left:4px solid var(--sc-callout-border); background:var(--sc-callout-bg); padding:8px 11px; margin:11px 0; border-radius:0 4px 4px 0; font-style:italic; }
 blockquote p { margin:0; } strong { font-weight:700; } em { font-style:italic; }
-code { background:#e4ddd0; padding:1px 4px; border-radius:2px; font-family:'Courier New',monospace; font-size:13px; }
-pre { background:#1B3A4B; color:#E8F4F8; padding:11px; border-radius:4px; overflow:hidden; margin:11px 0; font-size:13px; }
+code { background:var(--sc-code-bg); padding:1px 4px; border-radius:2px; font-family:'Courier New',monospace; font-size:13px; }
+pre { background:var(--sc-accent); color:var(--sc-accent-contrast); padding:11px; border-radius:4px; overflow:hidden; margin:11px 0; font-size:13px; }
 pre code { background:transparent; padding:0; color:inherit; }
 img:not(.phb-border) { max-width:380px; max-height:480px; border-radius:4px; object-fit:cover; }
 `;
 
-async function buildPdfBlob(pages: string[], title: string): Promise<Blob> {
+function themeClass(theme: ScriptoriumTheme): string {
+  return theme === "phb2014" ? "theme-phb2014" : "theme-onednd2024";
+}
+
+async function buildPdfBlob(
+  pages: string[],
+  title: string,
+  theme: ScriptoriumTheme,
+): Promise<Blob> {
   const holder = document.createElement("div");
   holder.style.cssText = "position:fixed;top:-9999px;left:-9999px;width:794px;";
   const styleEl = document.createElement("style");
   styleEl.textContent = RENDER_CSS;
   holder.appendChild(styleEl);
 
+  const cls = themeClass(theme);
   const pageEls: HTMLElement[] = [];
   for (let i = 0; i < pages.length; i++) {
     const page = document.createElement("div");
-    page.className = "phb-page";
+    page.className = `phb-page ${cls}`;
 
     const border = document.createElement("img");
     border.className = "phb-border";
@@ -85,7 +133,11 @@ async function buildPdfBlob(pages: string[], title: string): Promise<Blob> {
   return pdf.output("blob") as Blob;
 }
 
-export function useScriptoriumPdf(pages: ComputedRef<string[]>, title: Ref<string>) {
+export function useScriptoriumPdf(
+  pages: ComputedRef<string[]>,
+  title: Ref<string>,
+  theme: Ref<ScriptoriumTheme>,
+) {
   const showPdfPreview = ref(false);
   const pdfBlobUrl = ref<string | null>(null);
   const isGeneratingPdf = ref(false);
@@ -111,7 +163,7 @@ export function useScriptoriumPdf(pages: ComputedRef<string[]>, title: Ref<strin
   async function exportPdf() {
     isGeneratingPdf.value = true;
     try {
-      const blob = await buildPdfBlob(pages.value, title.value);
+      const blob = await buildPdfBlob(pages.value, title.value, theme.value);
       const fileName = `${title.value || "Untitled"}.pdf`;
       // Use File instead of Blob — Chrome's PDF viewer uses the File name as the suggested download filename
       const file = new File([blob], fileName, { type: "application/pdf" });

--- a/src/lib/scriptoriumImport.ts
+++ b/src/lib/scriptoriumImport.ts
@@ -20,7 +20,7 @@ import type { Location } from "@/types/location.types";
 import { LOCATION_TYPE_LABELS } from "@/types/location.types";
 import type { Quest, QuestObjective } from "@/types/quest.types";
 import { QUEST_STATUS_LABELS } from "@/types/quest.types";
-import type { ScriptoriumDocType } from "@/types/scriptorium.types";
+import type { ScriptoriumDocType, ScriptoriumTheme } from "@/types/scriptorium.types";
 
 // ── Output type ───────────────────────────────────────────────────────────────
 
@@ -31,6 +31,7 @@ export interface ScriptoriumImportData {
   tags: string[];
   is_published: boolean;
   is_two_column: boolean;
+  theme: ScriptoriumTheme;
   word_count: number;
 }
 
@@ -165,6 +166,7 @@ const npcFormatter: AssetFormatter<Npc> = {
       tags: uniqueTags(["npc"], npc.tags, [npc.race]),
       is_published: false,
       is_two_column: false,
+      theme: "onednd2024" as ScriptoriumTheme,
       word_count: countWords(html),
     };
   },
@@ -258,6 +260,7 @@ const monsterFormatter: AssetFormatter<Monster> = {
       tags: uniqueTags(["monster"], [monster.monster_type], monster.tags, [monster.source]),
       is_published: false,
       is_two_column: false,
+      theme: "onednd2024" as ScriptoriumTheme,
       word_count: countWords(html),
     };
   },
@@ -330,6 +333,7 @@ const spellFormatter: AssetFormatter<Spell> = {
       tags,
       is_published: false,
       is_two_column: false,
+      theme: "onednd2024" as ScriptoriumTheme,
       word_count: countWords(html),
     };
   },
@@ -406,6 +410,7 @@ const itemFormatter: AssetFormatter<{ item: Item; spells: Spell[] }> = {
       tags,
       is_published: false,
       is_two_column: false,
+      theme: "onednd2024" as ScriptoriumTheme,
       word_count: countWords(html),
     };
   },
@@ -467,6 +472,7 @@ const locationFormatter: AssetFormatter<Location> = {
       tags,
       is_published: false,
       is_two_column: false,
+      theme: "onednd2024" as ScriptoriumTheme,
       word_count: countWords(html),
     };
   },
@@ -529,6 +535,7 @@ const questFormatter: AssetFormatter<{
       tags: uniqueTags(["quest", quest.status], quest.tags),
       is_published: false,
       is_two_column: false,
+      theme: "onednd2024" as ScriptoriumTheme,
       word_count: countWords(html),
     };
   },

--- a/src/types/scriptorium.types.ts
+++ b/src/types/scriptorium.types.ts
@@ -12,6 +12,8 @@ export type ScriptoriumDocType =
   | "location"
   | "quest";
 
+export type ScriptoriumTheme = "onednd2024" | "phb2014";
+
 export interface ScriptoriumDocument {
   id: string;
   user_id: string;
@@ -21,6 +23,7 @@ export interface ScriptoriumDocument {
   tags: string[];
   is_published: boolean;
   is_two_column: boolean;
+  theme: ScriptoriumTheme;
   word_count: number;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20260421000001_scriptorium_theme.sql
+++ b/supabase/migrations/20260421000001_scriptorium_theme.sql
@@ -1,0 +1,6 @@
+-- Migration: scriptorium_theme
+-- Add theme column to scriptorium_documents for per-document OneDnD 2024 / classic PHB 2014 selection
+
+alter table public.scriptorium_documents
+  add column if not exists theme text not null default 'onednd2024'
+    check (theme in ('onednd2024', 'phb2014'));


### PR DESCRIPTION
Closes #222 (leave open until the migration lands on remote DB — see below).

Foundation for the Homebrewery-parity work tracked in #221. Refactors the hard-coded OneDnD 2024 palette into a CSS custom-property contract that every subsequent scriptorium block type (#223–#235) consumes, then layers a Classic PHB 2014 theme on top as the first consumer.

---

## What this PR delivers

### 1. CSS-variable contract (the foundation)

Defined on `.phb-body` / `.phb-page` in both `ScriptoriumEditor.vue` scoped styles and `useScriptoriumPdf.ts` `RENDER_CSS`, so the preview and the PDF exporter share one palette.

| Variable | Default (OneDnD 2024) | Classic (`.theme-phb2014`) |
|---|---|---|
| `--sc-ink` | `#1a1a1a` | unchanged |
| `--sc-accent` | `#1b3a4b` teal | `#58180d` red-brown |
| `--sc-accent-contrast` | `#f9f6ef` | `#eeeadf` |
| `--sc-page-bg` | `#f9f6ef` | `#eeeadf` |
| `--sc-callout-bg` | `#e8f4f8` | `#e0e5c1` |
| `--sc-callout-border` | `var(--sc-accent)` | inherits |
| `--sc-code-bg` | `#e4ddd0` | unchanged |
| `--sc-col-rule` | `#c9b99a` | unchanged |
| `--sc-heading-font` | `"Cinzel", Georgia, serif` | unchanged |
| `--sc-body-font` | `Georgia, "Times New Roman", serif` | `Georgia, "Palatino Linotype", "Book Antiqua", serif` |
| `--sc-h1-bg` | `var(--sc-accent)` filled bar | `transparent` |
| `--sc-h1-color` | `var(--sc-accent-contrast)` | `var(--sc-accent)` |
| `--sc-h1-border-b` | `none` | `3px double var(--sc-accent)` |
| `--sc-h1-padding` | `0.35rem 1rem` | `0.35rem 0 0.25rem` |
| `--sc-title-bar-bg` | `var(--sc-accent)` | inherits |
| `--sc-title-bar-color` | `var(--sc-accent-contrast)` | inherits |

All `.phb-*` selectors consume these variables — `grep '#[0-9a-fA-F]\{6\}'` on the touched files returns only (a) the variable declarations themselves, (b) the unrelated `DOC_TYPE_COLORS` chip tags, and (c) the app-chrome canvas gray `#a09a90`.

### 2. Classic PHB 2014 theme

First consumer of the contract. Per-document toggle in the editor toolbar (segmented "2024 | Classic"), persisted as `scriptorium_documents.theme`. The PDF render container applies the same theme class to each `.phb-page` element, so WYSIWYG.

### 3. Schema

New migration `20260421000001_scriptorium_theme.sql`:

```sql
alter table public.scriptorium_documents
  add column if not exists theme text not null default 'onednd2024'
    check (theme in ('onednd2024', 'phb2014'));
```

### Verification done

- `npx vue-tsc --noEmit` — clean
- `npx oxlint` on the three touched source files — clean
- `grep` sweep — every remaining hex literal in the two scriptorium files is in a variable declaration, a doc-type chip, or the inter-page canvas gray

### Verification NOT done (can't run in sandbox)

- No browser validation — no dev server available. **Eyeball the toggle and both themes locally before merging.**
- `supabase db push` not run — see below.

---

## ⚠️ HANDOFF CHECKLIST (before merging)

1. **Apply the migration locally.**
   ```bash
   git checkout claude/scriptorium-222-classic-phb-theme
   supabase db push
   ```
   The sandbox couldn't run this (no project ref linked).

2. **Smoke-test in browser.** Start the dev server, open an existing scriptorium document, switch the theme toggle, confirm both themes render in preview, export both to PDF and confirm the PDF matches.

3. **Close #222** once the migration is live.

---

## Continuing the Homebrewery-parity work locally

The remaining 13 tickets in the #221 tracking issue are now ready to be picked up. This PR's CSS-variable contract is the foundation — every subsequent block type must consume those variables rather than adding new palette literals, so both themes stay in sync by construction.

### Recommended execution order

1. **Next sequential (also a foundation):**
   - #235 — "Insert block…" snippet/template picker toolbar (registry pattern; subsequent tickets add a one-line entry to the registry instead of new toolbar buttons)

2. **Then fan out in parallel** (leaf tickets that don't share much):
   - #223 — Column break
   - #226 — Spacer utilities (vertical + horizontal)
   - #232 — Image wrap-left/right + absolute-positioned images
   - #233 — Decorative overlays (watercolor, watermark, artist credit)
   - #234 — Ink-friendly mode + page-size selection

3. **Sequence two at a time** (share files with each other):
   - #224 — Wide block
   - #225 — Page numbers + footer
   - #227 — Note / Descriptive / Quote callout blocks
   - #228 — Cover page templates
   - #229 — Auto-generated Table of Contents
   - #230 — Empty entity block templates
   - #231 — Class progression table templates

### Branching convention

One branch per ticket: `claude/scriptorium-<issue>-<slug>`.

Example for the next one: `claude/scriptorium-235-block-picker`.

### Per-ticket file map (what to touch)

Every new block type needs all three surfaces updated or preview and PDF will drift:

1. **Tiptap Node** — new file under `src/lib/tiptap/*.ts`
2. **Editor scoped CSS** — add to the `<style>` block at the bottom of `src/components/scriptorium/ScriptoriumEditor.vue` (consume the CSS variables from this PR, do NOT add new palette literals)
3. **PDF `RENDER_CSS`** — add to the template string in `src/composables/useScriptoriumPdf.ts` (same variable contract applies)
4. **Register** the node in the `extensions: [...]` array in `ScriptoriumEditor.vue` (or, once #235 lands, in the block registry)

### ⚠️ IMPORTANT — migration sequence collisions

If you run parallel agents/tasks that each add a migration, make each one invoke `/new-migration <name>` inside its own session. That skill checks both local files and `origin/main` to pick a collision-free sequence number — picking it manually from outside the agent defeats the purpose and will cause timestamp clashes every time. (This bit us this session — that's why #222 was implemented inline rather than delegated.)

### Contract for every parity ticket

- Must style correctly in **both** `.theme-onednd2024` (default) and `.theme-phb2014`. If a block needs a theme-specific treatment that can't be expressed by the existing variables, add a new per-block variable (like the `--sc-h1-*` set in this PR) — don't branch CSS selectors per theme unless the treatment is structurally different.
- Must survive `html2canvas` → `jsPDF` — any CSS feature you use needs to work in the offscreen render container.
- Must update `ROADMAP.md` (`[x]` entry under Scriptorium) and close the GitHub issue when shipping, per `CLAUDE.md`.

---

## Files changed

- `supabase/migrations/20260421000001_scriptorium_theme.sql`
- `src/types/scriptorium.types.ts`
- `src/components/scriptorium/ScriptoriumEditor.vue`
- `src/composables/useScriptoriumPdf.ts`
- `ROADMAP.md`

https://claude.ai/code/session_01Qsc2nzeej9LuksrSUHz43Y