### PR TITLE
Add Patreon membership as a subscription option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,12 @@ STRIPE_SECRET_KEY=sk_test_...
 # Set after running: npm run stripe:setup
 STRIPE_PRO_MONTHLY_PRICE_ID=price_...
 STRIPE_PRO_ANNUAL_PRICE_ID=price_...
+
+# Patreon OAuth — these go to Supabase secrets, NOT Vercel
+# Create an app at https://www.patreon.com/portal/registration/register-clients
+# Redirect URI must be: {SUPABASE_URL}/functions/v1/patreon-oauth-callback
+PATREON_CLIENT_ID=your-client-id
+PATREON_CLIENT_SECRET=your-client-secret
+PATREON_REDIRECT_URI=https://your-project.supabase.co/functions/v1/patreon-oauth-callback
+# Webhook secret from Patreon developer portal (Webhooks tab)
+PATREON_WEBHOOK_SECRET=your-webhook-secret

--- a/src/composables/usePatreon.ts
+++ b/src/composables/usePatreon.ts
@@ -1,0 +1,87 @@
+import { ref, computed } from "vue";
+import { useQuery, useQueryClient } from "@tanstack/vue-query";
+import { supabase } from "@/lib/supabase";
+import { useAuthStore } from "@/stores/auth";
+import type { PatreonConnection } from "@/types/subscription.types";
+
+async function fetchConnection(): Promise<PatreonConnection | null> {
+  const { data } = await supabase
+    .from("patreon_connections")
+    .select("user_id, patreon_user_id, patreon_email, full_name, token_expires_at, created_at, updated_at")
+    .maybeSingle();
+  return data as PatreonConnection | null;
+}
+
+export function usePatreon() {
+  const auth = useAuthStore();
+  const queryClient = useQueryClient();
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  const { data: connection, isLoading } = useQuery({
+    queryKey: ["patreon-connection"],
+    queryFn: fetchConnection,
+    staleTime: 60_000,
+    enabled: computed(() => !!auth.user),
+  });
+
+  const isLinked = computed(() => !!connection.value);
+
+  async function startOAuth() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error("Not authenticated");
+
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/patreon-link-url`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        },
+      );
+      const json = await res.json();
+      if (!res.ok || !json.url) throw new Error(json.error ?? "Failed to get Patreon URL");
+      window.location.href = json.url;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : "Something went wrong";
+      loading.value = false;
+    }
+  }
+
+  async function disconnect() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const { error: dbErr } = await supabase
+        .from("patreon_connections")
+        .delete()
+        .eq("user_id", auth.user!.id);
+      if (dbErr) throw dbErr;
+
+      // Revert subscription to free if still on Patreon billing
+      const { data: sub } = await supabase
+        .from("user_subscriptions")
+        .select("subscription_provider")
+        .maybeSingle();
+      if (sub?.subscription_provider === "patreon") {
+        await supabase.from("user_subscriptions").update({
+          plan_id: "free",
+          status: "active",
+          subscription_provider: "stripe",
+          patreon_member_id: null,
+        }).eq("user_id", auth.user!.id);
+      }
+
+      queryClient.invalidateQueries({ queryKey: ["patreon-connection"] });
+      queryClient.invalidateQueries({ queryKey: ["subscription"] });
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : "Something went wrong";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return { connection, isLinked, isLoading, loading, error, startOAuth, disconnect };
+}

--- a/src/composables/useSubscription.ts
+++ b/src/composables/useSubscription.ts
@@ -27,15 +27,27 @@ export function useSubscription() {
     const sub = data.value;
     return (
       !!sub &&
-      (sub.plan_id === "pro" || sub.plan_id === "tester") &&
+      (sub.plan_id === "pro" || sub.plan_id === "tester" || sub.plan_id === "patron") &&
       ["active", "trialing"].includes(sub.status)
     );
   });
+
+  const isPatron = computed(() => {
+    const sub = data.value;
+    return (
+      !!sub &&
+      sub.plan_id === "patron" &&
+      sub.subscription_provider === "patreon" &&
+      ["active", "trialing"].includes(sub.status)
+    );
+  });
+
+  const isPatronBilling = computed(() => data.value?.subscription_provider === "patreon");
 
   const isPendingCancellation = computed(() => {
     const sub = data.value;
     return !!sub?.cancel_at_period_end && !!sub.cancel_at;
   });
 
-  return { subscription: data, isPro, isPendingCancellation, isLoading };
+  return { subscription: data, isPro, isPatron, isPatronBilling, isPendingCancellation, isLoading };
 }

--- a/src/types/subscription.types.ts
+++ b/src/types/subscription.types.ts
@@ -1,4 +1,6 @@
-export type PlanId = 'free' | 'tester' | 'pro'
+export type PlanId = 'free' | 'tester' | 'pro' | 'patron'
+
+export type SubscriptionProvider = 'stripe' | 'patreon'
 
 export type SubscriptionStatus = 'active' | 'trialing' | 'past_due' | 'cancelled'
 
@@ -19,6 +21,7 @@ export interface Plan {
   stripe_annual_currency_options: Record<string, { unit_amount: number }> | null
   prices: Record<string, PlanPrice>
   quotas: Partial<Record<QuotaResource, number>>
+  patreon_tier_ids: string[]
 }
 
 export type QuotaResource =
@@ -42,11 +45,23 @@ export interface UserSubscription {
   user_id: string
   plan_id: PlanId
   status: SubscriptionStatus
+  subscription_provider: SubscriptionProvider
   stripe_customer_id: string | null
   stripe_subscription_id: string | null
+  patreon_member_id: string | null
   current_period_end: string | null
   cancel_at_period_end: boolean
   cancel_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface PatreonConnection {
+  user_id: string
+  patreon_user_id: string
+  patreon_email: string | null
+  full_name: string | null
+  token_expires_at: string
   created_at: string
   updated_at: string
 }

--- a/src/views/BillingView.vue
+++ b/src/views/BillingView.vue
@@ -2,6 +2,22 @@
   <div class="max-w-2xl mx-auto px-4 py-8 space-y-6">
     <PageHeader title="Billing & Subscription" />
 
+    <!-- Patreon connected success banner -->
+    <div
+      v-if="patreonConnected"
+      class="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 flex items-center gap-3"
+    >
+      <span class="font-fell text-sm text-green-400">Patreon connected! Your patron benefits are now active.</span>
+    </div>
+
+    <!-- Patreon callback error banner -->
+    <div
+      v-if="patreonError"
+      class="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 flex items-center gap-3"
+    >
+      <span class="font-fell text-sm text-red-400">{{ patreonError }}</span>
+    </div>
+
     <!-- Credit purchase success banner -->
     <div
       v-if="creditPurchaseSuccess"
@@ -29,13 +45,13 @@
 
       <template v-else>
         <div class="flex items-center gap-3">
-          <IconDM v-if="isPro" class="h-5 w-5 text-amber-400 shrink-0" />
+          <IconDM v-if="isPro" class="h-5 w-5 shrink-0" :class="isPatron ? 'text-[#f96854]' : 'text-amber-400'" />
           <IconQuest v-else class="h-5 w-5 text-muted-foreground shrink-0" />
           <span
             class="font-cinzel text-lg font-bold"
-            :class="isPro ? 'text-amber-400' : 'text-foreground'"
+            :class="isPatron ? 'text-[#f96854]' : isPro ? 'text-amber-400' : 'text-foreground'"
           >
-            {{ isPro ? "Pro DM" : "Free DM" }}
+            {{ isPatron ? "Patron DM" : isPro ? "Pro DM" : "Free DM" }}
           </span>
           <span
             v-if="subscription"
@@ -105,6 +121,91 @@
           Manage billing
         </button>
       </template>
+    </div>
+
+    <!-- Patreon connection card -->
+    <div class="rounded-xl border border-border bg-card p-6 space-y-4">
+      <div class="flex items-center gap-2">
+        <svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="currentColor" style="color: #f96854;">
+          <path d="M14.82 2.41C11.58 2.41 8.96 5.03 8.96 8.28c0 3.24 2.62 5.87 5.86 5.87 3.23 0 5.86-2.63 5.86-5.87 0-3.25-2.63-5.87-5.86-5.87zM3.18 21.59h3.64V2.41H3.18v19.18z"/>
+        </svg>
+        <h2 class="font-cinzel text-sm font-bold text-foreground tracking-wide">
+          Patreon
+        </h2>
+      </div>
+
+      <div v-if="patreonLoading" class="flex items-center gap-2 text-muted-foreground">
+        <IconLoading class="h-4 w-4 animate-spin" />
+        <span class="font-fell text-sm italic">Loading…</span>
+      </div>
+
+      <template v-else-if="isPatronLinked">
+        <!-- Connected state -->
+        <div class="flex items-center gap-2">
+          <span class="h-2 w-2 rounded-full bg-green-400 shrink-0" />
+          <span class="font-fell text-sm text-foreground">
+            Connected{{ patreonConnection?.full_name ? ` as ${patreonConnection.full_name}` : '' }}
+          </span>
+          <span v-if="isPatron" class="ml-1 px-2 py-0.5 rounded-full font-cinzel text-[10px] font-semibold tracking-wider uppercase bg-[#f96854]/15 text-[#f96854]">
+            Patron active
+          </span>
+        </div>
+
+        <p v-if="isPatron" class="font-fell text-xs text-muted-foreground italic leading-relaxed">
+          Your Patreon membership is active — thank you for your support! You have access to all Patron features including monthly content drops.
+        </p>
+        <p v-else class="font-fell text-xs text-muted-foreground italic leading-relaxed">
+          Your Patreon account is linked but no active membership was found. Become a patron to unlock Patron features.
+        </p>
+
+        <button
+          class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-border text-xs font-cinzel font-semibold tracking-wider text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors disabled:opacity-60"
+          :disabled="patreonActionLoading"
+          @click="disconnectPatreon"
+        >
+          <IconLoading v-if="patreonActionLoading" class="h-3 w-3 animate-spin" />
+          Disconnect Patreon
+        </button>
+      </template>
+
+      <template v-else>
+        <!-- Unlinked state -->
+        <p class="font-fell text-xs text-muted-foreground italic leading-relaxed">
+          Support us on Patreon to unlock Patron-exclusive features and monthly content drops. Link your account to activate your benefits automatically.
+        </p>
+        <button
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-cinzel text-xs font-semibold tracking-wider text-white transition-colors disabled:opacity-60"
+          style="background-color: #f96854;"
+          :disabled="patreonActionLoading"
+          @click="linkPatreon"
+        >
+          <IconLoading v-if="patreonActionLoading" class="h-3.5 w-3.5 animate-spin" />
+          Connect Patreon
+        </button>
+      </template>
+
+      <p v-if="patreonActionError" class="font-fell text-xs text-red-400 italic">{{ patreonActionError }}</p>
+    </div>
+
+    <!-- Patreon → Stripe swap CTA -->
+    <div
+      v-if="!isLoading && isPatron && isPatronBilling"
+      class="rounded-xl border border-border bg-card p-6 space-y-3"
+    >
+      <h2 class="font-cinzel text-sm font-bold text-foreground tracking-wide">
+        Switch to direct billing
+      </h2>
+      <p class="font-fell text-xs text-muted-foreground italic leading-relaxed">
+        Prefer to pay directly? Switching to Stripe removes the Patreon platform fee, meaning more of your money goes to development. You can cancel your Patreon pledge after switching.
+      </p>
+      <button
+        class="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-amber-500/50 text-sm font-cinzel font-semibold tracking-wider text-amber-400 hover:bg-amber-500/10 transition-colors disabled:opacity-60"
+        :disabled="stripeLoading"
+        @click="createCheckoutSession('month')"
+      >
+        <IconLoading v-if="stripeLoading" class="h-3.5 w-3.5 animate-spin" />
+        Switch to direct billing
+      </button>
     </div>
 
     <!-- Upgrade CTA (free / lapsed users) -->
@@ -328,6 +429,7 @@ import { useStripe } from "@/composables/useStripe";
 import { useAiCredits } from "@/composables/useAiCredits";
 import { usePlan } from "@/composables/usePlan";
 import { useQuota } from "@/composables/useQuota";
+import { usePatreon } from "@/composables/usePatreon";
 import { QUOTA_RESOURCE_LABELS } from "@/types/subscription.types";
 import type { QuotaResource } from "@/types/subscription.types";
 import { useCreditPacks } from "@/composables/useCreditConfig";
@@ -335,8 +437,24 @@ import { detectCurrency, resolveAmount, availableCurrencies, formatCents } from 
 
 const route = useRoute();
 const creditPurchaseSuccess = computed(() => route.query.credit_purchase === "success");
+const patreonConnected = computed(() => route.query.patreon === "connected");
+const patreonError = computed(() => {
+  if (route.query.patreon === "error") return "Failed to connect Patreon. Please try again.";
+  if (route.query.patreon === "cancelled") return null;
+  return null;
+});
 
-const { subscription, isPro, isPendingCancellation, isLoading } = useSubscription();
+const { subscription, isPro, isPatron, isPatronBilling, isPendingCancellation, isLoading } = useSubscription();
+
+const {
+  connection: patreonConnection,
+  isLinked: isPatronLinked,
+  isLoading: patreonLoading,
+  loading: patreonActionLoading,
+  error: patreonActionError,
+  startOAuth: linkPatreon,
+  disconnect: disconnectPatreon,
+} = usePatreon();
 const {
   loading: stripeLoading,
   createCheckoutSession,

--- a/supabase/functions/patreon-link-url/index.ts
+++ b/supabase/functions/patreon-link-url/index.ts
@@ -1,0 +1,52 @@
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return json({ error: "Missing authorization" }, 401);
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) return json({ error: "Unauthorized" }, 401);
+
+    const clientId = Deno.env.get("PATREON_CLIENT_ID");
+    const redirectUri = Deno.env.get("PATREON_REDIRECT_URI");
+    if (!clientId || !redirectUri) {
+      return json({ error: "Patreon not configured" }, 500);
+    }
+
+    // Pass the raw JWT as state so the callback can verify identity
+    const jwt = authHeader.replace(/^Bearer\s+/i, "");
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      scope: "identity identity[email] memberships",
+      state: jwt,
+    });
+
+    return json({ url: `https://www.patreon.com/oauth2/authorize?${params}` });
+  } catch (err) {
+    console.error("patreon-link-url:", err);
+    return json({ error: "Internal server error" }, 500);
+  }
+});

--- a/supabase/functions/patreon-oauth-callback/index.ts
+++ b/supabase/functions/patreon-oauth-callback/index.ts
@@ -1,0 +1,167 @@
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const admin = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+);
+
+const APP_URL = Deno.env.get("APP_URL") ?? "https://dungeongrimoire.com";
+
+interface PatreonTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+interface PatreonMembership {
+  id: string;
+  attributes: {
+    patron_status: string | null;
+  };
+  relationships?: {
+    currently_entitled_tiers?: {
+      data: Array<{ id: string; type: string }>;
+    };
+  };
+}
+
+interface PatreonIdentity {
+  data: {
+    id: string;
+    attributes: {
+      email: string;
+      full_name: string;
+    };
+  };
+  included?: PatreonMembership[];
+}
+
+async function exchangeCode(code: string, redirectUri: string): Promise<PatreonTokenResponse> {
+  const res = await fetch("https://www.patreon.com/api/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      grant_type: "authorization_code",
+      client_id: Deno.env.get("PATREON_CLIENT_ID")!,
+      client_secret: Deno.env.get("PATREON_CLIENT_SECRET")!,
+      redirect_uri: redirectUri,
+    }),
+  });
+  if (!res.ok) throw new Error(`Patreon token exchange failed: ${await res.text()}`);
+  return res.json();
+}
+
+async function fetchIdentity(accessToken: string): Promise<PatreonIdentity> {
+  const res = await fetch(
+    "https://www.patreon.com/api/oauth2/v2/identity" +
+      "?fields[user]=email,full_name" +
+      "&include=memberships,memberships.currently_entitled_tiers" +
+      "&fields[member]=patron_status",
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (!res.ok) throw new Error(`Patreon identity fetch failed: ${await res.text()}`);
+  return res.json();
+}
+
+// Resolve which plan_id a set of entitled tier IDs maps to.
+// Returns 'patron' if any tier matches; null if not a patron of a known tier.
+async function resolvePlanForTiers(tierIds: string[]): Promise<string | null> {
+  if (tierIds.length === 0) return null;
+  const { data: plans } = await admin
+    .from("plans")
+    .select("id, patreon_tier_ids")
+    .neq("id", "free");
+
+  for (const plan of plans ?? []) {
+    const mapped: string[] = plan.patreon_tier_ids ?? [];
+    if (tierIds.some(t => mapped.includes(t))) return plan.id;
+  }
+  // Any paid patron defaults to patron plan even if tiers aren't mapped yet
+  return "patron";
+}
+
+serve(async (req: Request) => {
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state"); // JWT
+  const error = url.searchParams.get("error");
+
+  const redirect = (path: string) =>
+    new Response(null, { status: 302, headers: { Location: `${APP_URL}${path}` } });
+
+  if (error || !code || !state) {
+    return redirect("/billing?patreon=cancelled");
+  }
+
+  try {
+    // Verify the JWT to identify the user
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: `Bearer ${state}` } } },
+    );
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) return redirect("/billing?patreon=error&reason=auth");
+
+    const redirectUri = Deno.env.get("PATREON_REDIRECT_URI")!;
+    const tokens = await exchangeCode(code, redirectUri);
+    const identity = await fetchIdentity(tokens.access_token);
+
+    const patreonUserId = identity.data.id;
+    const patreonEmail = identity.data.attributes.email ?? null;
+    const fullName = identity.data.attributes.full_name ?? null;
+    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+
+    // Collect entitled tier IDs from the membership includes
+    const memberships: PatreonMembership[] = (identity.included ?? []).filter(
+      (i): i is PatreonMembership => (i as PatreonMembership).attributes?.patron_status !== undefined,
+    );
+    const isActiveMember = memberships.some(
+      m => m.attributes.patron_status === "active_patron",
+    );
+    const entitledTierIds = memberships.flatMap(
+      m => m.relationships?.currently_entitled_tiers?.data.map(t => t.id) ?? [],
+    );
+
+    // Upsert connection record
+    await admin.from("patreon_connections").upsert({
+      user_id: user.id,
+      patreon_user_id: patreonUserId,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      token_expires_at: expiresAt,
+      patreon_email: patreonEmail,
+      full_name: fullName,
+    }, { onConflict: "user_id" });
+
+    if (isActiveMember) {
+      const planId = await resolvePlanForTiers(entitledTierIds);
+      if (planId) {
+        // Only upgrade to patron plan if user isn't already on Stripe
+        const { data: sub } = await admin
+          .from("user_subscriptions")
+          .select("subscription_provider, plan_id")
+          .eq("user_id", user.id)
+          .single();
+
+        if (!sub || sub.subscription_provider !== "stripe" || sub.plan_id === "free") {
+          await admin.from("user_subscriptions").upsert({
+            user_id: user.id,
+            plan_id: planId,
+            status: "active",
+            subscription_provider: "patreon",
+            patreon_member_id: `${patreonUserId}`,
+          }, { onConflict: "user_id" });
+        }
+      }
+    }
+
+    return redirect("/billing?patreon=connected");
+  } catch (err) {
+    console.error("patreon-oauth-callback:", err);
+    return redirect("/billing?patreon=error&reason=server");
+  }
+});

--- a/supabase/functions/patreon-webhook/index.ts
+++ b/supabase/functions/patreon-webhook/index.ts
@@ -1,0 +1,110 @@
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const admin = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+);
+
+async function verifySignature(req: Request, body: string): Promise<boolean> {
+  const secret = Deno.env.get("PATREON_WEBHOOK_SECRET");
+  if (!secret) return false;
+  const sig = req.headers.get("x-patreon-signature");
+  if (!sig) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  const expected = Array.from(new Uint8Array(mac))
+    .map(b => b.toString(16).padStart(2, "0"))
+    .join("");
+  return sig === expected;
+}
+
+// Resolve which plan a set of entitled tier IDs maps to
+async function resolvePlan(tierIds: string[]): Promise<string> {
+  if (tierIds.length > 0) {
+    const { data: plans } = await admin
+      .from("plans")
+      .select("id, patreon_tier_ids")
+      .neq("id", "free");
+    for (const plan of plans ?? []) {
+      const mapped: string[] = plan.patreon_tier_ids ?? [];
+      if (tierIds.some(t => mapped.includes(t))) return plan.id;
+    }
+  }
+  return "patron";
+}
+
+serve(async (req: Request) => {
+  const body = await req.text();
+  const ok = () => new Response("ok", { status: 200 });
+  const fail = (msg: string, status = 400) => new Response(msg, { status });
+
+  if (req.method !== "POST") return fail("Method not allowed", 405);
+
+  const valid = await verifySignature(req, body);
+  if (!valid) return fail("Invalid signature", 401);
+
+  const event = req.headers.get("x-patreon-event") ?? "";
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return fail("Invalid JSON");
+  }
+
+  const data = payload.data as Record<string, unknown> | undefined;
+  if (!data) return ok();
+
+  const memberId = (data.id as string | undefined) ?? "";
+  const attributes = (data.attributes as Record<string, unknown>) ?? {};
+  const relationships = (data.relationships as Record<string, unknown>) ?? {};
+  const patronStatus = attributes.patron_status as string | null;
+
+  // Collect entitled tier IDs from relationships
+  const tiersData = (
+    (relationships.currently_entitled_tiers as Record<string, unknown>)?.data as Array<{ id: string }> | undefined
+  ) ?? [];
+  const tierIds = tiersData.map(t => t.id);
+
+  // Look up which user has this Patreon member ID
+  const { data: sub } = await admin
+    .from("user_subscriptions")
+    .select("user_id, subscription_provider")
+    .eq("patreon_member_id", memberId)
+    .maybeSingle();
+
+  if (event === "members:pledge:create" || event === "members:pledge:update") {
+    if (!sub) return ok(); // unknown member — they'll link via OAuth
+
+    // Don't override an active Stripe subscription
+    if (sub.subscription_provider === "stripe") return ok();
+
+    const planId = await resolvePlan(tierIds);
+    const isActive = patronStatus === "active_patron";
+
+    await admin.from("user_subscriptions").update({
+      plan_id: isActive ? planId : "free",
+      status: isActive ? "active" : "cancelled",
+      subscription_provider: "patreon",
+      patreon_member_id: memberId,
+    }).eq("user_id", sub.user_id);
+  } else if (event === "members:pledge:delete") {
+    if (!sub || sub.subscription_provider === "stripe") return ok();
+
+    await admin.from("user_subscriptions").update({
+      plan_id: "free",
+      status: "active",
+      subscription_provider: "stripe",
+      patreon_member_id: null,
+    }).eq("user_id", sub.user_id);
+  }
+
+  return ok();
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -119,9 +119,11 @@ serve(async (req: Request) => {
           const sub = await stripe.subscriptions.retrieve(
             session.subscription as string,
           );
+          // subscription_provider switches to stripe here — handles Patreon→Stripe migration
           await updateByCustomer(session.customer as string, {
             plan_id: "pro",
             status: "active",
+            subscription_provider: "stripe",
             stripe_subscription_id: sub.id,
             current_period_end: toIso(sub.current_period_end),
             cancel_at_period_end: false,

--- a/supabase/migrations/20260513000001_patron_plan.sql
+++ b/supabase/migrations/20260513000001_patron_plan.sql
@@ -1,0 +1,17 @@
+-- Migration: patron_plan
+-- Adds the patron plan, subscription provider tracking, and patreon_tier_ids to plans
+
+-- Patron plan row (quotas null = unlimited, same as pro)
+insert into plans (id, name, quotas)
+values ('patron', 'Patron', '{}')
+on conflict (id) do nothing;
+
+-- Track which Patreon tier IDs map to this plan (admin configurable)
+alter table plans
+  add column if not exists patreon_tier_ids jsonb default '[]'::jsonb;
+
+-- Track which provider manages this subscription
+alter table user_subscriptions
+  add column if not exists subscription_provider text not null default 'stripe'
+    check (subscription_provider in ('stripe', 'patreon')),
+  add column if not exists patreon_member_id text unique;

--- a/supabase/migrations/20260513000002_patreon_connections.sql
+++ b/supabase/migrations/20260513000002_patreon_connections.sql
@@ -1,0 +1,26 @@
+-- Migration: patreon_connections
+-- Stores OAuth tokens for users who link their Patreon account
+
+create table patreon_connections (
+  user_id          uuid primary key references auth.users(id) on delete cascade,
+  patreon_user_id  text not null unique,
+  access_token     text not null,
+  refresh_token    text not null,
+  token_expires_at timestamptz not null,
+  patreon_email    text,
+  full_name        text,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+create trigger patreon_connections_updated_at
+  before update on patreon_connections
+  for each row execute procedure update_updated_at();
+
+alter table patreon_connections enable row level security;
+
+-- Users can only read their own connection
+create policy "patreon_connections_select" on patreon_connections
+  for select using (auth.uid() = user_id);
+
+-- Inserts/updates/deletes are done by the edge functions via service role only


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a dedicated `patron` plan and full Patreon OAuth flow alongside Stripe, so supporters on Patreon automatically get their benefits in-app
- Implements a Patreon → Stripe swap flow (the financially better direction) with a clear CTA in the billing page
- Patreon and Stripe remain cleanly separate via a `subscription_provider` column — Stripe always wins if both are active

## What's included

**Database**
- `patron` plan row (unlimited quotas, like pro)
- `patreon_tier_ids` jsonb on `plans` — admin maps Patreon tier IDs to plans
- `subscription_provider` + `patreon_member_id` columns on `user_subscriptions`
- `patreon_connections` table — stores OAuth tokens (readable by the owning user, written only by service role)

**Edge functions**
- `patreon-link-url` — authenticated, returns the Patreon OAuth URL with the user's JWT as state
- `patreon-oauth-callback` — public, receives the OAuth code, exchanges tokens, fetches membership, activates patron plan (skips if user already has active Stripe sub)
- `patreon-webhook` — validates HMAC-SHA256 signature, handles `members:pledge:create/update/delete`
- `stripe-webhook` — now sets `subscription_provider='stripe'` on checkout completion, completing the swap flow

**Frontend**
- `usePatreon` composable — connect / disconnect, query-cached connection state
- `useSubscription` gains `isPatron` and `isPatronBilling`
- `BillingView` — Patreon card (connect / status / disconnect), swap-to-Stripe CTA (shown only for patron-billed users), "Patron DM" branding in the current plan display

## Secrets to add

```
supabase secrets set \
  PATREON_CLIENT_ID=... \
  PATREON_CLIENT_SECRET=... \
  PATREON_REDIRECT_URI=https://<project>.supabase.co/functions/v1/patreon-oauth-callback \
  PATREON_WEBHOOK_SECRET=...
```

Patreon app registration: https://www.patreon.com/portal/registration/register-clients

## Test plan

- [ ] Connect Patreon account via billing page — verify `patreon_connections` row created and plan updates to `patron` for active patrons
- [ ] Disconnect Patreon — verify plan reverts to `free` if on Patreon billing
- [ ] Patreon webhook `members:pledge:delete` — verify plan reverts to `free`
- [ ] Stripe checkout from billing page while on Patreon billing — verify `subscription_provider` switches to `stripe` and plan becomes `pro`
- [ ] User with active Stripe sub connects Patreon — verify Stripe sub is not overwritten
- [ ] Admin: set `patreon_tier_ids` on patron plan, verify tier mapping works on next OAuth link

https://claude.ai/code/session_017CB55L4MR4oPoCKY4DqPwK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017CB55L4MR4oPoCKY4DqPwK)_