### PR TITLE
Add in-app bug report modal with GitHub issue creation

### DIFF
--- a/src/components/common/BugReportModal.vue
+++ b/src/components/common/BugReportModal.vue
@@ -1,0 +1,292 @@
+<template>
+  <Teleport to="body">
+    <Transition name="dialog-fade">
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-200 flex items-center justify-center p-4"
+        @mousedown.self="close"
+      >
+        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+        <div
+          class="relative w-full max-w-lg rounded-xl border border-border bg-card shadow-2xl flex flex-col max-h-[90dvh]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bug-report-title"
+        >
+          <!-- Header -->
+          <div class="flex items-center gap-3 px-5 py-4 border-b border-border shrink-0">
+            <div class="flex items-center justify-center w-8 h-8 rounded-full bg-destructive/15 text-destructive shrink-0">
+              <Bug class="h-4 w-4" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <h2 id="bug-report-title" class="font-cinzel text-sm font-bold text-foreground tracking-wide">
+                Report a Bug
+              </h2>
+              <p class="font-fell text-xs text-muted-foreground mt-0.5">
+                Your report opens a GitHub issue for the development team.
+              </p>
+            </div>
+            <button
+              class="text-muted-foreground hover:text-foreground transition-colors shrink-0"
+              aria-label="Close"
+              @click="close"
+            >
+              <X class="h-4 w-4" />
+            </button>
+          </div>
+
+          <!-- Success state -->
+          <div v-if="submitted" class="px-5 py-10 flex flex-col items-center gap-3 text-center">
+            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-green-500/15 text-green-400">
+              <CircleCheck class="h-6 w-6" />
+            </div>
+            <h3 class="font-cinzel text-sm font-bold text-foreground tracking-wide">Bug Reported!</h3>
+            <p class="font-fell text-sm text-muted-foreground max-w-xs leading-relaxed">
+              Thank you — issue #{{ issueNumber }} has been filed and the development team will look into it.
+            </p>
+            <button
+              class="mt-2 px-4 py-1.5 rounded-md border border-border font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors tracking-wider"
+              @click="close"
+            >
+              Close
+            </button>
+          </div>
+
+          <!-- Form -->
+          <form v-else class="overflow-y-auto flex-1 flex flex-col" @submit.prevent="submit">
+            <div class="px-5 py-4 space-y-4 flex-1">
+              <div class="space-y-1.5">
+                <label class="font-cinzel text-xs font-semibold text-foreground tracking-wide">
+                  Where in the app?
+                </label>
+                <input
+                  v-model="form.where"
+                  type="text"
+                  required
+                  placeholder="e.g. Encounter tracker, NPC detail page…"
+                  class="w-full px-3 py-2 rounded-md bg-background border border-border text-sm font-fell text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-gold-500"
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label class="font-cinzel text-xs font-semibold text-foreground tracking-wide">
+                  What were you doing?
+                </label>
+                <textarea
+                  v-model="form.action"
+                  required
+                  rows="2"
+                  placeholder="Describe the steps that led to the bug…"
+                  class="w-full px-3 py-2 rounded-md bg-background border border-border text-sm font-fell text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-gold-500 resize-none"
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label class="font-cinzel text-xs font-semibold text-foreground tracking-wide">
+                  What did you expect?
+                </label>
+                <textarea
+                  v-model="form.expected"
+                  required
+                  rows="2"
+                  placeholder="What should have happened…"
+                  class="w-full px-3 py-2 rounded-md bg-background border border-border text-sm font-fell text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-gold-500 resize-none"
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label class="font-cinzel text-xs font-semibold text-foreground tracking-wide">
+                  What actually happened?
+                </label>
+                <textarea
+                  v-model="form.actual"
+                  required
+                  rows="2"
+                  placeholder="Describe what went wrong…"
+                  class="w-full px-3 py-2 rounded-md bg-background border border-border text-sm font-fell text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-gold-500 resize-none"
+                />
+              </div>
+
+              <!-- Screenshot -->
+              <div class="space-y-1.5">
+                <label class="font-cinzel text-xs font-semibold text-foreground tracking-wide">
+                  Screenshot
+                  <span class="font-fell text-muted-foreground normal-case tracking-normal font-normal">(optional)</span>
+                </label>
+                <div v-if="screenshotPreview" class="relative rounded-md overflow-hidden border border-border bg-background">
+                  <img
+                    :src="screenshotPreview"
+                    alt="Screenshot preview"
+                    class="w-full max-h-40 object-contain"
+                  />
+                  <button
+                    type="button"
+                    class="absolute top-1.5 right-1.5 flex items-center justify-center w-6 h-6 rounded-full bg-card/90 border border-border text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Remove screenshot"
+                    @click="clearScreenshot"
+                  >
+                    <X class="h-3 w-3" />
+                  </button>
+                </div>
+                <label
+                  v-else
+                  class="flex items-center gap-2 px-3 py-2 rounded-md border border-dashed border-border text-xs font-fell text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors cursor-pointer"
+                >
+                  <ImagePlus class="h-4 w-4 shrink-0" />
+                  <span>Add screenshot</span>
+                  <input
+                    ref="fileInputRef"
+                    type="file"
+                    accept="image/*"
+                    class="sr-only"
+                    @change="handleFileChange"
+                  />
+                </label>
+              </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="flex items-center gap-3 px-5 py-4 border-t border-border shrink-0">
+              <p v-if="error" class="flex-1 font-fell text-xs text-destructive">{{ error }}</p>
+              <div v-else class="flex-1" />
+              <button
+                type="button"
+                class="px-4 py-1.5 rounded-md border border-border font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors tracking-wider"
+                @click="close"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                :disabled="submitting"
+                class="flex items-center gap-2 px-4 py-1.5 rounded-md bg-primary text-primary-foreground font-cinzel text-xs font-semibold tracking-wider hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                <Loader2 v-if="submitting" class="h-3 w-3 animate-spin" />
+                <span>{{ submitting ? "Submitting…" : "Submit Report" }}</span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { X, Bug, ImagePlus, Loader2, CircleCheck } from "lucide-vue-next";
+import { useAuthStore } from "@/stores/auth";
+import { supabase } from "@/lib/supabase";
+
+defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{ "update:modelValue": [val: boolean] }>();
+
+const auth = useAuthStore();
+
+const form = ref({ where: "", action: "", expected: "", actual: "" });
+const screenshotFile = ref<File | null>(null);
+const screenshotPreview = ref<string | null>(null);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const submitting = ref(false);
+const submitted = ref(false);
+const error = ref("");
+const issueNumber = ref<number | null>(null);
+
+function close() {
+  emit("update:modelValue", false);
+  setTimeout(reset, 200);
+}
+
+function reset() {
+  form.value = { where: "", action: "", expected: "", actual: "" };
+  screenshotFile.value = null;
+  screenshotPreview.value = null;
+  submitting.value = false;
+  submitted.value = false;
+  error.value = "";
+  issueNumber.value = null;
+}
+
+function handleFileChange(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0];
+  if (!file) return;
+  screenshotFile.value = file;
+  compressImage(file).then((dataUrl) => {
+    screenshotPreview.value = dataUrl;
+  });
+}
+
+function clearScreenshot() {
+  screenshotFile.value = null;
+  screenshotPreview.value = null;
+  if (fileInputRef.value) fileInputRef.value.value = "";
+}
+
+// Resize to max 1200px wide and compress to JPEG to keep the payload small.
+function compressImage(file: File, maxWidth = 1200, quality = 0.85): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      let { width, height } = img;
+      if (width > maxWidth) {
+        height = Math.round((height * maxWidth) / width);
+        width = maxWidth;
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      canvas.getContext("2d")!.drawImage(img, 0, 0, width, height);
+      URL.revokeObjectURL(img.src);
+      resolve(canvas.toDataURL("image/jpeg", quality));
+    };
+    img.src = URL.createObjectURL(file);
+  });
+}
+
+async function submit() {
+  error.value = "";
+  submitting.value = true;
+  try {
+    const submittedBy = auth.membership?.display_name || auth.userEmail || undefined;
+    const { data, error: fnError } = await supabase.functions.invoke("create-bug-report", {
+      body: {
+        where: form.value.where,
+        action: form.value.action,
+        expected: form.value.expected,
+        actual: form.value.actual,
+        screenshot: screenshotPreview.value ?? undefined,
+        screenshotName: screenshotFile.value?.name,
+        submittedBy,
+      },
+    });
+    if (fnError) throw fnError;
+    issueNumber.value = (data as { issueNumber: number })?.issueNumber ?? null;
+    submitted.value = true;
+  } catch (e) {
+    error.value = "Something went wrong — please try again.";
+    console.error("Bug report submit error:", e);
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+.dialog-fade-enter-active .relative,
+.dialog-fade-leave-active .relative {
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+.dialog-fade-enter-from .relative,
+.dialog-fade-leave-to .relative {
+  transform: scale(0.95);
+  opacity: 0;
+}
+</style>

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -88,6 +88,15 @@
       <AppInvitePanel v-if="auth.isAppAdmin" />
       <SoundboardWidgetToggle />
       <button
+        class="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+        title="Report a bug"
+        @click="bugReportOpen = true"
+      >
+        <Bug class="h-3.5 w-3.5 shrink-0" />
+        <span class="font-fell">Report a Bug</span>
+      </button>
+      <BugReportModal v-model="bugReportOpen" />
+      <button
         v-if="auth.isDM"
         class="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
         title="Preview the player portal as your players see it"
@@ -145,7 +154,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useRouter } from "vue-router";
-import { LogOut, Pencil, Check, Eye, Loader2 } from "lucide-vue-next";
+import { LogOut, Pencil, Check, Eye, Loader2, Bug } from "lucide-vue-next";
 import { isAnyAiGenerating, getAiGeneratorRegistry } from "@/ai/aiGeneratorRegistry";
 import { currentLoadingQuote } from "@/ai/aiGenerationState";
 import { useAuthStore } from "@/stores/auth";
@@ -159,10 +168,12 @@ import CampaignSwitcher from "./CampaignSwitcher.vue";
 import GlobalSearch from "./GlobalSearch.vue";
 import AppInvitePanel from "@/components/admin/AppInvitePanel.vue";
 import SoundboardWidgetToggle from "@/components/soundboard/SoundboardWidgetToggle.vue";
+import BugReportModal from "@/components/common/BugReportModal.vue";
 
 const auth = useAuthStore();
 const ui = useUiStore();
 const router = useRouter();
+const bugReportOpen = ref(false);
 // DM detection — the prep/play toggle is the only DM-only sidebar control
 // so far; gate its visibility so players never see it (issue #133 acceptance).
 const isDm = computed(() => auth.currentRole === "dm");

--- a/src/components/layout/AppTopBar.vue
+++ b/src/components/layout/AppTopBar.vue
@@ -29,8 +29,16 @@
       <span class="px-1" :class="ui.dmMode === 'play' ? '' : 'opacity-50'">PLAY</span>
     </button>
 
+    <button
+      class="text-muted-foreground hover:text-foreground transition-colors"
+      aria-label="Report a bug"
+      @click="bugReportOpen = true"
+    >
+      <Bug class="h-5 w-5" />
+    </button>
     <SoundboardWidgetToggle class="px-1.5! py-1!" />
     <DiceRoller />
+    <BugReportModal v-model="bugReportOpen" />
 
     <!-- Mobile nav FAB — bottom-left, thumb-friendly.
          Bottom/left offsets include env(safe-area-inset-*) so the FAB clears
@@ -109,16 +117,18 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from "vue";
 import { useRoute } from "vue-router";
-import { Menu, Search, X, Loader2 } from "lucide-vue-next";
+import { Menu, Search, X, Loader2, Bug } from "lucide-vue-next";
 import { useAuthStore } from "@/stores/auth";
 import { useUiStore } from "@/stores/ui";
 import DiceRoller from "@/components/common/DiceRoller.vue";
 import SoundboardWidgetToggle from "@/components/soundboard/SoundboardWidgetToggle.vue";
+import BugReportModal from "@/components/common/BugReportModal.vue";
 import { useGlobalSearch } from "@/composables/useGlobalSearch";
 
 const route = useRoute();
 const ui = useUiStore();
 const auth = useAuthStore();
+const bugReportOpen = ref(false);
 const isDm = computed(() => auth.currentRole === "dm");
 
 const pageTitle = computed(() => (route.meta.title as string | undefined) ?? "Grimoire");

--- a/src/layouts/PlayerLayout.vue
+++ b/src/layouts/PlayerLayout.vue
@@ -49,6 +49,14 @@
 
       <button
         class="p-1.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+        title="Report a bug"
+        @click="bugReportOpen = true"
+      >
+        <Bug class="h-4 w-4" />
+      </button>
+
+      <button
+        class="p-1.5 rounded text-muted-foreground hover:text-foreground transition-colors"
         title="Sign out"
         @click="handleSignOut"
       >
@@ -193,6 +201,8 @@
     </nav>
   </div>
 
+  <BugReportModal v-model="bugReportOpen" />
+
   <!-- "More" panel -->
   <Teleport to="body">
     <Transition name="more-panel">
@@ -230,7 +240,7 @@
 import { ref, computed, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useIsMobile } from "@/composables/useBreakpoint";
-import { LogOut, X, Eye, LayoutGrid, Swords } from "lucide-vue-next";
+import { LogOut, X, Eye, LayoutGrid, Swords, Bug } from "lucide-vue-next";
 import DiceRoller from "@/components/common/DiceRoller.vue";
 import { useRunningEncounters, usePlayerEncounterLive } from "@/composables/useEncounterLive";
 import { useAuthStore } from "@/stores/auth";
@@ -244,10 +254,12 @@ import { usePlayerNavPrefs } from "@/composables/usePlayerNavPrefs";
 import { MOBILE_NAV_SLOTS, TABLET_NAV_SLOTS } from "@/lib/playerNav";
 import CampaignChat from "@/components/chat/CampaignChat.vue";
 import PlayerEncounterPanel from "@/components/player/PlayerEncounterPanel.vue";
+import BugReportModal from "@/components/common/BugReportModal.vue";
 
 const auth = useAuthStore();
 const ui = useUiStore();
 const campaign = useCampaignStore();
+const bugReportOpen = ref(false);
 const route = useRoute();
 
 const membershipCampaignId = computed(() => auth.membership?.campaign_id ?? null);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -35,6 +35,14 @@ verify_jwt = false
 [functions.api-key-vault]
 verify_jwt = false
 
+# In-app bug reporter — called by the browser on behalf of any logged-in user.
+# The gateway check is off because we want anonymous reports too (e.g. users
+# who can't access their session). Security: the function only creates GitHub
+# issues; it never reads or mutates app data. The GITHUB_TOKEN secret is
+# scoped to `issues: write` only.
+[functions.create-bug-report]
+verify_jwt = false
+
 # Shared SRD rules sync — triggered by an admin / cron with the service-role
 # key, so the gateway check can stay on.
 # [functions.sync-srd-rules]

--- a/supabase/functions/create-bug-report/index.ts
+++ b/supabase/functions/create-bug-report/index.ts
@@ -1,0 +1,167 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// Public endpoint — no JWT required. Anyone using the app can file a report.
+// Security: we only create issues (no reads, no destructive ops). The
+// GITHUB_TOKEN secret is scoped to `issues: write` on irongollem/grimoire.
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+interface BugReportPayload {
+  where: string;
+  action: string;
+  expected: string;
+  actual: string;
+  screenshot?: string; // base64 data URL
+  screenshotName?: string;
+  submittedBy?: string;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: CORS_HEADERS });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405, headers: CORS_HEADERS });
+  }
+
+  let payload: BugReportPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return new Response("Invalid JSON", { status: 400, headers: CORS_HEADERS });
+  }
+
+  const { where, action, expected, actual, screenshot, screenshotName, submittedBy } = payload;
+
+  if (!where?.trim() || !action?.trim() || !expected?.trim() || !actual?.trim()) {
+    return new Response("Missing required fields", { status: 400, headers: CORS_HEADERS });
+  }
+
+  const githubToken = Deno.env.get("GITHUB_TOKEN");
+  if (!githubToken) {
+    console.error("GITHUB_TOKEN secret is not set");
+    return new Response("Server misconfigured", { status: 500, headers: CORS_HEADERS });
+  }
+
+  // Ensure the `user-report` label exists on the repo (idempotent).
+  await fetch("https://api.github.com/repos/irongollem/grimoire/labels", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${githubToken}`,
+      "Accept": "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      "User-Agent": "Grimoire-BugReporter/1.0",
+    },
+    body: JSON.stringify({
+      name: "user-report",
+      color: "e4a820",
+      description: "Submitted via in-app bug reporter — not filed by a maintainer",
+    }),
+  });
+  // 422 = label already exists — ignored intentionally.
+
+  // Upload screenshot to Supabase Storage if provided.
+  let screenshotUrl: string | null = null;
+  if (screenshot?.startsWith("data:")) {
+    try {
+      const supabase = createClient(
+        Deno.env.get("SUPABASE_URL")!,
+        Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+      );
+
+      // Ensure bucket exists (no-op if already present).
+      await supabase.storage.createBucket("bug-reports", { public: true }).catch(() => {});
+
+      const base64Data = screenshot.split(",")[1];
+      const mimeType = screenshot.split(";")[0].split(":")[1] ?? "image/jpeg";
+      const byteCharacters = atob(base64Data);
+      const byteArray = new Uint8Array(byteCharacters.length);
+      for (let i = 0; i < byteCharacters.length; i++) {
+        byteArray[i] = byteCharacters.charCodeAt(i);
+      }
+
+      const ext = mimeType.split("/")[1]?.replace("jpeg", "jpg") ?? "jpg";
+      const safeName = (screenshotName ?? "screenshot").replace(/[^a-z0-9._-]/gi, "_");
+      const path = `${Date.now()}-${safeName}.${ext}`;
+
+      const { data: uploadData, error: uploadError } = await supabase.storage
+        .from("bug-reports")
+        .upload(path, byteArray, { contentType: mimeType, upsert: false });
+
+      if (!uploadError && uploadData) {
+        const { data: pub } = supabase.storage.from("bug-reports").getPublicUrl(uploadData.path);
+        screenshotUrl = pub.publicUrl;
+      } else if (uploadError) {
+        console.error("Screenshot upload error:", uploadError);
+      }
+    } catch (e) {
+      console.error("Screenshot upload failed:", e);
+      // Non-fatal — continue without screenshot.
+    }
+  }
+
+  const timestamp = new Date().toISOString().replace("T", " ").slice(0, 19) + " UTC";
+  const submitter = submittedBy?.trim() || "Anonymous";
+
+  const body = [
+    "> [!IMPORTANT]",
+    "> **This issue was submitted automatically via the Grimoire in-app bug reporter.**",
+    "> It was **not** filed by a maintainer. Please review before acting on it.",
+    "",
+    "---",
+    "",
+    "### Where in the app",
+    where.trim(),
+    "",
+    "### What the user was doing",
+    action.trim(),
+    "",
+    "### What they expected",
+    expected.trim(),
+    "",
+    "### What actually happened",
+    actual.trim(),
+    "",
+    "### Screenshot",
+    screenshotUrl ? `![Screenshot](${screenshotUrl})` : "*None provided*",
+    "",
+    "---",
+    `*Submitted by: ${submitter} · ${timestamp}*`,
+  ].join("\n");
+
+  const issueTitle = `[App Bug Report] ${where.trim().slice(0, 80)}`;
+
+  const ghResponse = await fetch("https://api.github.com/repos/irongollem/grimoire/issues", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${githubToken}`,
+      "Accept": "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      "User-Agent": "Grimoire-BugReporter/1.0",
+    },
+    body: JSON.stringify({
+      title: issueTitle,
+      body,
+      labels: ["bug", "user-report"],
+    }),
+  });
+
+  if (!ghResponse.ok) {
+    const errText = await ghResponse.text();
+    console.error("GitHub API error:", ghResponse.status, errText);
+    return new Response("Failed to create issue", { status: 502, headers: CORS_HEADERS });
+  }
+
+  const issue = await ghResponse.json() as { number: number; html_url: string };
+
+  return new Response(
+    JSON.stringify({ issueNumber: issue.number, issueUrl: issue.html_url }),
+    { status: 201, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } },
+  );
+});


### PR DESCRIPTION
Users can now report bugs directly from the app without needing a GitHub account. A "Report a Bug" button in the sidebar (desktop) and top bar (mobile) opens a modal collecting where, what, expected vs actual, and an optional screenshot. On submit a Supabase edge function creates a GitHub issue tagged [App Bug Report] with labels `bug` + `user-report` so it's immediately clear the issue came from the system, not a maintainer. Screenshots are compressed client-side then uploaded to Supabase Storage with the public URL embedded in the issue body.

https://claude.ai/code/session_01RC74YQ4yj7yuEuN8opXkV1