### PR TITLE
feat(multiclass): per-class spell DC/attack + heterogeneous hit dice

### DIFF
--- a/src/components/player/PlayerCharacterHeader.vue
+++ b/src/components/player/PlayerCharacterHeader.vue
@@ -263,6 +263,39 @@ const memberIdRef = computed(() => props.member.id);
 const { data: characterClasses } = useCharacterClasses(memberIdRef);
 
 /**
+ * Hit dice composition by die size. For a single-class character this is
+ * `[{ die: 10, count: 5 }]`. A Fighter 5 / Wizard 3 returns
+ * `[{ die: 10, count: 5 }, { die: 6, count: 3 }]`.
+ */
+const hitDicePool = computed<{ die: number; count: number }[]>(() => {
+  const list = characterClasses.value ?? [];
+  if (list.length === 0) {
+    return [{ die: hitDie.value, count: props.member.level }];
+  }
+  const byDie = new Map<number, number>();
+  for (const c of list) {
+    const d = getHitDie(c.class_name);
+    byDie.set(d, (byDie.get(d) ?? 0) + c.levels);
+  }
+  return Array.from(byDie.entries())
+    .map(([die, count]) => ({ die, count }))
+    .sort((a, b) => b.die - a.die);
+});
+
+/**
+ * Compact label for the HD chip. Single-die shows the bare die size ("d10")
+ * so the count can be read from the chip value. Heterogeneous multiclass
+ * shows the full pool ("5d10+3d6") since one count no longer tells the
+ * full story. Spend tracking remains a single counter — proper per-die
+ * spend is a follow-up once the rest dialog is multiclass-aware.
+ */
+const hitDicePoolLabel = computed(() => {
+  const pool = hitDicePool.value;
+  if (pool.length <= 1) return `d${pool[0]?.die ?? hitDie.value}`;
+  return pool.map((p) => `${p.count}d${p.die}`).join("+");
+});
+
+/**
  * Total character level. Sum of `character_classes` rows if populated;
  * otherwise falls back to the legacy single `party_members.level`.
  */
@@ -300,7 +333,7 @@ const combatStats = computed(() => [
   { label: "SPD",  value: props.member.speed, suffix: "ft" },
   { label: "INIT", value: abilityModifier(props.member.dex), suffix: "" },
   { label: "PROF", value: `+${props.member.proficiency_bonus}`, suffix: "" },
-  { label: "HD",   value: `${hitDiceRemaining.value}/${memberTotalLevel.value}`, suffix: `d${hitDie.value}` },
+  { label: "HD",   value: `${hitDiceRemaining.value}/${memberTotalLevel.value}`, suffix: hitDicePoolLabel.value },
 ]);
 
 const hpPct = computed(() => {

--- a/src/components/spells/PlayerMySpells.vue
+++ b/src/components/spells/PlayerMySpells.vue
@@ -113,15 +113,15 @@
               class="shrink-0 font-cinzel text-[10px] tracking-wider text-primary/70 border border-primary/30 rounded px-1"
             >C</span>
 
-            <!-- Attack / save info -->
+            <!-- Attack / save info (multiclass-aware via source class) -->
             <span
-              v-if="isCastable(entry) && spellAttackBonus !== null && (entry.spell.attack_type === 'ranged_spell' || entry.spell.attack_type === 'melee_spell')"
+              v-if="isCastable(entry) && attackBonusFor(entry) !== null && (entry.spell.attack_type === 'ranged_spell' || entry.spell.attack_type === 'melee_spell')"
               class="shrink-0 font-cinzel text-[10px] text-muted-foreground"
-            >Atk {{ signedNum(spellAttackBonus) }}</span>
+            >Atk {{ signedNum(attackBonusFor(entry)!) }}</span>
             <span
-              v-else-if="isCastable(entry) && spellSaveDc !== null && entry.spell.attack_type === 'save'"
+              v-else-if="isCastable(entry) && saveDcFor(entry) !== null && entry.spell.attack_type === 'save'"
               class="shrink-0 font-cinzel text-[10px] text-muted-foreground"
-            >DC {{ spellSaveDc }}</span>
+            >DC {{ saveDcFor(entry) }}</span>
 
             <!-- Cast button (castable spells) -->
             <button
@@ -256,6 +256,7 @@ import { usePromptedRoll } from "@/composables/usePromptedRoll";
 import { cantripDiceMultiplier } from "@/types/spell.types";
 import type { CasterType, CharacterSpellEntry, Spell } from "@/types/spell.types";
 import type { SpellSlotEntry } from "@/types/party.types";
+import { pickSpellcastingStats, type SpellcastingClassStats } from "@/types/multiclass.types";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import PlayerSpellModal from "@/components/spells/PlayerSpellModal.vue";
 
@@ -269,6 +270,13 @@ const props = defineProps<{
   spellSlots: SpellSlotEntry[];
   spellAttackBonus: number | null;
   spellSaveDc: number | null;
+  /**
+   * Per-class spellcasting stats. Each spell entry picks the stats for its
+   * source class via `source_class_id` (falling back to the first entry).
+   * Empty array → fall back to the single-class spellAttackBonus / spellSaveDc
+   * props.
+   */
+  spellcastingByClass?: SpellcastingClassStats[];
   /**
    * "spellbook" — show all character_spells (Wizard spellbook tab + Known tab for known casters)
    * "prepared"  — show only is_prepared = true (Wizard/Cleric/etc. prepared tab)
@@ -317,6 +325,19 @@ async function togglePip(level: number, pip: number) {
     return { ...s, used: newUsed };
   });
   await updateMember({ id: props.partyMemberId, update: { spell_slots: updated } });
+}
+
+// ── Multiclass-aware stat lookup ───────────────────────────────────────────────
+
+/** Pick the spellcasting stats for a spell entry, matching on source_class_id. */
+function statsFor(entry: CharacterSpellEntry): SpellcastingClassStats | null {
+  return pickSpellcastingStats(props.spellcastingByClass ?? [], entry.source_class_id);
+}
+function attackBonusFor(entry: CharacterSpellEntry): number | null {
+  return statsFor(entry)?.attack ?? props.spellAttackBonus;
+}
+function saveDcFor(entry: CharacterSpellEntry): number | null {
+  return statsFor(entry)?.dc ?? props.spellSaveDc;
 }
 
 // ── Cast ───────────────────────────────────────────────────────────────────────
@@ -429,11 +450,13 @@ async function castSpell(entry: CharacterSpellEntry, castLevel: number) {
     // Flavor text
     let text = `casts ${spell.name}`;
     if (extraLevels > 0) text += ` (upcast ${SLOT_LEVEL_LABELS[castLevel - 1]})`;
-    if (castLevel > 0 && props.spellAttackBonus !== null
+    const atk = attackBonusFor(entry);
+    const dc  = saveDcFor(entry);
+    if (castLevel > 0 && atk !== null
       && (spell.attack_type === "ranged_spell" || spell.attack_type === "melee_spell")) {
-      text += ` — Atk ${signedNum(props.spellAttackBonus)}`;
-    } else if (castLevel > 0 && props.spellSaveDc !== null && spell.attack_type === "save") {
-      text += ` — DC ${props.spellSaveDc} ${spell.save_attribute ?? ""}`;
+      text += ` — Atk ${signedNum(atk)}`;
+    } else if (castLevel > 0 && dc !== null && spell.attack_type === "save") {
+      text += ` — DC ${dc} ${spell.save_attribute ?? ""}`;
     }
     await sendFlavorMessage(text, "spell");
 

--- a/src/types/multiclass.types.ts
+++ b/src/types/multiclass.types.ts
@@ -100,3 +100,64 @@ export function totalLevel(classes: CharacterClass[]): number {
 export function primaryClass(classes: CharacterClass[]): CharacterClass | null {
   return classes.find((c) => c.is_primary) ?? classes[0] ?? null;
 }
+
+import { getCastingAbility } from "@/types/spell.types";
+
+/**
+ * Per-class spellcasting stats (DC and attack bonus). A multiclass character
+ * has one entry per casting class — e.g. a Paladin 3 / Wizard 5 casts Paladin
+ * spells off CHA and Wizard spells off INT, so each spell uses its own
+ * class's DC.
+ */
+export interface SpellcastingClassStats {
+  /** character_classes row id — matches character_spells.source_class_id */
+  classId: string;
+  className: string;
+  castingAbility: "int" | "wis" | "cha";
+  dc: number;
+  attack: number;
+}
+
+/**
+ * Compute per-class spell DC and attack bonus from a character's ability
+ * scores + classes. Non-casters are omitted. Proficiency bonus comes from
+ * the character (single value, shared across classes per 5e RAW).
+ */
+export function computeSpellcastingPerClass(
+  member: AbilityScores & { proficiency_bonus: number },
+  classes: CharacterClass[],
+): SpellcastingClassStats[] {
+  const out: SpellcastingClassStats[] = [];
+  for (const c of classes) {
+    const ability = getCastingAbility(c.class_name);
+    if (!ability) continue;
+    const mod = Math.floor((member[ability] - 10) / 2);
+    const attack = member.proficiency_bonus + mod;
+    out.push({
+      classId: c.id,
+      className: c.class_name,
+      castingAbility: ability,
+      attack,
+      dc: 8 + attack,
+    });
+  }
+  return out;
+}
+
+/**
+ * Resolve the right stats row for a spell entry. Matches by `sourceClassId`
+ * (the `character_spells.source_class_id` FK); falls back to the first entry
+ * for legacy rows that have no source class. Returns null when the array is
+ * empty — callers should then fall back to single-class numbers.
+ */
+export function pickSpellcastingStats(
+  entries: SpellcastingClassStats[],
+  sourceClassId: string | null | undefined,
+): SpellcastingClassStats | null {
+  if (entries.length === 0) return null;
+  if (sourceClassId) {
+    const hit = entries.find((e) => e.classId === sourceClassId);
+    if (hit) return hit;
+  }
+  return entries[0] ?? null;
+}

--- a/src/views/play/PlayerSpellsView.vue
+++ b/src/views/play/PlayerSpellsView.vue
@@ -31,6 +31,7 @@
       :spell-slots="effectiveSpellSlots"
       :spell-attack-bonus="spellAttackBonus"
       :spell-save-dc="spellSaveDc"
+      :spellcasting-by-class="spellcastingByClass"
       :max-prepared="maxPrepared"
       :member-level="memberLevel"
       view-mode="prepared"
@@ -46,6 +47,7 @@
       :spell-slots="effectiveSpellSlots"
       :spell-attack-bonus="spellAttackBonus"
       :spell-save-dc="spellSaveDc"
+      :spellcasting-by-class="spellcastingByClass"
       :max-prepared="maxPrepared"
       view-mode="spellbook"
     />
@@ -154,6 +156,7 @@ import type { Spell } from "@/types/spell.types";
 import { SPELL_SCHOOLS, SPELL_CLASSES, getCasterType, computeMaxPrepared, getDefaultSpellSlots, getMulticlassSpellSlots } from "@/types/spell.types";
 import { useCharacterClasses } from "@/composables/useCharacterClasses";
 import { useClassByName } from "@/composables/useCustomClasses";
+import { computeSpellcastingPerClass } from "@/types/multiclass.types";
 
 const addInnateOpen = ref(false);
 
@@ -225,6 +228,18 @@ const spellAttackBonus = computed(() => {
 const spellSaveDc = computed(() => {
   const bonus = spellAttackBonus.value;
   return bonus !== null ? 8 + bonus : null;
+});
+
+// Per-class spell DC / attack for multiclass casters. PlayerMySpells picks
+// the right row for each spell entry via source_class_id. Empty for single-
+// class characters — the legacy spellAttackBonus / spellSaveDc props remain
+// the source of truth in that case.
+const spellcastingByClass = computed(() => {
+  const m = member.value;
+  if (!m) return [];
+  const list = characterClasses.value ?? [];
+  if (list.length === 0) return [];
+  return computeSpellcastingPerClass(m, list);
 });
 
 // Character spells — IDs used for button state in browse tab


### PR DESCRIPTION
Resurrects the work from the abandoned `claude/multiclassing-spell-slots` branch (which was 352 commits behind `main` and pre-dated the move of the spell UI from `PlayerCharacterView` to `PlayerSpellsView`). Re-implemented against current `main`.

## Summary

**Per-class spell DC / attack.** A Paladin 3 / Wizard 5 currently sees every spell at one DC, regardless of which class granted it. After this change each spell on the player sheet derives its Atk / DC from its own class via `character_spells.source_class_id` (FK already shipped):

- New `computeSpellcastingPerClass(member, classes)` returns one `SpellcastingClassStats` row per casting class.
- New `pickSpellcastingStats(entries, sourceClassId)` resolves the right row for an individual spell entry.
- `PlayerSpellsView` computes `spellcastingByClass` once and passes it to both Prepared and Spellbook/Known `PlayerMySpells` instances.
- `PlayerMySpells` renders the per-class Atk / DC badge, and the cast-flavor message uses the same per-class numbers.
- Falls back to the existing single-class `spellAttackBonus` / `spellSaveDc` props for entries with no `source_class_id` (legacy / DM-created) and for single-class characters (empty array, no override).

**Heterogeneous hit dice pool.** The HD chip on the header shows:
- single-die: `d10` (unchanged, with the count read from the chip value)
- multiclass: `5d10+3d6` — each die type visible at a glance

Spend tracking remains a single counter; per-die spend is a follow-up once the rest dialog is multiclass-aware (called out in the original commit message and still true).

## Files changed (4)

- `src/types/multiclass.types.ts` — `SpellcastingClassStats`, `computeSpellcastingPerClass`, `pickSpellcastingStats`
- `src/views/play/PlayerSpellsView.vue` — wire `spellcastingByClass` computed
- `src/components/spells/PlayerMySpells.vue` — accept `spellcastingByClass` prop, use `attackBonusFor` / `saveDcFor` in both the badge and the cast flavor
- `src/components/player/PlayerCharacterHeader.vue` — `hitDicePool` + `hitDicePoolLabel` computeds, HD chip suffix

`PlayerInnateSpells` is intentionally untouched — innate spells (racial / feat / item) aren't class-sourced.

## Test plan

- [ ] Single-class Cleric: Spells page DCs unchanged; HD chip still shows `d8`
- [ ] Multiclass Paladin (CHA) / Wizard (INT): Paladin spells show CHA-based DC, Wizard spells show INT-based DC
- [ ] Cast a Paladin spell on the Wizard multiclass → flavor message contains the Paladin DC
- [ ] Mixed-die multiclass (Paladin / Wizard): HD chip shows e.g. `3d10+5d6`
- [ ] Legacy spell rows without `source_class_id` still render (falling back to first class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)