### PR TITLE
Extend subject-overrides-setting to trap client + all edge functions

### DIFF
--- a/src/ai/useTrapGeneration.ts
+++ b/src/ai/useTrapGeneration.ts
@@ -17,6 +17,7 @@ import { b64ToBlob, wrapUserInput } from "./utils";
 import { useCampaignStore } from "@/stores/campaign";
 import { logUsage } from "@/composables/useAiCredits";
 import { fetchSystemPrompt, fetchImageBasePrompt } from "./systemPrompts";
+import { buildSimpleImagePrompt } from "./imagePrompt";
 import type { ImageUsage } from "./providers/types";
 
 const LOCAL_MODE_KEY = "grimoire_key_local_mode";
@@ -200,7 +201,9 @@ export function useTrapGeneration() {
 
         if (options?.groupPortraitUrl && openAiKey) {
           b64 = await generateWithPartyReference(
-            [settingPrompt, trapData.image_prompt].filter(Boolean).join(" — "),
+            // base is supplied by generateWithPartyReference itself; pass "" so
+            // the helper only emits setting + precedence directive + subject.
+            buildSimpleImagePrompt({ base: "", setting: settingPrompt, subject: trapData.image_prompt }),
             options.groupPortraitUrl,
             openAiKey,
             imageBasePrompt,
@@ -212,9 +215,11 @@ export function useTrapGeneration() {
         }
 
         if (!b64) {
-          const imagePrompt = [imageBasePrompt, settingPrompt, trapData.image_prompt]
-            .filter(Boolean)
-            .join(" — ");
+          const imagePrompt = buildSimpleImagePrompt({
+            base: imageBasePrompt,
+            setting: settingPrompt,
+            subject: trapData.image_prompt,
+          });
           const { b64: _b64, usage: _imgUsage } = await imageProvider.generate(imagePrompt, "1024x1536");
           b64 = _b64;
           imgUsage = _imgUsage;

--- a/supabase/functions/_shared/image-prompt.ts
+++ b/supabase/functions/_shared/image-prompt.ts
@@ -1,0 +1,40 @@
+// Shared image-prompt construction for server-side (Deno edge) AI generation.
+// The matching browser module lives at src/ai/imagePrompt.ts — keep both in
+// sync (the two runtimes can't share a single file).
+
+// Tells the image model that the Subject is canonical when it conflicts with
+// the Setting. Without this, the model averages the two — e.g. a butler
+// described by the user gets rendered in winter survivalist gear because the
+// campaign setting is "rugged wintry landscape".
+export const SUBJECT_OVERRIDES_SETTING =
+  "If the Subject describes clothing, profession, or appearance that does not fit the Setting (for example, a butler or noble indoors in an otherwise wintry land), render the Subject exactly as described. The Setting is only background atmosphere, not a wardrobe override.";
+
+interface PromptParts {
+  base: string;
+  setting: string;
+  subject: string;
+}
+
+/** Newline-joined, labelled prompt — used by NPC true portrait generation. */
+export function buildLabelledImagePrompt({ base, setting, subject }: PromptParts): string {
+  return [
+    `Style: ${base}`,
+    setting ? `Setting: ${setting}` : null,
+    setting ? `Precedence: ${SUBJECT_OVERRIDES_SETTING}` : null,
+    `Subject: ${subject}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** " — "-joined prompt — used by everything except NPC true portrait. */
+export function buildSimpleImagePrompt({ base, setting, subject }: PromptParts): string {
+  return [
+    base,
+    setting,
+    setting ? SUBJECT_OVERRIDES_SETTING : null,
+    subject,
+  ]
+    .filter(Boolean)
+    .join(" — ");
+}

--- a/supabase/functions/generate-location/index.ts
+++ b/supabase/functions/generate-location/index.ts
@@ -10,6 +10,7 @@ import {
   validatePromptInput,
   wrapUserInput,
 } from "../_shared/ai-prompt.ts";
+import { buildSimpleImagePrompt } from "../_shared/image-prompt.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -260,7 +261,11 @@ serve(async (req: Request) => {
     const [imgSettled, mapSettled] = await Promise.allSettled([
       generate_image
         ? openaiImageGenerate(openaiKey, imgModel,
-            [imageBasePrompt, campaign.ai_setting_prompt, locationData.image_prompt].filter(Boolean).join(" — "),
+            buildSimpleImagePrompt({
+              base: imageBasePrompt,
+              setting: campaign.ai_setting_prompt ?? "",
+              subject: locationData.image_prompt,
+            }),
             "1024x1024")
         : Promise.resolve(null),
       generate_map

--- a/supabase/functions/generate-npc/index.ts
+++ b/supabase/functions/generate-npc/index.ts
@@ -10,17 +10,12 @@ import {
   validatePromptInput,
   wrapUserInput,
 } from "../_shared/ai-prompt.ts";
+import { buildLabelledImagePrompt, buildSimpleImagePrompt } from "../_shared/image-prompt.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
-
-// Tells the image model that the Subject is canonical when it conflicts with
-// the Setting. Without this, the model averages the two — e.g. a butler
-// described by the user gets rendered in winter survivalist gear because the
-// campaign setting is "rugged wintry landscape".
-const SUBJECT_OVERRIDES_SETTING = "If the Subject describes clothing, profession, or appearance that does not fit the Setting (for example, a butler or noble indoors in an otherwise wintry land), render the Subject exactly as described. The Setting is only background atmosphere, not a wardrobe override.";
 
 const admin = createClient(
   Deno.env.get("SUPABASE_URL")!,
@@ -368,12 +363,11 @@ serve(async (req: Request) => {
   const imgModel = imgModelConfig ?? (imageProvider === "falai" ? "fal-ai/flux-2/flex" : "gpt-image-1.5");
 
   if (generateImage && npcData.true_portrait_prompt) {
-    const imagePrompt = [
-      `Style: ${imageBasePrompt}`,
-      campaign.ai_setting_prompt ? `Setting: ${campaign.ai_setting_prompt}` : null,
-      campaign.ai_setting_prompt ? `Precedence: ${SUBJECT_OVERRIDES_SETTING}` : null,
-      `Subject: ${npcData.true_portrait_prompt}`,
-    ].filter(Boolean).join("\n");
+    const imagePrompt = buildLabelledImagePrompt({
+      base: imageBasePrompt,
+      setting: campaign.ai_setting_prompt ?? "",
+      subject: npcData.true_portrait_prompt,
+    });
 
     try {
       if (imageProvider === "falai" && falaiKey) {
@@ -392,14 +386,11 @@ serve(async (req: Request) => {
 
     // Alter-ego disguise uses OpenAI edit — skip if using fal.ai (no edit endpoint)
     if (imageProvider !== "falai" && generateAlterEgo && portrait_b64 && npcData.disguise_image_prompt && openaiKey) {
-      const disguisePrompt = [
-        imageBasePrompt,
-        campaign.ai_setting_prompt,
-        campaign.ai_setting_prompt ? SUBJECT_OVERRIDES_SETTING : null,
-        npcData.disguise_image_prompt,
-      ]
-        .filter(Boolean)
-        .join(" — ");
+      const disguisePrompt = buildSimpleImagePrompt({
+        base: imageBasePrompt,
+        setting: campaign.ai_setting_prompt ?? "",
+        subject: npcData.disguise_image_prompt,
+      });
       try {
         const { b64 } = await openaiImageEdit(openaiKey, imgModel, portrait_b64, disguisePrompt, "1024x1536");
         disguise_portrait_b64 = b64;

--- a/supabase/functions/generate-trap/index.ts
+++ b/supabase/functions/generate-trap/index.ts
@@ -10,6 +10,7 @@ import {
   validatePromptInput,
   wrapUserInput,
 } from "../_shared/ai-prompt.ts";
+import { buildSimpleImagePrompt } from "../_shared/image-prompt.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -287,8 +288,11 @@ serve(async (req: Request) => {
 
   if (generate_image && openaiKey) {
     try {
-      const imagePrompt = [imageBasePrompt, campaign.ai_setting_prompt, trapData.image_prompt]
-        .filter(Boolean).join(" — ");
+      const imagePrompt = buildSimpleImagePrompt({
+        base: imageBasePrompt,
+        setting: campaign.ai_setting_prompt ?? "",
+        subject: trapData.image_prompt,
+      });
 
       if (group_portrait_url) {
         imgResult = await openaiImageEdit(openaiKey, imgModel, group_portrait_url, [imagePrompt, PARTY_SUFFIX].join(" — "), "1024x1536");


### PR DESCRIPTION
## Summary

Follow-up to #5aaf35b, which added the shared `src/ai/imagePrompt.ts` module and applied the new precedence directive to most client-side generators. This PR finishes the rollout to the remaining surfaces:

- **`useTrapGeneration`** — both prompt build sites (party-reference variant and standard) now go through `buildSimpleImagePrompt`. The party-reference call passes `base: ""` because `generateWithPartyReference` adds the base itself.
- **`supabase/functions/_shared/image-prompt.ts`** — new Deno-side mirror of the client module (the two runtimes can't share a single file).
- **`generate-npc`** — drops the inline `SUBJECT_OVERRIDES_SETTING` constant; both true-portrait and disguise prompts go through the shared helpers.
- **`generate-location` / `generate-trap`** — main image prompt now uses `buildSimpleImagePrompt`. Map prompt in `generate-location` is unaffected (no user-input collision there).

After this, every entity generator (NPC, Location, Item, Monster, Faction, Trap, Puzzle) on both the client (BYOK) and edge (platform-key) paths includes the precedence directive whenever a setting prompt is configured.

## Why
Campaigns with a strong setting prompt (e.g. "rugged wintry landscape") were causing the image model to merge the subject with the setting's wardrobe. A butler or noble NPC came out in winter survivalist gear. The directive tells the model the Subject is canonical when it conflicts with the Setting.

## Test plan

- [ ] On a campaign with a setting prompt set, generate an NPC whose description specifies an off-setting profession (butler, noble, courtier). Confirm the image renders the described clothing — not the setting's default attire.
- [ ] Repeat for Locations (e.g. setting "frozen wastes" + subject "marble palace interior").
- [ ] Repeat for Traps (with and without `groupPortraitUrl`).
- [ ] Sanity check: on a campaign with **no** setting prompt, generation still works (directive is omitted, prompt structure unchanged from before).
- [ ] BYOK mode (local key in localStorage) and platform-key mode (edge function) both behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)