### PR TITLE
Upgrade image model to gpt-image-2 + add gpt-image-1-mini draft mode + reduce generation size

### DIFF
--- a/src/ai/providers/index.ts
+++ b/src/ai/providers/index.ts
@@ -10,10 +10,11 @@ export type { TextProvider, ImageProvider };
 function resolveKey(provider: string): string {
   const store = useCampaignStore();
   const key = ({
-    openai:    store.decryptedOpenAiKey,
-    anthropic: store.decryptedAnthropicKey,
-    gemini:    store.decryptedGeminiKey,
-    falai:     store.decryptedFalAiKey,
+    openai:       store.decryptedOpenAiKey,
+    "openai-mini": store.decryptedOpenAiKey,
+    anthropic:    store.decryptedAnthropicKey,
+    gemini:       store.decryptedGeminiKey,
+    falai:        store.decryptedFalAiKey,
   } as Record<string, string>)[provider] ?? "";
   if (!key)
     throw new Error(
@@ -36,7 +37,8 @@ export function getImageProvider(): ImageProvider {
   const provider = useCampaignStore().activeCampaign?.image_provider ?? "openai";
   const key = resolveKey(provider);
   switch (provider) {
-    case "falai": return createFalAiImageProvider(key);
-    default:      return createOpenAiImageProvider(key);
+    case "falai":        return createFalAiImageProvider(key);
+    case "openai-mini":  return createOpenAiImageProvider(key, "gpt-image-1-mini");
+    default:             return createOpenAiImageProvider(key);
   }
 }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -32,7 +32,10 @@ export function createOpenAiTextProvider(apiKey: string): TextProvider {
   };
 }
 
-export function createOpenAiImageProvider(apiKey: string): ImageProvider {
+export function createOpenAiImageProvider(
+  apiKey: string,
+  model: "gpt-image-2" | "gpt-image-1-mini" = "gpt-image-2",
+): ImageProvider {
   return {
     async generate(prompt: string, size: string): Promise<string> {
       const res = await fetch(IMAGE_URL, {
@@ -42,7 +45,7 @@ export function createOpenAiImageProvider(apiKey: string): ImageProvider {
           Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-          model: "gpt-image-2",
+          model,
           prompt,
           size,
           output_format: "webp",
@@ -60,7 +63,7 @@ export function createOpenAiImageProvider(apiKey: string): ImageProvider {
 
     async edit(source: Blob, prompt: string, size: string): Promise<string> {
       const form = new FormData();
-      form.append("model", "gpt-image-2");
+      form.append("model", model);
       form.append(
         "image[]",
         new File([source], "portrait.webp", { type: "image/webp" }),

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -42,7 +42,7 @@ export function createOpenAiImageProvider(apiKey: string): ImageProvider {
           Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-          model: "gpt-image-1.5",
+          model: "gpt-image-2",
           prompt,
           size,
           output_format: "webp",
@@ -60,7 +60,7 @@ export function createOpenAiImageProvider(apiKey: string): ImageProvider {
 
     async edit(source: Blob, prompt: string, size: string): Promise<string> {
       const form = new FormData();
-      form.append("model", "gpt-image-1.5");
+      form.append("model", "gpt-image-2");
       form.append(
         "image[]",
         new File([source], "portrait.webp", { type: "image/webp" }),

--- a/src/ai/useChroniclerImageGeneration.ts
+++ b/src/ai/useChroniclerImageGeneration.ts
@@ -188,6 +188,9 @@ export async function generateChroniclerImage(params: {
   const { sceneText, entities, size } = params;
   const store = useCampaignStore();
   const apiKey = store.decryptedOpenAiKey;
+  const imageModel = store.activeCampaign?.image_provider === "openai-mini"
+    ? "gpt-image-1-mini"
+    : "gpt-image-2";
   const settingPrompt = store.activeCampaign?.ai_setting_prompt ?? "";
   if (!apiKey) throw new Error("No OpenAI API key configured. Add one in Campaign Settings → AI.");
 
@@ -212,7 +215,7 @@ export async function generateChroniclerImage(params: {
   if (portraitBlobs.length > 0) {
     // Multi-image edit endpoint — composes reference portraits into the scene
     const form = new FormData();
-    form.append("model", "gpt-image-2");
+    form.append("model", imageModel);
     form.append("prompt", prompt);
     form.append("size", size);
     form.append("output_format", "webp");
@@ -235,7 +238,7 @@ export async function generateChroniclerImage(params: {
     const res = await fetch(GENERATE_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ model: "gpt-image-2", prompt, size, output_format: "webp" }),
+      body: JSON.stringify({ model: imageModel, prompt, size, output_format: "webp" }),
     });
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));

--- a/src/ai/useChroniclerImageGeneration.ts
+++ b/src/ai/useChroniclerImageGeneration.ts
@@ -212,7 +212,7 @@ export async function generateChroniclerImage(params: {
   if (portraitBlobs.length > 0) {
     // Multi-image edit endpoint — composes reference portraits into the scene
     const form = new FormData();
-    form.append("model", "gpt-image-1.5");
+    form.append("model", "gpt-image-2");
     form.append("prompt", prompt);
     form.append("size", size);
     form.append("output_format", "webp");
@@ -235,7 +235,7 @@ export async function generateChroniclerImage(params: {
     const res = await fetch(GENERATE_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ model: "gpt-image-1.5", prompt, size, output_format: "webp" }),
+      body: JSON.stringify({ model: "gpt-image-2", prompt, size, output_format: "webp" }),
     });
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));

--- a/src/ai/useItemGeneration.ts
+++ b/src/ai/useItemGeneration.ts
@@ -89,7 +89,7 @@ export function useItemGeneration() {
           .filter(Boolean)
           .join(" — ");
 
-        const b64 = await imageProvider.generate(imagePrompt, "1024x1536");
+        const b64 = await imageProvider.generate(imagePrompt, "1024x1024");
 
         // ── 3. Upload to Supabase storage ─────────────────────────────────
         if (b64 && auth.user) {

--- a/src/ai/useMonsterGeneration.ts
+++ b/src/ai/useMonsterGeneration.ts
@@ -85,7 +85,7 @@ export function useMonsterGeneration() {
           .filter(Boolean)
           .join(" — ");
 
-        const b64 = await imageProvider.generate(imagePrompt, "1024x1536");
+        const b64 = await imageProvider.generate(imagePrompt, "1024x1024");
 
         // ── 3. Upload to Supabase storage ─────────────────────────────
         if (b64 && auth.user) {

--- a/src/ai/useNpcGeneration.ts
+++ b/src/ai/useNpcGeneration.ts
@@ -138,7 +138,7 @@ export function useNpcGeneration() {
           .filter(Boolean)
           .join("\n");
 
-        const b64 = await imageProvider.generate(imagePrompt, "1024x1536");
+        const b64 = await imageProvider.generate(imagePrompt, "1024x1024");
         const truePortraitBlob = b64 ? b64ToBlob(b64) : null;
 
         const uploadTrue = async () => {
@@ -166,7 +166,7 @@ export function useNpcGeneration() {
             const disguiseB64 = await imageProvider.edit(
               truePortraitBlob,
               disguisePrompt,
-              "1024x1536",
+              "1024x1024",
             );
             if (!disguiseB64 || !auth.user) return;
             disguise_portrait_url = await uploadWithVariants({ bucket: "npcPortraits", userId: auth.user.id, blob: b64ToBlob(disguiseB64) });

--- a/src/ai/usePuzzleGeneration.ts
+++ b/src/ai/usePuzzleGeneration.ts
@@ -88,7 +88,7 @@ export function usePuzzleGeneration() {
           .join(" — ");
 
         try {
-          const b64 = await imageProvider.generate(imagePrompt, "1024x1536");
+          const b64 = await imageProvider.generate(imagePrompt, "1024x1024");
 
           if (b64) {
             image_url = await uploadWithVariants({

--- a/src/components/campaign/AiTab.vue
+++ b/src/components/campaign/AiTab.vue
@@ -98,6 +98,9 @@
             <span v-if="form.image_provider === 'falai'" class="text-yellow-600 dark:text-yellow-500">
               fal.ai does not support alter-ego disguise portraits — that requires OpenAI.
             </span>
+            <span v-if="form.image_provider === 'openai-mini'" class="text-muted-foreground">
+              Draft mode: lower cost, same sizes and features as gpt-image-2, but lower output quality.
+            </span>
           </p>
           <select
             v-if="availableImageProviders.length > 0"
@@ -239,8 +242,9 @@ const TEXT_PROVIDER_OPTIONS = [
 ] as const;
 
 const IMAGE_PROVIDER_OPTIONS = [
-  { value: "openai", label: "OpenAI — gpt-image-2" },
-  { value: "falai",  label: "fal.ai — FLUX 2 Flex" },
+  { value: "openai",       label: "OpenAI — gpt-image-2",             keyProvider: "openai" },
+  { value: "openai-mini",  label: "OpenAI — gpt-image-1-mini (draft)", keyProvider: "openai" },
+  { value: "falai",        label: "fal.ai — FLUX 2 Flex",             keyProvider: "falai"  },
 ] as const;
 
 function providerHasKey(providerId: string): boolean {
@@ -253,7 +257,7 @@ function providerHasKey(providerId: string): boolean {
 }
 
 const availableTextProviders  = computed(() => TEXT_PROVIDER_OPTIONS.filter((o) => providerHasKey(o.value)));
-const availableImageProviders = computed(() => IMAGE_PROVIDER_OPTIONS.filter((o) => providerHasKey(o.value)));
+const availableImageProviders = computed(() => IMAGE_PROVIDER_OPTIONS.filter((o) => providerHasKey(o.keyProvider)));
 
 // Auto-correct selection if the chosen provider loses its key
 watch(availableTextProviders, (options) => {
@@ -273,10 +277,11 @@ const TEXT_COSTS: Record<string, string> = {
   anthropic: "~$0.02 per generation   (Sonnet 4.6: $3 / $15 per M tokens)",
   gemini:    "~$0.0004 per generation (Gemini Flash: $0.075 / $0.30 per M tokens)",
 };
-// Cost hints — gpt-image-2 at high quality 1024×1536 is the main cost driver
+// Cost hints — gpt-image-2 at high quality 1024×1024 is the main cost driver
 const IMAGE_COSTS: Record<string, string> = {
-  openai: "~$0.15–0.40 per portrait · ~$0.30–0.80 with alter-ego (gpt-image-2, high quality)",
-  falai:  "~$0.025 per portrait (FLUX 2 Flex)",
+  openai:        "~$0.05–0.20 per portrait · ~$0.10–0.40 with alter-ego (gpt-image-2, high quality)",
+  "openai-mini": "~$0.005–0.036 per portrait · alter-ego supported (gpt-image-1-mini)",
+  falai:         "~$0.025 per portrait (FLUX 2 Flex)",
 };
 const activeTextCost  = computed(() => ({ hint: TEXT_COSTS[form.value.text_provider]  ?? TEXT_COSTS.openai }));
 const activeImageCost = computed(() => ({ hint: IMAGE_COSTS[form.value.image_provider] ?? IMAGE_COSTS.openai }));

--- a/src/components/campaign/AiTab.vue
+++ b/src/components/campaign/AiTab.vue
@@ -239,7 +239,7 @@ const TEXT_PROVIDER_OPTIONS = [
 ] as const;
 
 const IMAGE_PROVIDER_OPTIONS = [
-  { value: "openai", label: "OpenAI — gpt-image-1.5" },
+  { value: "openai", label: "OpenAI — gpt-image-2" },
   { value: "falai",  label: "fal.ai — FLUX 2 Flex" },
 ] as const;
 
@@ -273,9 +273,9 @@ const TEXT_COSTS: Record<string, string> = {
   anthropic: "~$0.02 per generation   (Sonnet 4.6: $3 / $15 per M tokens)",
   gemini:    "~$0.0004 per generation (Gemini Flash: $0.075 / $0.30 per M tokens)",
 };
-// Cost hints — gpt-image-1.5 at high quality 1024×1536 is the main cost driver
+// Cost hints — gpt-image-2 at high quality 1024×1536 is the main cost driver
 const IMAGE_COSTS: Record<string, string> = {
-  openai: "~$0.15–0.40 per portrait · ~$0.30–0.80 with alter-ego (gpt-image-1.5, high quality)",
+  openai: "~$0.15–0.40 per portrait · ~$0.30–0.80 with alter-ego (gpt-image-2, high quality)",
   falai:  "~$0.025 per portrait (FLUX 2 Flex)",
 };
 const activeTextCost  = computed(() => ({ hint: TEXT_COSTS[form.value.text_provider]  ?? TEXT_COSTS.openai }));


### PR DESCRIPTION
## Summary

- **Model upgrade**: `gpt-image-1.5` → `gpt-image-2` across all generation paths
- **Draft mode**: New `gpt-image-1-mini` provider option for cheap prototyping (~5–40× cheaper than gpt-image-2)
- **Smaller generation size**: Portrait generation reduced from 1024×1536 → 1024×1024 for all entity types (NPCs, monsters, items, puzzles) — display variants max at 600px wide so the extra height was never used

## What changed

### Provider layer (`src/ai/providers/`)
- `createOpenAiImageProvider()` accepts an optional `model` param (`"gpt-image-2"` default, or `"gpt-image-1-mini"`)
- `getImageProvider()` maps new `"openai-mini"` provider value → gpt-image-1-mini
- `resolveKey()` maps `"openai-mini"` to the existing OpenAI API key — no new key required

### Generation files
- `useNpcGeneration`, `useMonsterGeneration`, `useItemGeneration`, `usePuzzleGeneration`: portrait size `1024x1536` → `1024x1024`
- `useChroniclerImageGeneration`: reads `image_provider` to pick model (mini or standard) without a separate setting

### UI (`src/components/campaign/AiTab.vue`)
- New dropdown option: **OpenAI — gpt-image-1-mini (draft)**
- Both OpenAI options share the same API key (no extra setup for the user)
- Updated cost hints reflecting reduced sizes and mini pricing

## Compatibility notes (from docs)

- gpt-image-1-mini supports the same 3 sizes and the `/v1/images/edits` multi-image endpoint — no feature gaps vs gpt-image-2
- No `similarity` param support on mini, but we don't use it
- No DB migration needed: `image_provider` is already a freeform string column; `"openai-mini"` stores fine

## Test plan

- [ ] AI settings → select **gpt-image-2** → generate NPC portrait — confirm 1024×1024 square image returned
- [ ] AI settings → select **gpt-image-1-mini (draft)** — confirm both OpenAI options appear when an OpenAI key is present
- [ ] Generate NPC with alter-ego (disguise) using mini → confirm edit endpoint works
- [ ] Generate NPC with alter-ego using gpt-image-2 → confirm edit endpoint works
- [ ] Chronicler scene generation with @-mentioned entities (portrait blobs) — confirm mini and standard both work
- [ ] Chronicler scene generation text-only — confirm mini and standard both work
- [ ] Switch between openai / openai-mini / falai — confirm cost hint updates correctly
- [ ] Remove OpenAI key — confirm both openai and openai-mini options disappear from the dropdown

https://claude.ai/code/session_01MdSPWB2dGRoHqWxhye8CAM