### PR TITLE
Allow DMs to create party characters from the Party Tracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vue-tsc": "^2.2.0"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": "^24.0.0"
       },
       "optionalDependencies": {
         "@rolldown/binding-darwin-arm64": "^1.0.0-rc.15"

--- a/src/components/party/PartyTracker.vue
+++ b/src/components/party/PartyTracker.vue
@@ -12,7 +12,7 @@
     >
       <template #action>
         <RouterLink
-          to="/play/character/create"
+          to="/party/new"
           class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-sm font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
         >
           Add first hero

--- a/src/composables/useCharacterCreationForm.ts
+++ b/src/composables/useCharacterCreationForm.ts
@@ -164,6 +164,7 @@ export function useCharacterCreationForm() {
   const derivedInitiative = computed(() => mod(f.dex));
 
   const isEditMode = computed(() => route.name === "play-character-edit");
+  const isDmCreate = computed(() => route.name === "party-member-new");
   const { data: partyMembers }    = useParty();
   const { data: campaignMembers } = useCampaignMembers();
   const { mutateAsync: create }               = useCreatePartyMember();
@@ -180,7 +181,7 @@ export function useCharacterCreationForm() {
       ? (partyMembers.value.find((m) => m.id === editMemberId.value) ?? null)
       : null,
   );
-  const backRoute = (route.query.memberId as string | undefined) ? "/party" : "/play";
+  const backRoute = isDmCreate.value || (route.query.memberId as string | undefined) ? "/party" : "/play";
 
   const tabParam = route.query.tab as string | undefined;
   const activeTab  = ref<"identity" | "stats" | "profs">(
@@ -549,10 +550,12 @@ export function useCharacterCreationForm() {
         // ── Create flow ───────────────────────────────────────────────────────
         const created = await create({ ...basePayload, owner_user_id: auth.user?.id ?? null });
 
-        // Link as active character for this player
-        const myMembership = (campaignMembers.value ?? []).find((cm) => cm.user_id === auth.user?.id);
-        if (myMembership) {
-          await updateCampaignMember({ id: myMembership.id, update: { party_member_id: created.id } });
+        // Link as active character for this player (skip when DM creates an unclaimed character)
+        if (!isDmCreate.value) {
+          const myMembership = (campaignMembers.value ?? []).find((cm) => cm.user_id === auth.user?.id);
+          if (myMembership) {
+            await updateCampaignMember({ id: myMembership.id, update: { party_member_id: created.id } });
+          }
         }
 
         // Seed level 1 character_classes row
@@ -600,7 +603,9 @@ export function useCharacterCreationForm() {
         }
 
         await auth.refreshMembership();
-        if (levelUp) {
+        if (isDmCreate.value) {
+          router.push("/party");
+        } else if (levelUp) {
           router.push(`/play/character/levelup?targetLevel=2&memberId=${created.id}`);
         } else {
           router.push("/play/champions");
@@ -638,7 +643,7 @@ export function useCharacterCreationForm() {
     // ASI (new chars)
     asiMode, customAsi, customAsiTotal, adjustCustomAsi,
     // computed
-    isEditMode, existingMember, backRoute,
+    isEditMode, isDmCreate, existingMember, backRoute,
     allSpecies, allBackgrounds,
     speciesOptions, backgroundOptions, selectedSpecies, subraceOptions,
     selectedClass, selectedBg, selectedSubrace,

--- a/src/composables/useCharacterCreationForm.ts
+++ b/src/composables/useCharacterCreationForm.ts
@@ -548,7 +548,7 @@ export function useCharacterCreationForm() {
         router.push(freePicks.length > 0 ? "/play/spells?tab=innate" : "/play/champions");
       } else {
         // ── Create flow ───────────────────────────────────────────────────────
-        const created = await create({ ...basePayload, owner_user_id: auth.user?.id ?? null });
+        const created = await create({ ...basePayload, owner_user_id: isDmCreate.value ? null : (auth.user?.id ?? null) });
 
         // Link as active character for this player (skip when DM creates an unclaimed character)
         if (!isDmCreate.value) {

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -319,6 +319,12 @@ export const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: true, title: "Party Tracker" },
   },
   {
+    path: "/party/new",
+    name: "party-member-new",
+    component: () => import("@/views/play/PlayerCharacterCreateView.vue"),
+    meta: { requiresAuth: true, title: "Create Character" },
+  },
+  {
     path: "/party/:id",
     name: "party-member",
     component: () => import("@/views/party/PartyMemberView.vue"),

--- a/src/views/party/PartyView.vue
+++ b/src/views/party/PartyView.vue
@@ -10,7 +10,7 @@
         Add Companion
       </button>
       <RouterLink
-        to="/play/character/create"
+        to="/party/new"
         class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 font-cinzel text-xs font-semibold text-primary-foreground hover:opacity-90 transition-opacity"
       >
         <IconAdd class="h-3.5 w-3.5" />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new `/party/new` route (no `requiresPlayer` guard) so DMs can access the character creation wizard directly from the Party Tracker
- "Add Hero" and "Add first hero" buttons now point to `/party/new` instead of `/play/character/create` (which was redirecting DMs to `/dashboard`)
- Characters created via this route are left **unclaimed** — not auto-linked to the DM's membership — so they can be assigned to a player later via the campaign members tab (great for one-shots)
- After creation the DM is returned to `/party` instead of `/play/champions`

## Test plan

- [ ] As a DM on a new campaign, click "Add first hero" — should open the character creation wizard (not redirect to dashboard)
- [ ] As a DM on the Party Tracker with existing members, click "Add Hero" — should open the wizard
- [ ] Complete the wizard and confirm you land on `/party` with the new character listed
- [ ] Confirm the new character has no player assigned (shows as unclaimed in Campaign Settings → Members tab)
- [ ] Confirm a player creating their own character via `/play/character/create` still auto-links correctly

https://claude.ai/code/session_01RWTkqkC9u3HXGgtTKYopwh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWTkqkC9u3HXGgtTKYopwh)_