### PR TITLE
feat(species): campaign-specific races and per-campaign species blocklist

### DIFF
--- a/src/components/campaign/SpeciesTab.vue
+++ b/src/components/campaign/SpeciesTab.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <p class="font-fell text-sm text-muted-foreground">
+      Toggle which species are available when creating party members. Disabled species are hidden from the race picker.
+      Campaign-only species (marked exclusively for this campaign) are always available here.
+    </p>
+
+    <!-- Campaign-only species (informational) -->
+    <div v-if="campaignSpecies.length > 0" class="rounded-lg border border-border bg-card overflow-hidden">
+      <div class="px-4 py-3 border-b border-border bg-muted/20 flex items-center gap-2">
+        <span class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">CAMPAIGN-ONLY SPECIES</span>
+        <span class="font-cinzel text-[10px] text-primary/70 tracking-wider">exclusive to this campaign</span>
+      </div>
+      <div class="divide-y divide-border">
+        <div
+          v-for="sp in campaignSpecies"
+          :key="sp.id"
+          class="flex items-center gap-3 px-4 py-2.5"
+        >
+          <div class="h-4 w-4 shrink-0 flex items-center justify-center">
+            <div class="h-2 w-2 rounded-full bg-primary/60" />
+          </div>
+          <span class="font-fell text-sm text-foreground flex-1">{{ sp.name }}</span>
+          <span class="font-cinzel text-[10px] tracking-wider text-primary/60 shrink-0">campaign-only</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Universal species with enable/disable toggles -->
+    <div v-if="universalSpecies.length > 0" class="rounded-lg border border-border bg-card overflow-hidden">
+      <div class="px-4 py-3 border-b border-border bg-muted/20">
+        <span class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">UNIVERSAL SPECIES</span>
+      </div>
+      <div class="divide-y divide-border">
+        <label
+          v-for="sp in universalSpecies"
+          :key="sp.id"
+          class="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-muted/20 transition-colors"
+        >
+          <input
+            type="checkbox"
+            :checked="!disabled.has(sp.id)"
+            class="h-4 w-4 rounded border-border bg-background shrink-0"
+            @change="toggle(sp.id)"
+          />
+          <span class="font-fell text-sm text-foreground flex-1">{{ sp.name }}</span>
+          <span
+            v-if="disabled.has(sp.id)"
+            class="font-cinzel text-[10px] tracking-wider text-muted-foreground/60 shrink-0"
+          >hidden</span>
+        </label>
+      </div>
+    </div>
+
+    <div v-if="disabled.size > 0" class="flex items-center justify-between">
+      <p class="font-fell text-xs text-muted-foreground italic">
+        {{ disabled.size }} species hidden from party member picker.
+      </p>
+      <button
+        type="button"
+        class="font-cinzel text-[10px] tracking-wider text-primary/70 hover:text-primary transition-colors"
+        @click="enableAll"
+      >
+        Enable all
+      </button>
+    </div>
+
+    <p v-if="universalSpecies.length === 0 && campaignSpecies.length === 0" class="font-fell text-sm text-muted-foreground italic">
+      No species found. Create some in the Species codex first.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { useCampaignStore } from "@/stores/campaign";
+import { useUpdateCampaign } from "@/composables/useCampaigns";
+import { useAllSpecies } from "@/composables/useSpecies";
+
+const campaign = useCampaignStore();
+const { mutate: updateCampaign } = useUpdateCampaign();
+const { data: allSpecies } = useAllSpecies();
+
+const campaignSpecies = computed(() =>
+  (allSpecies.value ?? []).filter((s) => s.campaign_id === campaign.activeCampaignId),
+);
+
+const universalSpecies = computed(() =>
+  (allSpecies.value ?? []).filter((s) => s.campaign_id === null),
+);
+
+const disabled = ref(new Set<string>(campaign.activeCampaign?.disabled_species_ids ?? []));
+
+watch(
+  () => campaign.activeCampaign?.disabled_species_ids,
+  (val) => { disabled.value = new Set(val ?? []); },
+);
+
+function persist() {
+  if (!campaign.activeCampaignId) return;
+  updateCampaign({ id: campaign.activeCampaignId, update: { disabled_species_ids: [...disabled.value] } });
+}
+
+function toggle(speciesId: string) {
+  if (disabled.value.has(speciesId)) disabled.value.delete(speciesId);
+  else disabled.value.add(speciesId);
+  disabled.value = new Set(disabled.value);
+  persist();
+}
+
+function enableAll() {
+  disabled.value = new Set();
+  persist();
+}
+</script>

--- a/src/components/party/PartyMemberForm.vue
+++ b/src/components/party/PartyMemberForm.vue
@@ -620,7 +620,17 @@ const allClassNames = computed<string[]>(() => {
 });
 
 const { data: allSpecies } = useAllSpecies();
-const speciesOptions  = computed(() => (allSpecies.value ?? []).map(s => ({ id: s.id, name: s.name })));
+const speciesOptions = computed(() => {
+  const campaignId = campaignStore.activeCampaignId;
+  const disabledIds = new Set(campaignStore.activeCampaign?.disabled_species_ids ?? []);
+  return (allSpecies.value ?? [])
+    .filter((s) => {
+      if (disabledIds.has(s.id)) return false;
+      if (s.campaign_id !== null && s.campaign_id !== campaignId) return false;
+      return true;
+    })
+    .map((s) => ({ id: s.id, name: s.name }));
+});
 // form.race stores the denormalised species *name* (readable everywhere — dashboard,
 // NPC-by-race, etc.). form.species_id stores the FK to the species table, which is
 // what the combobox binds to. When the DM picks a species we write both.

--- a/src/components/species/SpeciesDetail.vue
+++ b/src/components/species/SpeciesDetail.vue
@@ -39,6 +39,17 @@
           <input type="checkbox" v-model="form.is_shapeshifter" class="rounded" />
           <span class="font-fell text-sm text-muted-foreground italic">Shapeshifter (player can polymorph)</span>
         </label>
+
+        <!-- Campaign-specific flag -->
+        <div v-if="campaignStore.activeCampaignId" class="rounded-md border border-border/60 bg-muted/20 p-3 space-y-1">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" :checked="form.campaign_id === campaignStore.activeCampaignId" class="rounded" @change="toggleCampaignSpecific" />
+            <span class="font-fell text-sm text-foreground">Campaign-only</span>
+          </label>
+          <p class="font-fell text-xs text-muted-foreground italic pl-6">
+            Restrict this species to <strong>{{ campaignStore.activeCampaign?.name }}</strong>. It won't appear in other campaigns.
+          </p>
+        </div>
       </div>
 
       <!-- Right: Fields -->
@@ -344,6 +355,7 @@ import { useQuery } from "@tanstack/vue-query";
 import { useRouter } from "vue-router";
 import { useCreateSpecies, useUpdateSpecies, useDeleteSpecies } from "@/composables/useSpecies";
 import { useConfirm } from "@/composables/useConfirm";
+import { useCampaignStore } from "@/stores/campaign";
 import { supabase } from "@/lib/supabase";
 import RichTextEditor from "@/components/common/RichTextEditor.vue";
 import ImageUpload from "@/components/common/ImageUpload.vue";
@@ -356,6 +368,7 @@ const props = defineProps<{ species?: Species | null }>();
 
 const router = useRouter();
 const { confirm } = useConfirm();
+const campaignStore = useCampaignStore();
 const { mutateAsync: createSpecies } = useCreateSpecies();
 const { mutateAsync: updateSpecies } = useUpdateSpecies();
 const { mutate: deleteSpecies } = useDeleteSpecies();
@@ -434,7 +447,14 @@ function makeForm(s?: Species | null) {
     avg_height: s?.avg_height ?? "",
     avg_weight: s?.avg_weight ?? "",
     grantedSpells: (s?.granted_spells ?? []).map((g) => ({ ...g })),
+    campaign_id: s?.campaign_id ?? null as string | null,
   };
+}
+
+function toggleCampaignSpecific() {
+  const id = campaignStore.activeCampaignId;
+  if (!id) return;
+  form.campaign_id = form.campaign_id === id ? null : id;
 }
 
 // ── Spell grants ──────────────────────────────────────────────────────────────
@@ -562,6 +582,7 @@ async function save() {
       avg_height: form.avg_height.trim() || null,
       avg_weight: form.avg_weight.trim() || null,
       granted_spells: form.grantedSpells,
+      campaign_id: form.campaign_id,
     };
 
     if (props.species) {

--- a/src/types/campaign.types.ts
+++ b/src/types/campaign.types.ts
@@ -24,6 +24,7 @@ export interface Campaign {
   optional_rules: CampaignOptionalRules;
   excluded_monster_ids: string[];
   disabled_class_names: string[];
+  disabled_species_ids: string[];
   // AI keys — one slot per provider
   openai_api_key:     string | null;
   anthropic_api_key:  string | null;
@@ -48,9 +49,10 @@ type ApiKeyFields = "openai_api_key" | "anthropic_api_key" | "gemini_api_key" | 
 type PortraitFields = "group_portrait_url";
 type ProviderFields = "text_provider" | "image_provider";
 
-export type CampaignInsert = Omit<Campaign, "id" | "user_id" | "created_at" | "updated_at" | "excluded_monster_ids" | "disabled_class_names" | "health_visibility" | "immersive_rolls" | "optional_rules" | ApiKeyFields | ProviderFields | "ai_setting_prompt" | "allow_chronicle_promotion" | "ical_token" | PortraitFields | "current_month" | "current_day" | "current_location_id"> & {
+export type CampaignInsert = Omit<Campaign, "id" | "user_id" | "created_at" | "updated_at" | "excluded_monster_ids" | "disabled_class_names" | "disabled_species_ids" | "health_visibility" | "immersive_rolls" | "optional_rules" | ApiKeyFields | ProviderFields | "ai_setting_prompt" | "allow_chronicle_promotion" | "ical_token" | PortraitFields | "current_month" | "current_day" | "current_location_id"> & {
   excluded_monster_ids?: string[];
   disabled_class_names?: string[];
+  disabled_species_ids?: string[];
   health_visibility?: Campaign["health_visibility"];
   immersive_rolls?: boolean;
   optional_rules?: CampaignOptionalRules;

--- a/src/types/species.types.ts
+++ b/src/types/species.types.ts
@@ -33,6 +33,7 @@ export interface SpeciesSubrace {
 export interface Species {
   id: string;
   user_id: string;
+  campaign_id: string | null;
   name: string;
   description: string | null;    // Tiptap JSON
   notes: string | null;          // Tiptap JSON (DM-only)
@@ -55,5 +56,5 @@ export interface Species {
   updated_at: string;
 }
 
-export type SpeciesInsert = Omit<Species, "id" | "user_id" | "created_at" | "updated_at">;
+export type SpeciesInsert = Omit<Species, "id" | "user_id" | "created_at" | "updated_at" | "campaign_id"> & { campaign_id?: string | null };
 export type SpeciesUpdate = Partial<SpeciesInsert>;

--- a/src/views/campaign/CampaignSettingsView.vue
+++ b/src/views/campaign/CampaignSettingsView.vue
@@ -64,6 +64,9 @@
         <div v-else-if="activeTab === 'classes'" class="max-w-lg">
           <ClassesTab />
         </div>
+        <div v-else-if="activeTab === 'species'" class="max-w-lg">
+          <SpeciesTab />
+        </div>
         <div v-else-if="activeTab === 'ai'" class="max-w-lg">
           <AiTab />
         </div>
@@ -103,6 +106,7 @@ import InvitesTab from "@/components/campaign/InvitesTab.vue";
 import SchedulingTab from "@/components/campaign/SchedulingTab.vue";
 import RulesTab from "@/components/campaign/RulesTab.vue";
 import ClassesTab from "@/components/campaign/ClassesTab.vue";
+import SpeciesTab from "@/components/campaign/SpeciesTab.vue";
 import AiTab from "@/components/campaign/AiTab.vue";
 import SpotifyTab from "@/components/campaign/SpotifyTab.vue";
 import BackupTab from "@/components/campaign/BackupTab.vue";
@@ -114,6 +118,7 @@ type SettingsTab =
   | "scheduling"
   | "rules"
   | "classes"
+  | "species"
   | "ai"
   | "spotify"
   | "backup"
@@ -121,7 +126,7 @@ type SettingsTab =
   | "danger";
 
 const VALID_TABS = new Set<SettingsTab>([
-  "details", "members", "scheduling", "rules", "classes",
+  "details", "members", "scheduling", "rules", "classes", "species",
   "ai", "spotify", "backup", "bundle", "danger",
 ]);
 
@@ -131,6 +136,7 @@ const tabs: { id: SettingsTab; label: string }[] = [
   { id: "scheduling", label: "Scheduling" },
   { id: "rules", label: "Rules" },
   { id: "classes", label: "Classes" },
+  { id: "species", label: "Species" },
   { id: "ai", label: "AI Assistant" },
   { id: "spotify", label: "Spotify" },
   { id: "backup", label: "Backup" },

--- a/supabase/migrations/20260513000001_campaign_specific_species.sql
+++ b/supabase/migrations/20260513000001_campaign_specific_species.sql
@@ -1,0 +1,8 @@
+-- Migration: campaign_specific_species
+-- Adds campaign_id to species (marks a species as exclusive to one campaign) and disabled_species_ids to campaigns (per-campaign species blocklist)
+
+alter table species
+  add column campaign_id uuid references campaigns(id) on delete set null;
+
+alter table campaigns
+  add column disabled_species_ids uuid[] not null default '{}';


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Campaign-only species toggle** — when editing a species, DMs can mark it as exclusive to the active campaign. That species won't appear in the race picker for any other campaign. Useful for homebrew races unique to a specific world.
- **Per-campaign species blocklist** — a new **Species** tab in Campaign Settings lists all universal species with enable/disable checkboxes (mirrors the existing Classes tab). DMs can hide species that don't fit their campaign setting (e.g. no elves/dwarves in a sci-fi campaign).
- Both restrictions are enforced in `PartyMemberForm.vue` — the species picker filters out campaign-foreign and disabled species automatically.

## Migration

`supabase/migrations/20260513000001_campaign_specific_species.sql` adds:
- `campaign_id uuid` (nullable FK → campaigns) on the `species` table
- `disabled_species_ids uuid[]` (default `{}`) on the `campaigns` table

Run `supabase db push` to apply.

## Test plan

- [ ] Create a new species with an active campaign — check "Campaign-only" and save; verify it only appears in that campaign's party member picker
- [ ] Open Campaign Settings → Species tab; uncheck a universal species; verify it disappears from the party member race picker
- [ ] Re-enable the species via "Enable all" and verify it returns
- [ ] Confirm campaign-only species appear in the "Campaign-only species" info section (not the toggle list)
- [ ] Verify existing species (no campaign_id) still show up in all campaigns' race pickers

https://claude.ai/code/session_01J8uWUXdSQQg5pANHvAeEWz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8uWUXdSQQg5pANHvAeEWz)_