### PR TITLE
fix(#168): post-save view-mode + DM level-up modal

### DIFF
--- a/src/components/encounters/EncounterDetail.vue
+++ b/src/components/encounters/EncounterDetail.vue
@@ -57,7 +57,7 @@
           type="button"
           class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 font-cinzel text-xs font-semibold text-foreground hover:border-primary/50 transition-colors"
           :disabled="isSaving"
-          @click="handleSave"
+          @click="handleSaveAndReturn"
         >
           <span v-if="isSaving">Saving…</span>
           <span v-else>Save</span>
@@ -895,6 +895,12 @@ async function handleSave(): Promise<string | null> {
       throw e;
     }
   }
+}
+
+// Save button: save then return to view mode (strip ?edit=true)
+async function handleSaveAndReturn() {
+  const id = await handleSave();
+  if (props.encounter && id) onCancel();
 }
 
 async function handleRunEncounter() {

--- a/src/components/player/PlayerCharacterHeader.vue
+++ b/src/components/player/PlayerCharacterHeader.vue
@@ -50,8 +50,16 @@
               <span class="font-cinzel text-2xs md:text-sm text-muted-foreground">
                 {{ member.experience_points ?? 0 }}<template v-if="xpToNext !== null"> / {{ xpToNext }}</template>
               </span>
+              <!-- DM: emit event (player /play/* routes aren't accessible to DMs) -->
+              <button
+                v-if="readyToLevelUp && auth.isDM"
+                type="button"
+                class="font-cinzel text-2xs md:text-sm text-primary tracking-wider hover:opacity-80 ml-0.5"
+                @click="emit('level-up')"
+              >Ready ↑</button>
+              <!-- Player: link to the level-up flow -->
               <RouterLink
-                v-if="readyToLevelUp && !hidePlayerActions"
+                v-else-if="readyToLevelUp && !hidePlayerActions"
                 :to="`/play/character/levelup?memberId=${member.id}`"
                 class="font-cinzel text-2xs md:text-sm text-primary tracking-wider hover:opacity-80 ml-0.5"
               >Ready ↑</RouterLink>
@@ -170,6 +178,7 @@
 import { ref, computed, nextTick } from "vue";
 import { RouterLink } from "vue-router";
 import { IconStar } from '@/lib/icons';
+import { useAuthStore } from "@/stores/auth";
 import { useUpdatePartyMember } from "@/composables/useParty";
 import { useClassByName } from "@/composables/useCustomClasses";
 import { useCharacterClasses } from "@/composables/useCharacterClasses";
@@ -193,12 +202,14 @@ import FocalImage from "@/components/common/FocalImage.vue";
 import RestButtons from "@/components/player/RestButtons.vue";
 
 const props = defineProps<{ member: PartyMember; wildshape?: WildshapeState; hidePlayerActions?: boolean }>();
+const emit = defineEmits<{ (e: "level-up"): void }>();
 
 const { data: allSpecies } = useAllSpecies();
 const speciesName = computed(() =>
   (allSpecies.value ?? []).find(s => s.id === props.member.species_id)?.name ?? null,
 );
 
+const auth = useAuthStore();
 const { mutateAsync: updateMember } = useUpdatePartyMember();
 const { rollConcentrationSave, endConcentration } = useConcentration();
 

--- a/src/components/quests/QuestEditor.vue
+++ b/src/components/quests/QuestEditor.vue
@@ -1192,7 +1192,9 @@ async function save() {
           campaign.activeCampaignId,
           `📋 Quest shared: "${title.value.trim()}"`,
         );
-      router.push("/quests");
+      // Return to view mode (strip ?edit=true), not the list
+      const { edit: _edit, ...rest } = route.query;
+      router.push({ query: rest });
     } else {
       const created = await create(buildPayload());
       if (playerVisibleTo.value.length > 0 && campaign.activeCampaignId)

--- a/src/views/party/PartyMemberView.vue
+++ b/src/views/party/PartyMemberView.vue
@@ -23,7 +23,11 @@
       </button>
     </div>
 
-    <PlayerCharacterView :member-id="id" hide-player-actions />
+    <PlayerCharacterView
+      :member-id="id"
+      hide-player-actions
+      @level-up="editOpen = true"
+    />
 
     <PartyMemberForm
       v-if="editOpen && member"

--- a/src/views/play/PlayerCharacterView.vue
+++ b/src/views/play/PlayerCharacterView.vue
@@ -29,6 +29,7 @@
             :wildshape="activeWildshape ?? undefined"
             :hide-player-actions="hidePlayerActions"
             class="md:flex-1"
+            @level-up="emit('level-up')"
           />
           <div class="md:w-72 md:shrink-0 md:border-l md:border-border md:bg-card md:flex md:flex-col">
             <!-- Ability scores: vertical single-table, flush against card edges -->
@@ -350,6 +351,7 @@ import PlayerLoreTab from "@/components/player/PlayerLoreTab.vue";
 import { useSpecies } from "@/composables/useSpecies";
 
 const props = defineProps<{ memberId?: string; hidePlayerActions?: boolean }>();
+const emit = defineEmits<{ (e: "level-up"): void }>();
 
 const auth = useAuthStore();
 const ui = useUiStore();


### PR DESCRIPTION
Tail-end follow-ups to issue #168 (sheet/editor split). The original PR also re-implemented the Trap + DungeonFeature sheet/editor split, but that work was already shipped by dc526ca on main — that commit has been dropped during rebase, leaving only the genuinely new changes.

## Summary

- **QuestEditor:** updating an existing quest now strips `?edit=true` and returns to the sheet view instead of pushing to the quest list.
- **EncounterDetail:** new `handleSaveAndReturn()` wraps `handleSave()` and strips `?edit=true`. The Run Encounter / drop-loot paths continue to call `handleSave()` directly because they handle their own routing.
- **PlayerCharacterHeader / PlayerCharacterView / PartyMemberView:** DMs clicking the "Ready ↑" link in the XP bar now emit a `level-up` event that PartyMemberView turns into "open PartyMemberForm modal". Players still navigate to `/play/character/levelup` as before. Reason: `/play/*` routes are player-only, so the old `RouterLink` would bounce DMs to the dashboard.

## Files changed (5)

- `src/components/quests/QuestEditor.vue`
- `src/components/encounters/EncounterDetail.vue`
- `src/components/player/PlayerCharacterHeader.vue`
- `src/views/party/PartyMemberView.vue`
- `src/views/play/PlayerCharacterView.vue`

## Test plan

- [ ] Edit an existing quest → Save → land back on the quest sheet (not the list)
- [ ] Edit an existing encounter → Save → land back on the encounter sheet
- [ ] As DM, open a party member with `readyToLevelUp=true` → click "Ready ↑" → PartyMemberForm opens (does not navigate away)
- [ ] As player, same flow → still navigates to `/play/character/levelup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)