### PR TITLE
Atlas favourites chevron + Soundboard duplicate controls/pause fixes

### DIFF
--- a/src/components/soundboard/SoundCard.vue
+++ b/src/components/soundboard/SoundCard.vue
@@ -222,9 +222,9 @@
       </p>
     </template>
 
-    <!-- ── Page picker (only when multiple pages exist) ─────────────────── -->
+    <!-- ── Page picker (audio sounds only; multiple pages exist) ────────── -->
     <div
-      v-if="pages && pages.length > 1 && !sound.page_id"
+      v-if="!isSpotify && pages && pages.length > 1 && !sound.page_id"
       class="flex items-center gap-1.5 [@media(hover:hover)]:opacity-0 group-hover:opacity-100 transition-opacity"
     >
       <IconLayers class="h-3 w-3 text-muted-foreground/50 shrink-0" />
@@ -238,8 +238,8 @@
       </select>
     </div>
 
-    <!-- ── HTML Audio controls ─────────────────────────────────────────── -->
-    <template v-else>
+    <!-- ── HTML Audio controls (non-Spotify sounds only) ────────────────── -->
+    <template v-if="!isSpotify">
       <div class="flex items-center gap-2">
         <!-- IconPlay / IconPause -->
         <button
@@ -251,7 +251,7 @@
               ? 'bg-gold-500/20 border-gold-500/50 text-gold-300 hover:bg-gold-500/30'
               : 'border-border text-muted-foreground hover:text-foreground hover:border-border/80'
           "
-          :title="playBlocked ? 'WebM — cannot play in Safari' : audioState.isPlaying ? 'IconPause' : 'IconPlay'"
+          :title="playBlocked ? 'WebM — cannot play in Safari' : audioState.isPlaying ? 'Pause' : 'Play'"
           :disabled="playBlocked"
           @click="togglePlay"
         >
@@ -377,7 +377,7 @@ const playBlocked = computed(() => (isWebM.value && IS_SAFARI) || audioState.val
 function togglePlay() {
   if (playBlocked.value) return;
   if (audioState.value.isPlaying) {
-    soundboardStore.stop(props.sound.id);
+    soundboardStore.pause(props.sound.id);
   } else {
     soundboardStore.play(props.sound.id, props.sound.file_url);
   }

--- a/src/stores/soundboard.ts
+++ b/src/stores/soundboard.ts
@@ -113,6 +113,14 @@ export const useSoundboardStore = defineStore("soundboard", () => {
     }
   }
 
+  function pause(soundId: string): void {
+    const audio = audioInstances.get(soundId);
+    if (audio) audio.pause();
+    if (playbackStates.value[soundId]) {
+      playbackStates.value[soundId].isPlaying = false;
+    }
+  }
+
   function seek(soundId: string, time: number): void {
     const audio = audioInstances.get(soundId);
     if (audio) {
@@ -172,6 +180,7 @@ export const useSoundboardStore = defineStore("soundboard", () => {
     playingCount,
     getState,
     play,
+    pause,
     stop,
     seek,
     setVolume,

--- a/src/views/play/PlayerLocationsView.vue
+++ b/src/views/play/PlayerLocationsView.vue
@@ -51,12 +51,12 @@
           :data-location-id="loc.id"
           class="rounded-lg border border-amber-400/40 bg-card overflow-hidden"
         >
-          <!-- Header row -->
+          <!-- Header row — favourites are a flat list, so no children-toggle here -->
           <div class="w-full flex items-stretch">
             <button
               type="button"
               class="flex-1 flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-colors text-left min-w-0"
-              @click="toggleChildren(loc.id)"
+              @click="toggleDetail(loc.id)"
             >
               <span
                 class="h-2 w-2 rounded-full shrink-0"
@@ -67,11 +67,6 @@
               <span class="font-cinzel text-2xs md:text-sm text-muted-foreground tracking-wider shrink-0">
                 {{ locLabel(loc.location_type) }}
               </span>
-              <IconChevronDown
-                v-if="hasSharedChildren.has(loc.id)"
-                class="h-3.5 w-3.5 text-muted-foreground transition-transform duration-150 shrink-0"
-                :class="childrenOpen.has(loc.id) ? 'rotate-180' : ''"
-              />
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary

Three small UI/UX bug fixes spotted today, all touching shared player/DM surfaces.

- **#408** — Player Atlas favourite cards no longer show a non-functional fold-open chevron. The favourites section is a flat list, so the row click now opens details (consistent with the row's Details affordance).
- **#409** — Spotify cards on the soundboard no longer render a second HTML audio play+volume bar. The audio control block was accidentally chained off the page picker's `v-else`; both are now gated on `!isSpotify`.
- **#410** — The play/pause toggle on a sound card now actually pauses. Added a `pause()` action to the soundboard store (`audio.pause()`, no rewind) and route the toggle through it. The dedicated Stop button still resets to 0:00.

## Test plan

- [ ] **Atlas favourites:** as a player, favourite a location with shared children → the favourite card has no chevron, clicking the row opens details, the main tree still expands children normally.
- [ ] **Atlas main tree:** the children chevron + toggle still work as before on non-favourite rows.
- [ ] **Soundboard, Spotify card with single page:** only one set of controls visible (green Spotify play + volume). No gold HTML audio controls.
- [ ] **Soundboard, Spotify card with multiple pages (unassigned):** still only the green Spotify controls; page picker hidden for Spotify items.
- [ ] **Soundboard, audio card:** the page picker still appears when multiple pages exist and item is unassigned. HTML audio controls render as before.
- [ ] **Soundboard play/pause:** start a long track, let it run a few seconds, click the toggle. Track pauses where it is. Click again → resumes from that position. Stop button still resets to 0:00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)