### PR TITLE
Reusable TS importers + enrich-merge model: chapter NPCs, faiths, pantheons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "portless": "^0.10.2",
         "stripe": "^22.1.0",
         "tailwindcss": "^4.0.0",
+        "tsx": "^4.22.1",
         "typescript": "~5.7.2",
         "vite": "^8.0.8",
         "vite-ssg": "^28.3.0",
@@ -377,6 +378,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -3313,6 +3756,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -5172,6 +5657,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint:fix": "oxlint --config oxlint.json --fix src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "stripe:setup": "node --env-file=.env.local scripts/stripe-setup.mjs"
+    "stripe:setup": "node --env-file=.env.local scripts/stripe-setup.mjs",
+    "import-chapter-npcs": "tsx --env-file=.env.local scripts/import-chapter-npcs.ts",
+    "import-faiths": "tsx --env-file=.env.local scripts/import-faiths.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.1",
@@ -64,6 +66,7 @@
     "portless": "^0.10.2",
     "stripe": "^22.1.0",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.22.1",
     "typescript": "~5.7.2",
     "vite": "^8.0.8",
     "vite-ssg": "^28.3.0",

--- a/scripts/chapter_npc_configs/chapter_5.json
+++ b/scripts/chapter_npc_configs/chapter_5.json
@@ -17,6 +17,14 @@
       "parent_name": "Sothery",
       "description": "A Sugarspun town adjacent to the Sugar Carnival valley, home of the masters' conservatory where Sugarspun performers train. Sugarwell trades in pulled-sugar work, conservatory tuition, and traveler hospitality. The chapter's third-option exhibit: a Sugarspun life lived without the Carnival's nightly dissolution.",
       "tags": ["chapter-5","sugarwell","sothery","sugarspun","conservatory","third-option","town"]
+    },
+    {
+      "key": "quiverglass_townhouse",
+      "name": "Quiverglass Townhouse",
+      "type": "building",
+      "parent_name": "Marrow City",
+      "description": "Three-story Marrow townhouse in Marrow City's University District. Home of the Quiverglass household — a glassmaker lineage that turned scholarly two generations back, holders of the heritable noble-style \"Lady of the Winged Crown.\" Currently inhabited by Lady Quiverglass and her daughter Vellette. The household maintains a small library of correspondence with Dr. Vellum Pen and a personal moth-garden in the inner courtyard. Visitable in Ch7-adjacent Marrow City scenes per Quiverglass's open invitation if the party engaged her at the Carnival.",
+      "tags": ["chapter-5","marrow-city","university-district","quiverglass","townhouse","noble-household","library","moth-garden","ch7-hook","future-use"]
     }
   ],
   "npcs": {
@@ -70,6 +78,30 @@
       "display_name": "Floss",
       "location": "sugarwell", "status": "alive", "relationship": "ally", "relevance": 3,
       "tags": ["chapter-5","sugarspun","tuft","mid-stage","innkeeper","sugarwell","pulled-sugar-inn","hospitable","third-option","former-trapeze"]
+    },
+    "Master Cantor (Sugarwell Locus NPC)": {
+      "display_name": "Master Cantor",
+      "location": "sugarwell", "status": "alive", "relationship": "ally", "relevance": 3,
+      "tags": ["chapter-5","sugarspun","tuft","mid-stage","conservatory","music-wing-chair","sugarwell","carnival-music-archivist","founders-score","fifteen-years-trying"]
+    },
+    "Master Cadenza (Sugarwell Locus NPC, new male)": {
+      "display_name": "Master Cadenza",
+      "location": "sugarwell", "status": "alive", "relationship": "neutral", "relevance": 2,
+      "tags": ["chapter-5","sugarspun","tuft","early-mid-stage","apprentice","sugarwell","conservatory","composer","cantor-successor","music-wing","promising"]
+    },
+    "Toffee (Carnival child, new male)": {
+      "display_name": "Toffee",
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 2,
+      "tags": ["chapter-5","sugarspun","tuft","undissolved","carnival","child","carousel-rider","jeweled-costume","brittle-cotton-friend","age-twin"]
+    },
+    "Marzipan the Elder (Visiting traveler, new male)": {
+      "display_name": "Marzipan the Elder",
+      "location": "carnival", "status": "alive", "relationship": "neutral", "relevance": 3,
+      "tags": ["chapter-5","sugarspun","tuft","late-stage","traveler","marzipane-brother","chose-the-road","seasonal-visitor","contrast-figure","road-not-chair","row-3-d-companion"]
+    },
+    "Vellette Quiverglass": {
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 4,
+      "tags": ["chapter-5","marrow","untaught","young","marrow-noble","quiverglass-household","anticipation-crown","sweet-memory-scene","coming-of-age","mother-daughter","quiverglass-daughter","pre-pedagogy"]
     }
   }
 }

--- a/scripts/chapter_npc_configs/chapter_5.json
+++ b/scripts/chapter_npc_configs/chapter_5.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "Sidecar config for `late_in_the_kind_country_chapter_5_npcs.md`. Pass via --config; idempotent re-runs are safe.",
+  "default_location_key": "carnival",
+  "locations": [
+    {
+      "key": "carnival",
+      "name": "The Sugar Carnival",
+      "type": "town",
+      "parent_name": "Sothery",
+      "description": "A walled fairground valley south of the Smudge Flats. The Sugar Carnival has run continuously for nineteen years under Spangle's stagemistress-ship, with Trill's predecessor before that. Daily program: Bow of Welcome, the Slow Fall on the trapeze, the carousel, lemonade tents, audience bleachers. The valley sustains a no-rain bargain; Sugarspun who reach late-stage choose seats in the audience rather than walking on. The chapter's emotional spine.",
+      "tags": ["chapter-5","locus","carnival","sugarspun","sothery","antibody","valley","no-rain-bargain"]
+    },
+    {
+      "key": "sugarwell",
+      "name": "Sugarwell",
+      "type": "town",
+      "parent_name": "Sothery",
+      "description": "A Sugarspun town adjacent to the Sugar Carnival valley, home of the masters' conservatory where Sugarspun performers train. Sugarwell trades in pulled-sugar work, conservatory tuition, and traveler hospitality. The chapter's third-option exhibit: a Sugarspun life lived without the Carnival's nightly dissolution.",
+      "tags": ["chapter-5","sugarwell","sothery","sugarspun","conservatory","third-option","town"]
+    }
+  ],
+  "npcs": {
+    "Brittle": {
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 4,
+      "tags": ["chapter-5","sugarspun","tuft","undissolved","lemonade-girl","carnival","child","bow-keeper","outside-curious","campaign-carry"]
+    },
+    "Cotton": {
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 2,
+      "tags": ["chapter-5","sugarspun","tuft","undissolved","lemonade-girl","carnival","child","age-twin"]
+    },
+    "Spangle": {
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 5,
+      "tags": ["chapter-5","sugarspun","tuft","middle-stage","stagemistress","carnival","antibody","articulate","chief-host"]
+    },
+    "Glissade": {
+      "location": "carnival", "status": "alive", "relationship": "neutral", "relevance": 4,
+      "tags": ["chapter-5","sugarspun","tuft","late-stage","bandmaster","carousel","bell-note","carnival","fused-to-bandstand","brine-mentor"]
+    },
+    "Plume": {
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 4,
+      "tags": ["chapter-5","sugarspun","tuft","mid-stage-advanced","trapeze","slow-fall","carnival","senior-performer","glissade-age-twin"]
+    },
+    "Curtsy": {
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 3,
+      "tags": ["chapter-5","sugarspun","tuft","early-mid-stage","apprentice","juggler","carnival","spangle-successor"]
+    },
+    "Trill": {
+      "location": "carnival", "status": "alive", "relationship": "neutral", "relevance": 2,
+      "tags": ["chapter-5","sugarspun","tuft","settled","audience","seat-3-a","carnival","predecessor","spangle-predecessor"]
+    },
+    "Marzipane": {
+      "location": "carnival", "status": "alive", "relationship": "neutral", "relevance": 3,
+      "tags": ["chapter-5","sugarspun","tuft","settled","audience","seat-3-d","carnival","fifty-three-years","plume-age-twin","unextractable"]
+    },
+    "Tallow Wickwax": {
+      "location": "carnival", "status": "alive", "relationship": "neutral", "relevance": 2,
+      "tags": ["chapter-5","wick","almost-gone","candle-stub","seat-4-a","audience","carnival","cross-people","crumble-lantern-link"]
+    },
+    "Brine (Glissade Junior)": {
+      "display_name": "Brine (Glissade Junior)",
+      "location": "carnival", "status": "alive", "relationship": "enemy", "relevance": 4,
+      "tags": ["chapter-5","sugarspun","salt-bonded","saltwater-clown","wrong","glissade-apprentice","abandoned","tactical-combatant","sugarwell-born"]
+    },
+    "Madame Petrichor (Terminal Entry)": {
+      "display_name": "Madame Petrichor",
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 5,
+      "tags": ["chapter-5","sugarspun","tuft","late-stage-advanced","peddler","traveler","campaign-companion","considers-chair","walks-on","hospice-bound","cart","cinder","praline-source"]
+    },
+    "Floss (Sugarwell Locus NPC)": {
+      "display_name": "Floss",
+      "location": "sugarwell", "status": "alive", "relationship": "ally", "relevance": 3,
+      "tags": ["chapter-5","sugarspun","tuft","mid-stage","innkeeper","sugarwell","pulled-sugar-inn","hospitable","third-option","former-trapeze"]
+    }
+  }
+}

--- a/scripts/chapter_npc_configs/chapter_5.json
+++ b/scripts/chapter_npc_configs/chapter_5.json
@@ -92,7 +92,12 @@
     "Toffee (Carnival child, new male)": {
       "display_name": "Toffee",
       "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 2,
-      "tags": ["chapter-5","sugarspun","tuft","undissolved","carnival","child","carousel-rider","jeweled-costume","brittle-cotton-friend","age-twin"]
+      "tags": ["chapter-5","sugarspun","tuft","undissolved","carnival","child","carousel-rider","toffee-and-mint-cream","brittle-cotton-friend","age-twin","matched-pair-foundling","sherbet-matched"]
+    },
+    "Sherbet (Carnival child, new — front-row audience child)": {
+      "display_name": "Sherbet",
+      "location": "carnival", "status": "alive", "relationship": "ally", "relevance": 4,
+      "tags": ["chapter-5","sugarspun","tuft","undissolved","carnival","child","orange-and-cream","sherbet-fizz","foundling-pair","front-row-audience","row-1-g","toffee-matched","watcher","carnival-future","campaign-carry-giver"]
     },
     "Marzipan the Elder (Visiting traveler, new male)": {
       "display_name": "Marzipan the Elder",

--- a/scripts/import-chapter-npcs.ts
+++ b/scripts/import-chapter-npcs.ts
@@ -1,0 +1,531 @@
+#!/usr/bin/env tsx
+/**
+ * Import chapter NPC markdown into the Grimoire campaign DB.
+ *
+ * Usage:
+ *   npm run import-chapter-npcs -- <markdown_path> --chapter <N> [--dry-run]
+ *
+ * Or invoke directly:
+ *   tsx --env-file=.env.local scripts/import-chapter-npcs.ts <md> --chapter N
+ *
+ * Required env vars (read by the supabase client in `./lib/import-chapter-npcs-db.ts`):
+ *   VITE_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *
+ * Flags:
+ *   --chapter N                Chapter number (required). Used for `chapter-N` tag.
+ *   --config PATH              Sidecar JSON config (defaults to <markdown>.config.json).
+ *   --campaign-id UUID         Target campaign (default: Kind Country).
+ *   --user-id UUID             Target user (default: Kind Country owner).
+ *   --default-parent NAME      Parent location for auto-created locations (default: "Sothery").
+ *   --dry-run                  Parse + plan; print summary; do not touch DB.
+ *   --verbose / -v             Verbose logging.
+ *
+ * Idempotency: matches existing NPCs and locations by normalized name
+ * (case-insensitive, whitespace-collapsed) within the campaign. Re-runs are
+ * safe. To intentionally insert a near-duplicate (e.g. an NPC with the same
+ * first name as another), rename it in the source markdown's `## NAME` heading.
+ *
+ * See `scripts/lib/parse-chapter-npcs.ts` for the parsing logic and
+ * `scripts/lib/import-chapter-npcs-db.ts` for DB interaction. The pure parser
+ * has a vitest suite at `scripts/lib/parse-chapter-npcs.test.ts`.
+ *
+ * Format support: Ch1, Ch2, Ch3, Ch4, Ch5. The Prologue format (NPCs as `###`
+ * under group `##` headings) is NOT supported — flagged & skipped.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, basename } from "node:path";
+import { parseArgs } from "node:util";
+
+import {
+  applySidecar,
+  findPotentialDuplicates,
+  isSkipHeading,
+  parseNpc,
+  resolveLocationSpecs,
+  splitNpcBlocks,
+  normalizeName,
+  type LocationSpec,
+  type NpcRecord,
+  type SidecarConfig,
+} from "./lib/parse-chapter-npcs";
+import {
+  createServiceClient,
+  enrichNpc,
+  ensureLocations,
+  fetchDbState,
+  insertNpcs,
+  NPC_MERGE_FIELDS,
+  type ExistingNpc,
+} from "./lib/import-chapter-npcs-db";
+import {
+  planForceOverwrite,
+  planHasWrites,
+  planRowMerge,
+  summarisePlan,
+  type RowMergePlan,
+} from "./lib/merge-fields";
+
+// Defaults for the Kind Country campaign.
+const DEFAULT_USER_ID = "fc8ae595-641f-4127-87ad-03588f3710d1";
+const DEFAULT_CAMPAIGN_ID = "f6220b21-bff2-4419-a8c1-3dd7d6fc371b";
+const DEFAULT_PARENT_LOCATION = "Sothery";
+
+interface CliArgs {
+  markdown: string;
+  chapter: number;
+  configPath: string | null;
+  campaignId: string;
+  userId: string;
+  defaultParent: string;
+  dryRun: boolean;
+  verbose: boolean;
+  /** Normalized names the user has explicitly opted to insert despite a substring collision. */
+  allowDuplicatesOf: Set<string>;
+  /** Normalized names where --force-from-source overrides the preserve-non-empty rule. */
+  forceFromSource: Set<string>;
+}
+
+function parseCli(): CliArgs {
+  const { values, positionals } = parseArgs({
+    options: {
+      chapter: { type: "string" },
+      config: { type: "string" },
+      "campaign-id": { type: "string" },
+      "user-id": { type: "string" },
+      "default-parent": { type: "string" },
+      "allow-duplicate-of": { type: "string", multiple: true },
+      "force-from-source": { type: "string", multiple: true },
+      "dry-run": { type: "boolean", default: false },
+      verbose: { type: "boolean", short: "v", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help || positionals.length === 0) {
+    printUsage();
+    process.exit(values.help ? 0 : 1);
+  }
+
+  if (!values.chapter) {
+    console.error("ERROR: --chapter is required");
+    process.exit(1);
+  }
+  const chapter = Number(values.chapter);
+  if (!Number.isFinite(chapter) || chapter < 0) {
+    console.error(`ERROR: --chapter must be a non-negative number, got ${values.chapter}`);
+    process.exit(1);
+  }
+
+  return {
+    markdown: positionals[0]!,
+    chapter,
+    configPath: values.config ?? null,
+    campaignId: values["campaign-id"] ?? DEFAULT_CAMPAIGN_ID,
+    userId: values["user-id"] ?? DEFAULT_USER_ID,
+    defaultParent: values["default-parent"] ?? DEFAULT_PARENT_LOCATION,
+    dryRun: values["dry-run"] ?? false,
+    verbose: values.verbose ?? false,
+    allowDuplicatesOf: new Set(
+      ((values["allow-duplicate-of"] as string[] | undefined) ?? []).map(normalizeName),
+    ),
+    forceFromSource: new Set(
+      ((values["force-from-source"] as string[] | undefined) ?? []).map(normalizeName),
+    ),
+  };
+}
+
+function printUsage(): void {
+  const me = basename(process.argv[1] ?? "import-chapter-npcs.ts");
+  console.log(`Usage: tsx --env-file=.env.local ${me} <markdown_path> --chapter <N> [options]
+
+Options:
+  --chapter N                Chapter number (required)
+  --config PATH              Sidecar JSON config (default: <markdown>.config.json next to MD)
+  --campaign-id UUID         Target campaign (default: Kind Country)
+  --user-id UUID             Target user (default: Kind Country owner)
+  --default-parent NAME      Parent location name for new locations (default: Sothery)
+  --allow-duplicate-of NAME  Allow inserting an NPC whose name is a substring
+                             of an existing NPC NAME (or vice versa). Repeatable.
+                             Default: warn + skip such cases.
+  --force-from-source NAME   For NAME, OVERWRITE existing field values from source
+                             (instead of the default preserve-non-empty merge).
+                             Image columns (portrait_url, etc.) are protected by
+                             being outside the merge schema. Repeatable.
+  --dry-run                  Parse + plan; do not touch DB
+  -v, --verbose              Verbose logging
+  -h, --help                 This help`);
+}
+
+interface Logger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  debug: (msg: string) => void;
+}
+
+function makeLogger(verbose: boolean): Logger {
+  return {
+    info: (msg) => console.log(`INFO: ${msg}`),
+    warn: (msg) => console.warn(`WARN: ${msg}`),
+    debug: (msg) => verbose && console.log(`DEBUG: ${msg}`),
+  };
+}
+
+function loadSidecar(args: CliArgs, log: Logger): SidecarConfig {
+  let path = args.configPath;
+  if (!path) {
+    const guess = args.markdown.replace(/\.md$/, ".config.json");
+    if (existsSync(guess)) path = guess;
+    else {
+      // Look for repo-level config: scripts/chapter_npc_configs/chapter_<N>.json
+      const repoDefault = resolve(__dirname, "chapter_npc_configs", `chapter_${args.chapter}.json`);
+      if (existsSync(repoDefault)) path = repoDefault;
+    }
+  }
+  if (!path) {
+    log.info("no sidecar config; using auto-generated tags + defaults");
+    return {};
+  }
+  if (!existsSync(path)) {
+    log.warn(`config path not found: ${path}`);
+    return {};
+  }
+  log.info(`loaded sidecar config: ${path}`);
+  return JSON.parse(readFileSync(path, "utf8")) as SidecarConfig;
+}
+
+interface EnrichEntry {
+  record: NpcRecord;
+  existing: ExistingNpc;
+  plan: RowMergePlan;
+}
+
+interface Plan {
+  records: NpcRecord[];
+  locationSpecs: LocationSpec[];
+  skippedHeadings: string[];
+  npcsToInsert: NpcRecord[];
+  /** Existing rows that need fields filled from source. */
+  npcsToEnrich: EnrichEntry[];
+  /** Existing rows targeted by --force-from-source: overwrite all non-image fields. */
+  npcsToForceOverwrite: EnrichEntry[];
+  /** Existing rows where every source field is already covered — true skip. */
+  npcsAlreadyComplete: Array<{ record: NpcRecord; existing: ExistingNpc }>;
+  /** Existing rows with one or more field conflicts — surfaced, not written. */
+  npcsWithConflicts: EnrichEntry[];
+  /** Possible substring-match duplicates. Not inserted unless --allow-duplicate-of given. */
+  npcsBlocked: Array<{ record: NpcRecord; existing: string[] }>;
+  locationsToCreate: LocationSpec[];
+  locationsExisting: LocationSpec[];
+}
+
+function logPlan(plan: Plan, log: Logger): void {
+  log.info(
+    `plan: ${plan.locationsToCreate.length} new locations, ${plan.locationsExisting.length} existing reused, ` +
+    `${plan.npcsToInsert.length} new NPCs, ${plan.npcsToEnrich.length} to enrich, ` +
+    `${plan.npcsToForceOverwrite.length} to FORCE-OVERWRITE (per --force-from-source), ` +
+    `${plan.npcsAlreadyComplete.length} already complete, ` +
+    `${plan.npcsWithConflicts.length} with CONFLICTS, ${plan.npcsBlocked.length} BLOCKED`,
+  );
+  for (const s of plan.locationsToCreate) {
+    log.info(`  + location: ${s.name} (key=${s.key}, type=${s.type}, parent=${s.parent_name ?? "none"})`);
+  }
+  for (const s of plan.locationsExisting) {
+    log.info(`  = location exists: ${s.name} (key=${s.key})`);
+  }
+  for (const r of plan.npcsToInsert) {
+    const race = (r.race || "?").slice(0, 32);
+    log.info(
+      `  + INSERT: ${r.name.padEnd(36)} race=${race.padEnd(34)} loc=${(r.location_key ?? "(none)").padEnd(14)} rel=${r.relationship}, ${r.tags.length} tags`,
+    );
+  }
+  for (const e of plan.npcsToEnrich) {
+    log.info(`  ~ ENRICH: ${e.existing.name.padEnd(36)} ${summarisePlan(e.plan)}`);
+  }
+  for (const e of plan.npcsToForceOverwrite) {
+    log.warn(`  ! FORCE-OVERWRITE: ${e.existing.name.padEnd(36)} ${summarisePlan(e.plan)}`);
+    for (const field of e.plan.filled) {
+      const oldV = (e.existing as unknown as Record<string, unknown>)[field];
+      const newV = e.plan.updates[field];
+      const oldS = typeof oldV === "string" ? (oldV as string).slice(0, 80) : JSON.stringify(oldV);
+      const newS = typeof newV === "string" ? (newV as string).slice(0, 80) : JSON.stringify(newV);
+      log.warn(`      ${field}: existing=${JSON.stringify(oldS)} → source=${JSON.stringify(newS)}`);
+    }
+  }
+  for (const e of plan.npcsWithConflicts) {
+    log.warn(`  ! CONFLICT: ${e.existing.name.padEnd(36)} ${summarisePlan(e.plan)}`);
+    for (const c of e.plan.conflicts) {
+      const ex = typeof c.existing === "string" ? c.existing.slice(0, 60) : JSON.stringify(c.existing);
+      const sr = typeof c.source === "string" ? c.source.slice(0, 60) : JSON.stringify(c.source);
+      log.warn(`      ${c.field}: existing=${JSON.stringify(ex)} | source=${JSON.stringify(sr)}`);
+    }
+  }
+  for (const { record: r, existing: existingNpc } of plan.npcsAlreadyComplete) {
+    log.debug(`  = ALREADY COMPLETE: ${r.name} (db id=${existingNpc.id})`);
+  }
+  for (const blocked of plan.npcsBlocked) {
+    log.warn(
+      `  ! BLOCKED: ${blocked.record.name} looks like a duplicate of existing: ${blocked.existing.join(", ")}. ` +
+      `Either rename in the markdown, merge manually, or re-run with --allow-duplicate-of="${blocked.existing[0]}"`,
+    );
+  }
+  for (const r of plan.npcsToInsert) {
+    if (r.tags.length < 8 || r.tags.length > 13) {
+      log.warn(`${r.name}: ${r.tags.length} tags (target 8-13); consider sidecar override`);
+    }
+  }
+}
+
+async function main(): Promise<number> {
+  const args = parseCli();
+  const log = makeLogger(args.verbose);
+
+  if (!existsSync(args.markdown)) {
+    console.error(`ERROR: markdown file not found: ${args.markdown}`);
+    return 1;
+  }
+
+  const config = loadSidecar(args, log);
+  const text = readFileSync(args.markdown, "utf8");
+  const blocks = splitNpcBlocks(text);
+  log.info(`found ${blocks.length} top-level \`## \` blocks`);
+
+  const defaultLocKey = config.default_location_key ?? null;
+  const skippedHeadings: string[] = [];
+  const records: NpcRecord[] = [];
+  for (const { heading, body } of blocks) {
+    if (isSkipHeading(heading)) {
+      skippedHeadings.push(heading);
+      continue;
+    }
+    const rec = parseNpc(heading, body, args.chapter, defaultLocKey);
+    if (rec) records.push(rec);
+  }
+  log.info(
+    `parsed ${records.length} NPCs; skipped ${skippedHeadings.length} non-NPC headings (${skippedHeadings.join(", ") || "none"})`,
+  );
+
+  applySidecar(records, config);
+  const locationSpecs = resolveLocationSpecs(config, args.defaultParent);
+
+  // Open DB connection
+  const supabase = createServiceClient();
+  const state = await fetchDbState(supabase, args.userId, args.campaignId);
+  log.info(`DB state: ${state.npcs.length} existing NPCs, ${state.locations.length} existing locations in campaign`);
+
+  // Plan: split by idempotency
+  // 1. exact normalized name match -> compute merge plan:
+  //      writes pending -> npcsToEnrich
+  //      conflicts only  -> npcsWithConflicts (flagged, NOT written)
+  //      nothing pending -> npcsAlreadyComplete (true skip)
+  // 2. substring match (either direction) -> blocked (warn) unless explicitly allowed
+  // 3. otherwise -> insert
+  const npcsToInsert: NpcRecord[] = [];
+  const npcsToEnrich: EnrichEntry[] = [];
+  const npcsToForceOverwrite: EnrichEntry[] = [];
+  const npcsAlreadyComplete: Array<{ record: NpcRecord; existing: ExistingNpc }> = [];
+  const npcsWithConflicts: EnrichEntry[] = [];
+  const npcsBlocked: Array<{ record: NpcRecord; existing: string[] }> = [];
+  const existingNormalized = new Set(state.npcs.map((n) => n.normalized));
+  for (const r of records) {
+    const exactMatch = state.npcByNormalizedName.get(normalizeName(r.name));
+    if (exactMatch) {
+      const locName = r.location_key
+        ? locationSpecs.find((s) => s.key === r.location_key)?.name
+        : undefined;
+      const locationId = locName ? state.locationByName.get(locName) ?? null : null;
+      const sourcePayload: Record<string, unknown> = {
+        race: r.race || null,
+        occupation: r.occupation || null,
+        appearance: r.appearance || null,
+        personality: r.personality || null,
+        backstory: r.backstory || null,
+        notes: r.notes || null,
+        status: r.status,
+        relationship: r.relationship,
+        relevance: r.relevance,
+        tags: r.tags,
+        location_id: locationId,
+      };
+      const existingRow = exactMatch as unknown as Record<string, unknown>;
+      const useForceOverride = args.forceFromSource.has(normalizeName(r.name));
+
+      const mergePlan = useForceOverride
+        ? planForceOverwrite(existingRow, sourcePayload, NPC_MERGE_FIELDS)
+        : planRowMerge(existingRow, sourcePayload, NPC_MERGE_FIELDS);
+
+      if (useForceOverride) {
+        if (planHasWrites(mergePlan)) {
+          npcsToForceOverwrite.push({ record: r, existing: exactMatch, plan: mergePlan });
+        } else {
+          npcsAlreadyComplete.push({ record: r, existing: exactMatch });
+        }
+      } else if (mergePlan.conflicts.length > 0) {
+        npcsWithConflicts.push({ record: r, existing: exactMatch, plan: mergePlan });
+      } else if (planHasWrites(mergePlan)) {
+        npcsToEnrich.push({ record: r, existing: exactMatch, plan: mergePlan });
+      } else {
+        npcsAlreadyComplete.push({ record: r, existing: exactMatch });
+      }
+      continue;
+    }
+    const dups = findPotentialDuplicates(r.name, existingNormalized);
+    const allowed = dups.every((d) => args.allowDuplicatesOf.has(d));
+    if (dups.length > 0 && !allowed) {
+      npcsBlocked.push({ record: r, existing: dups });
+      continue;
+    }
+    npcsToInsert.push(r);
+  }
+  const locationsToCreate: LocationSpec[] = [];
+  const locationsExisting: LocationSpec[] = [];
+  for (const s of locationSpecs) {
+    if (state.locationByName.has(s.name)) locationsExisting.push(s);
+    else locationsToCreate.push(s);
+  }
+
+  const plan: Plan = {
+    records,
+    locationSpecs,
+    skippedHeadings,
+    npcsToInsert,
+    npcsToEnrich,
+    npcsToForceOverwrite,
+    npcsAlreadyComplete,
+    npcsWithConflicts,
+    npcsBlocked,
+    locationsToCreate,
+    locationsExisting,
+  };
+  logPlan(plan, log);
+
+  if (
+    npcsToInsert.length === 0 &&
+    npcsToEnrich.length === 0 &&
+    npcsToForceOverwrite.length === 0 &&
+    locationsToCreate.length === 0
+  ) {
+    log.info("nothing to write");
+    return 0;
+  }
+
+  if (args.dryRun) {
+    log.info("dry-run: not touching DB");
+    const summary = {
+      new_locations: locationsToCreate.map((s) => ({
+        name: s.name, type: s.type, parent: s.parent_name, tags: s.tags,
+      })),
+      new_npcs: npcsToInsert.map((r) => ({
+        name: r.name,
+        race: r.race,
+        occupation: r.occupation,
+        location_key: r.location_key,
+        status: r.status,
+        relationship: r.relationship,
+        relevance: r.relevance,
+        tags: r.tags,
+        tag_count: r.tags.length,
+        lens: {
+          appearance_len: r.appearance.length,
+          personality_len: r.personality.length,
+          backstory_len: r.backstory.length,
+          notes_len: r.notes.length,
+        },
+      })),
+      enrich_existing_npcs: npcsToEnrich.map((e) => ({
+        name: e.existing.name,
+        id: e.existing.id,
+        filled: e.plan.filled,
+        appended: e.plan.appended,
+        unioned: e.plan.unioned,
+        unchanged: e.plan.unchanged,
+        update_fields: Object.keys(e.plan.updates),
+      })),
+      force_overwrite_npcs: npcsToForceOverwrite.map((e) => ({
+        name: e.existing.name,
+        id: e.existing.id,
+        overwrites: Object.fromEntries(
+          e.plan.filled.map((field) => {
+            const existingV = (e.existing as unknown as Record<string, unknown>)[field];
+            const newV = e.plan.updates[field];
+            const trunc = (x: unknown) =>
+              typeof x === "string" && x.length > 200 ? `${x.slice(0, 200)}…(${x.length}ch)` : x;
+            return [field, { from: trunc(existingV), to: trunc(newV) }];
+          }),
+        ),
+        unchanged: e.plan.unchanged,
+      })),
+      conflicts: npcsWithConflicts.map((e) => ({
+        name: e.existing.name,
+        id: e.existing.id,
+        fields: e.plan.conflicts.map((c) => c.field),
+        filled_anyway: [], // never write conflict fields
+        details: e.plan.conflicts.map((c) => ({
+          field: c.field,
+          existing: typeof c.existing === "string" ? (c.existing as string).slice(0, 200) : c.existing,
+          source: typeof c.source === "string" ? (c.source as string).slice(0, 200) : c.source,
+        })),
+      })),
+      already_complete_npcs: npcsAlreadyComplete.map((p) => p.record.name),
+      skipped_existing_locations: locationsExisting.map((s) => s.name),
+      blocked_potential_duplicates: npcsBlocked.map((b) => ({
+        candidate: b.record.name, looks_like_existing: b.existing,
+      })),
+    };
+    console.log("=".repeat(60));
+    console.log("DRY-RUN PLAN (not executed)");
+    console.log("=".repeat(60));
+    console.log(JSON.stringify(summary, null, 2));
+    return 0;
+  }
+
+  // Execute — locations first (since enrichment may include location_id fills),
+  // then enrich-merges, then new inserts.
+  const locResult = await ensureLocations(supabase, args.userId, args.campaignId, locationSpecs, state);
+  log.info(`created ${locResult.created.length} locations, reused ${locResult.reused.length}`);
+
+  // Apply enrich-merges to existing NPCs. Issue updates one at a time so a
+  // single failure doesn't roll back everything.
+  let enrichedOk = 0;
+  for (const entry of npcsToEnrich) {
+    try {
+      const row = await enrichNpc(supabase, entry.existing.id, entry.plan);
+      enrichedOk++;
+      log.debug(`  enriched ${row.name} (${row.id}): ${summarisePlan(entry.plan)}`);
+    } catch (e) {
+      log.warn(`  enrich failed for ${entry.existing.name}: ${(e as Error).message}`);
+    }
+  }
+  log.info(`enriched ${enrichedOk}/${npcsToEnrich.length} existing NPCs`);
+
+  let forcedOk = 0;
+  for (const entry of npcsToForceOverwrite) {
+    try {
+      const row = await enrichNpc(supabase, entry.existing.id, entry.plan);
+      forcedOk++;
+      log.debug(`  force-overwrote ${row.name} (${row.id}): ${summarisePlan(entry.plan)}`);
+    } catch (e) {
+      log.warn(`  force-overwrite failed for ${entry.existing.name}: ${(e as Error).message}`);
+    }
+  }
+  if (npcsToForceOverwrite.length > 0) {
+    log.info(`force-overwrote ${forcedOk}/${npcsToForceOverwrite.length} existing NPCs`);
+  }
+
+  const inserted = await insertNpcs(supabase, args.userId, args.campaignId, npcsToInsert, locResult.byKey);
+  log.info(`inserted ${inserted.length} new NPCs`);
+  for (const row of inserted) log.debug(`  ${row.name} → ${row.id} (location_id=${row.location_id ?? "null"})`);
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`FATAL: ${msg}`);
+    if (err instanceof Error && err.stack) console.error(err.stack);
+    process.exit(2);
+  },
+);

--- a/scripts/import-faiths.test.ts
+++ b/scripts/import-faiths.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Behavioral tests for the importer's CLI-level guarantees. The pure parsing
+ * tests live in `scripts/lib/parse-faiths.test.ts`.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DRY_RUN_PANTHEON_UUIDS,
+  ensurePantheons,
+} from "./import-faiths";
+
+// Minimal Logger shape (matches the non-exported interface via structural typing).
+const noopLog = { info: () => {}, warn: () => {}, debug: () => {} };
+
+/** Build a stub Supabase client that:
+ *   - allows SELECT chains (returns the data the test prescribes)
+ *   - records any call to `.insert()` so the test can assert "no writes"
+ */
+function makeStubClient(existingPantheons: Array<{ id: string; name: string }>) {
+  const insertCalls: unknown[] = [];
+  const stub = {
+    from: (_table: string) => ({
+      select: () => ({
+        eq: function eqChain(): unknown { return this; },
+        in: () => Promise.resolve({ data: existingPantheons, error: null }),
+      }),
+      insert: (payload: unknown) => {
+        insertCalls.push(payload);
+        return { select: () => Promise.resolve({ data: [], error: null }) };
+      },
+    }),
+  };
+  // Make `eq()` chainable so `.eq(...).eq(...).in(...)` resolves.
+  const select = stub.from("pantheons").select;
+  // Replace the eq function with one that returns the same select shape.
+  stub.from = (_table: string) => {
+    const fromShape: ReturnType<typeof stub.from> = {
+      select: () => {
+        const selectShape: ReturnType<typeof select> = {
+          eq: function chain() { return selectShape; },
+          in: () => Promise.resolve({ data: existingPantheons, error: null }),
+        };
+        return selectShape;
+      },
+      insert: (payload: unknown) => {
+        insertCalls.push(payload);
+        return { select: () => Promise.resolve({ data: [], error: null }) };
+      },
+    };
+    return fromShape;
+  };
+  return {
+    client: stub as unknown as Parameters<typeof ensurePantheons>[0],
+    insertCalls,
+  };
+}
+
+describe("ensurePantheons — dry-run performs ZERO writes", () => {
+  it("against an empty-pantheons campaign, dry-run does NOT insert and returns placeholder UUIDs", async () => {
+    const { client, insertCalls } = makeStubClient([]);
+
+    const result = await ensurePantheons(client, "user-uuid", "campaign-uuid", noopLog, /*dryRun=*/ true);
+
+    expect(insertCalls).toEqual([]); // ← the contract: no writes
+    expect(result.size).toBe(3);
+    // All 3 pantheons resolve to placeholder UUIDs (none existed)
+    expect(result.get("Heavenly Bodies")).toBe(DRY_RUN_PANTHEON_UUIDS["Heavenly Bodies"]);
+    expect(result.get("Lesser Deities")).toBe(DRY_RUN_PANTHEON_UUIDS["Lesser Deities"]);
+    expect(result.get("Folk and Margin Figures")).toBe(DRY_RUN_PANTHEON_UUIDS["Folk and Margin Figures"]);
+  });
+
+  it("against a partially-populated campaign, dry-run uses real UUIDs for existing + placeholders for missing", async () => {
+    // Simulate: Heavenly Bodies already exists; the other 2 do not.
+    const realHeavenlyUuid = "abcd1234-aaaa-bbbb-cccc-000000000000";
+    const { client, insertCalls } = makeStubClient([
+      { id: realHeavenlyUuid, name: "Heavenly Bodies" },
+    ]);
+
+    const result = await ensurePantheons(client, "user-uuid", "campaign-uuid", noopLog, /*dryRun=*/ true);
+
+    expect(insertCalls).toEqual([]); // ← still no writes
+    expect(result.get("Heavenly Bodies")).toBe(realHeavenlyUuid); // real UUID preserved
+    expect(result.get("Lesser Deities")).toBe(DRY_RUN_PANTHEON_UUIDS["Lesser Deities"]);
+    expect(result.get("Folk and Margin Figures")).toBe(DRY_RUN_PANTHEON_UUIDS["Folk and Margin Figures"]);
+  });
+
+  it("against a fully-populated campaign, dry-run returns all real UUIDs (no placeholders, no inserts)", async () => {
+    const realIds = {
+      "Heavenly Bodies": "11111111-1111-1111-1111-111111111111",
+      "Lesser Deities": "22222222-2222-2222-2222-222222222222",
+      "Folk and Margin Figures": "33333333-3333-3333-3333-333333333333",
+    };
+    const { client, insertCalls } = makeStubClient(
+      Object.entries(realIds).map(([name, id]) => ({ id, name })),
+    );
+
+    const result = await ensurePantheons(client, "user-uuid", "campaign-uuid", noopLog, /*dryRun=*/ true);
+
+    expect(insertCalls).toEqual([]);
+    for (const [name, id] of Object.entries(realIds)) {
+      expect(result.get(name)).toBe(id);
+    }
+  });
+
+  it("control case: when dryRun=false against empty-pantheons, DOES call insert", async () => {
+    const { client, insertCalls } = makeStubClient([]);
+
+    await ensurePantheons(client, "user-uuid", "campaign-uuid", noopLog, /*dryRun=*/ false);
+
+    expect(insertCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe("DRY_RUN_PANTHEON_UUIDS — placeholder shape", () => {
+  it("uses recognizable DEAD-BEEF-tagged placeholders for all 3 pantheons", () => {
+    for (const [_name, uuid] of Object.entries(DRY_RUN_PANTHEON_UUIDS)) {
+      // The DEAD/4EEF middle is the recognizable marker — real v4 UUIDs would
+      // never have these segments, so any accidental DB write attempting to
+      // use one would fail loudly rather than silently corrupting data.
+      expect(uuid).toMatch(/-dead-4eef-/);
+    }
+  });
+});

--- a/scripts/import-faiths.ts
+++ b/scripts/import-faiths.ts
@@ -63,6 +63,11 @@ import {
   type FieldSpec,
   type RowMergePlan,
 } from "./lib/merge-fields";
+import {
+  DEITY_RICHTEXT_FIELDS,
+  PANTHEON_RICHTEXT_FIELDS,
+  tiptapifyFields,
+} from "./lib/tiptap";
 
 /**
  * Field merge schema for deity enrichment. Only the fields the faiths parser
@@ -307,13 +312,15 @@ export async function ensurePantheons(
   log.info(`ensurePantheons: inserting ${missing.length} new pantheon(s): ${missing.map((m) => m.name).join(", ")}`);
   const { data: inserted, error: insErr } = await supabase
     .from("pantheons")
-    .insert(missing.map((m) => ({
+    // `description` is a Tiptap-typed field — convert to Tiptap JSON at the
+    // write boundary so the editor renders it correctly.
+    .insert(missing.map((m) => tiptapifyFields({
       user_id: userId,
       campaign_id: campaignId,
       name: m.name,
       description: m.description,
       tags: m.tags,
-    })))
+    }, PANTHEON_RICHTEXT_FIELDS)))
     .select("id, name");
   if (insErr) throw insErr;
   for (const row of inserted ?? []) byName.set(row.name as string, row.id as string);
@@ -581,11 +588,14 @@ async function main(): Promise<number> {
 
   // Execute — UPDATE existing rows (enriches + force-overwrites use the same
   // UPDATE shape; only the plan-builder differed), then INSERT new rows.
+  // Rich-text fields (description, dm_notes) are converted from plain markdown
+  // to Tiptap JSON at this write boundary so they render correctly in the UI.
   let enrichedOk = 0;
   for (const entry of toEnrich) {
+    const updates = tiptapifyFields(entry.plan.updates, DEITY_RICHTEXT_FIELDS);
     const { error } = await supabase
       .from("deities")
-      .update(entry.plan.updates)
+      .update(updates)
       .eq("id", entry.existing.id);
     if (error) {
       log.warn(`  enrich failed for ${entry.existing.name}: ${error.message}`);
@@ -598,9 +608,10 @@ async function main(): Promise<number> {
 
   let forcedOk = 0;
   for (const entry of toForceOverwrite) {
+    const updates = tiptapifyFields(entry.plan.updates, DEITY_RICHTEXT_FIELDS);
     const { error } = await supabase
       .from("deities")
-      .update(entry.plan.updates)
+      .update(updates)
       .eq("id", entry.existing.id);
     if (error) {
       log.warn(`  force-overwrite failed for ${entry.existing.name}: ${error.message}`);
@@ -614,10 +625,10 @@ async function main(): Promise<number> {
   }
 
   if (toInsert.length > 0) {
-    const payload = toInsert.map((r) => ({
+    const payload = toInsert.map((r) => tiptapifyFields({
       ...recordToInsert(r, args.campaignId, pantheonByName.get(r.pantheon) ?? null),
       user_id: args.userId,
-    }));
+    }, DEITY_RICHTEXT_FIELDS));
     const { data, error } = await supabase
       .from("deities")
       .insert(payload)

--- a/scripts/import-faiths.ts
+++ b/scripts/import-faiths.ts
@@ -1,0 +1,649 @@
+#!/usr/bin/env tsx
+/**
+ * Import a faiths/deities markdown file into a campaign's `deities` table.
+ *
+ * Usage:
+ *   npm run import-faiths -- <markdown_path> [options]
+ *
+ * Or invoke directly:
+ *   tsx --env-file=.env.local scripts/import-faiths.ts <md>
+ *
+ * Required env vars:
+ *   VITE_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *
+ * Flags:
+ *   --campaign-id UUID         Target campaign (default: Kind Country).
+ *   --user-id UUID             Target user (default: Kind Country owner).
+ *   --dry-run                  Parse + plan; print summary; do not touch DB.
+ *   --allow-duplicate-of NAME  Allow inserting a deity whose name is a substring
+ *                              of an existing deity NAME (or vice versa). Repeatable.
+ *   --verbose / -v             Verbose logging.
+ *
+ * Idempotency: matches existing deities by normalized name (case-insensitive,
+ * whitespace-collapsed) within the campaign. Substring-name collisions are
+ * BLOCKED with a warning unless `--allow-duplicate-of` is passed. See
+ * `scripts/import-chapter-npcs.ts` for the same convention.
+ *
+ * No pantheon is created automatically — Sothery's design is "small faiths,
+ * no orthodoxy". Add pantheons manually in the UI if a campaign needs them.
+ *
+ * Source format: `## Deity Name` headings at top level. Skips group sections
+ * matching `SKIP_HEADING_PREFIXES` (e.g. "Folk and Margin Figures",
+ * "A Note for Players"). See `scripts/lib/parse-faiths.ts` for details.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { basename } from "node:path";
+import { parseArgs } from "node:util";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { DeityInsert } from "@/types/deity.types";
+
+import {
+  FOLK_AND_MARGIN_HEADING,
+  PANTHEON_FOLK,
+  PANTHEON_HEAVENLY,
+  PANTHEON_LESSER,
+  findPotentialDuplicates,
+  isSkipHeading,
+  normalizeName,
+  parseClericDomains,
+  parseFaith,
+  parseFolkAndMargin,
+  parsePreambleSuns,
+  splitFaithBlocks,
+  type FaithRecord,
+} from "./lib/parse-faiths";
+import {
+  planForceOverwrite,
+  planHasWrites,
+  planRowMerge,
+  summarisePlan,
+  type FieldSpec,
+  type RowMergePlan,
+} from "./lib/merge-fields";
+
+/**
+ * Field merge schema for deity enrichment. Only the fields the faiths parser
+ * actually produces appear here — `symbol_image_url`, `portrait_*`, etc. are
+ * deliberately untouched so the importer never overwrites manual UI work.
+ *
+ * `portfolio` is scalar (short one-sentence summary, not prose) — we don't
+ * want to append a separator below a one-line summary.
+ */
+const DEITY_MERGE_FIELDS: Record<string, FieldSpec> = {
+  titles: { kind: "scalar" },
+  alignment: { kind: "scalar" },
+  symbol: { kind: "scalar" },
+  domains: { kind: "array" },
+  portfolio: { kind: "scalar" },
+  description: { kind: "prose" },
+  dm_notes: { kind: "prose" },
+  tags: { kind: "array" },
+  // Pantheon FK is a scalar: existing-empty → fill from source; existing-set
+  // → leave (so manual reassignment in the UI isn't clobbered by a re-import).
+  pantheon_id: { kind: "scalar" },
+};
+
+// Kind Country defaults (same as the NPC importer).
+const DEFAULT_USER_ID = "fc8ae595-641f-4127-87ad-03588f3710d1";
+const DEFAULT_CAMPAIGN_ID = "f6220b21-bff2-4419-a8c1-3dd7d6fc371b";
+
+interface CliArgs {
+  markdown: string;
+  campaignId: string;
+  userId: string;
+  dryRun: boolean;
+  verbose: boolean;
+  allowDuplicatesOf: Set<string>;
+  /**
+   * Per-record override: for names in this set, the importer uses
+   * `planForceOverwrite` instead of the default `planRowMerge`. Existing user
+   * content gets replaced with source values for every field in the merge
+   * schema. Image-related columns are out of the schema and remain protected.
+   * Intended for one-off "I made it up; please overwrite from canonical lore"
+   * cases. Not a permanent rule change.
+   */
+  forceFromSource: Set<string>;
+}
+
+function parseCli(): CliArgs {
+  const { values, positionals } = parseArgs({
+    options: {
+      "campaign-id": { type: "string" },
+      "user-id": { type: "string" },
+      "allow-duplicate-of": { type: "string", multiple: true },
+      "force-from-source": { type: "string", multiple: true },
+      "dry-run": { type: "boolean", default: false },
+      verbose: { type: "boolean", short: "v", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help || positionals.length === 0) {
+    printUsage();
+    process.exit(values.help ? 0 : 1);
+  }
+
+  return {
+    markdown: positionals[0]!,
+    campaignId: values["campaign-id"] ?? DEFAULT_CAMPAIGN_ID,
+    userId: values["user-id"] ?? DEFAULT_USER_ID,
+    dryRun: values["dry-run"] ?? false,
+    verbose: values.verbose ?? false,
+    allowDuplicatesOf: new Set(
+      ((values["allow-duplicate-of"] as string[] | undefined) ?? []).map(normalizeName),
+    ),
+    forceFromSource: new Set(
+      ((values["force-from-source"] as string[] | undefined) ?? []).map(normalizeName),
+    ),
+  };
+}
+
+function printUsage(): void {
+  const me = basename(process.argv[1] ?? "import-faiths.ts");
+  console.log(`Usage: tsx --env-file=.env.local ${me} <markdown_path> [options]
+
+Options:
+  --campaign-id UUID         Target campaign (default: Kind Country)
+  --user-id UUID             Target user (default: Kind Country owner)
+  --allow-duplicate-of NAME  Allow inserting a deity whose name is a substring
+                             of an existing deity NAME (or vice versa). Repeatable.
+  --force-from-source NAME   For NAME, OVERWRITE existing field values from source
+                             (instead of the default preserve-non-empty merge).
+                             Image columns are protected by being outside the
+                             merge schema. Repeatable. One-off override.
+  --dry-run                  Parse + plan; do not touch DB
+  -v, --verbose              Verbose logging
+  -h, --help                 This help`);
+}
+
+interface Logger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  debug: (msg: string) => void;
+}
+
+function makeLogger(verbose: boolean): Logger {
+  return {
+    info: (msg) => console.log(`INFO: ${msg}`),
+    warn: (msg) => console.warn(`WARN: ${msg}`),
+    debug: (msg) => verbose && console.log(`DEBUG: ${msg}`),
+  };
+}
+
+function createServiceClient(): SupabaseClient {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Run via:\n" +
+      "  tsx --env-file=.env.local scripts/import-faiths.ts ...",
+    );
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+interface ExistingDeity {
+  id: string;
+  name: string;
+  normalized: string;
+  titles: string | null;
+  alignment: string | null;
+  symbol: string | null;
+  domains: string[];
+  portfolio: string | null;
+  description: string | null;
+  dm_notes: string | null;
+  tags: string[];
+  pantheon_id: string | null;
+}
+
+async function fetchExistingDeities(
+  supabase: SupabaseClient,
+  userId: string,
+  campaignId: string,
+): Promise<ExistingDeity[]> {
+  const { data, error } = await supabase
+    .from("deities")
+    .select("id, name, titles, alignment, symbol, domains, portfolio, description, dm_notes, tags, pantheon_id")
+    .eq("user_id", userId)
+    .eq("campaign_id", campaignId);
+  if (error) throw error;
+  return (data ?? []).map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+    normalized: normalizeName(r.name as string),
+    titles: (r.titles as string | null) ?? null,
+    alignment: (r.alignment as string | null) ?? null,
+    symbol: (r.symbol as string | null) ?? null,
+    domains: (r.domains as string[] | null) ?? [],
+    portfolio: (r.portfolio as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    dm_notes: (r.dm_notes as string | null) ?? null,
+    tags: (r.tags as string[] | null) ?? [],
+    pantheon_id: (r.pantheon_id as string | null) ?? null,
+  }));
+}
+
+/**
+ * Deterministic placeholder UUIDs used by `ensurePantheons` in dry-run mode.
+ * The shape is a valid v4-like UUID with a recognizable "DEAD/BEEF" middle so
+ * any DB write attempting to use one would fail loudly. Exported for tests.
+ */
+export const DRY_RUN_PANTHEON_UUIDS: Record<string, string> = {
+  "Heavenly Bodies":        "00000000-dead-4eef-8000-000000000001",
+  "Lesser Deities":         "00000000-dead-4eef-8000-000000000002",
+  "Folk and Margin Figures": "00000000-dead-4eef-8000-000000000003",
+};
+
+/**
+ * Ensure the 3 canonical Sothery pantheons exist in this campaign. Matched by
+ * `(user_id, campaign_id, name)` for idempotency. Returns a name→id map so
+ * each FaithRecord can resolve its `pantheon` string to a `pantheon_id` FK.
+ *
+ * In `dryRun` mode, performs ZERO DB calls and returns deterministic
+ * placeholder UUIDs. Required so `--dry-run` is contractually read-only —
+ * the planning step still gets a name→id map and produces a coherent preview,
+ * but no rows are ever written.
+ */
+export async function ensurePantheons(
+  supabase: SupabaseClient,
+  userId: string,
+  campaignId: string,
+  log: Logger,
+  dryRun = false,
+): Promise<Map<string, string>> {
+  const want: Array<{ name: string; description: string; tags: string[] }> = [
+    {
+      name: PANTHEON_HEAVENLY,
+      description:
+        "The cosmological tier above and below the lesser deities. The Three Suns — gold, rose, and purple — are the high cosmology of Sothery; not directly worshipped by most peoples, and serving one is regarded with mild reverence and mild bafflement. The Saucer is the porcelain dish on which the country rests; venerated by some, nodded to by all, addressed in the way one addresses a room one is grateful to be inside.",
+      tags: ["cosmology", "heavenly-bodies", "three-suns", "saucer"],
+    },
+    {
+      name: PANTHEON_LESSER,
+      description:
+        "The small faiths most commonly named in the country. No church and no orthodoxy; most peoples honor a thing — a hearth, a slow kettle, a moth, a door — without ever quite calling it a god. Most peoples have one primary devotion, but no faith is exclusive. The country shares its faiths the way it shares its tea, with very little ceremony.",
+      tags: ["lesser-deities", "small-faiths", "sothery"],
+    },
+    {
+      name: PANTHEON_FOLK,
+      description:
+        "Figures the country talks about and sometimes prays to without quite admitting it. Not lesser deities exactly — they may be stories, they may be persons, they may be both. PC devotion to these figures is a session-zero conversation.",
+      tags: ["folk-figures", "margin-figures", "session-zero"],
+    },
+  ];
+
+  // Read-only fetch of existing pantheons (safe in both modes — SELECTs only).
+  const { data: existing, error: fetchErr } = await supabase
+    .from("pantheons")
+    .select("id, name")
+    .eq("user_id", userId)
+    .eq("campaign_id", campaignId)
+    .in("name", want.map((w) => w.name));
+  if (fetchErr) throw fetchErr;
+  const byName = new Map<string, string>((existing ?? []).map((r) => [r.name as string, r.id as string]));
+
+  const missing = want.filter((w) => !byName.has(w.name));
+  if (missing.length === 0) {
+    log.info(`ensurePantheons: all ${want.length} pantheons already exist; reusing`);
+    return byName;
+  }
+
+  if (dryRun) {
+    // Don't insert — substitute placeholder UUIDs for the missing pantheons.
+    // Existing pantheons keep their real UUIDs so the dry-run merge plan is
+    // accurate for already-assigned deities.
+    log.info(`ensurePantheons: dry-run — ${missing.length} pantheon(s) would be inserted: ${missing.map((m) => m.name).join(", ")} (using placeholder UUIDs)`);
+    for (const m of missing) byName.set(m.name, DRY_RUN_PANTHEON_UUIDS[m.name]!);
+    return byName;
+  }
+
+  log.info(`ensurePantheons: inserting ${missing.length} new pantheon(s): ${missing.map((m) => m.name).join(", ")}`);
+  const { data: inserted, error: insErr } = await supabase
+    .from("pantheons")
+    .insert(missing.map((m) => ({
+      user_id: userId,
+      campaign_id: campaignId,
+      name: m.name,
+      description: m.description,
+      tags: m.tags,
+    })))
+    .select("id, name");
+  if (insErr) throw insErr;
+  for (const row of inserted ?? []) byName.set(row.name as string, row.id as string);
+  return byName;
+}
+
+function recordToInsert(r: FaithRecord, campaignId: string, pantheonId: string | null): DeityInsert {
+  return {
+    campaign_id: campaignId,
+    name: r.name,
+    titles: r.titles,
+    alternate_names: [],
+    pantheon_id: pantheonId,
+    alignment: r.alignment,
+    symbol: r.symbol,
+    symbol_image_url: null,
+    portrait_url: null,
+    portrait_focal_point: null,
+    domains: r.domains,
+    portfolio: r.portfolio,
+    description: r.description || null,
+    dm_notes: r.dm_notes,
+    tags: r.tags,
+    player_visible_to: [],
+  } satisfies Omit<DeityInsert, never>;
+}
+
+async function main(): Promise<number> {
+  const args = parseCli();
+  const log = makeLogger(args.verbose);
+
+  if (!existsSync(args.markdown)) {
+    console.error(`ERROR: markdown file not found: ${args.markdown}`);
+    return 1;
+  }
+
+  const text = readFileSync(args.markdown, "utf8");
+  const blocks = splitFaithBlocks(text);
+  log.info(`found ${blocks.length} top-level \`## \` blocks`);
+
+  const skippedHeadings: string[] = [];
+  const parsed: FaithRecord[] = [];
+  const domainWarnings: Array<{ name: string; unknown: string[] }> = [];
+
+  // Pass 1 — Three Suns from preamble (no markdown ## entries, content from campaign_book.md)
+  const sunRecords = parsePreambleSuns(text);
+  if (sunRecords.length > 0) {
+    log.info(`parsePreambleSuns: produced ${sunRecords.length} sun records from preamble`);
+    parsed.push(...sunRecords);
+  }
+
+  // Pass 2 — main ## blocks; Folk and Margin Figures routes to its dedicated sub-parser
+  for (const { heading, body } of blocks) {
+    if (isSkipHeading(heading)) {
+      skippedHeadings.push(heading);
+      continue;
+    }
+    if (heading === FOLK_AND_MARGIN_HEADING) {
+      const folks = parseFolkAndMargin(body);
+      log.info(`parseFolkAndMargin: produced ${folks.length} record(s) from "${heading}"`);
+      parsed.push(...folks);
+      continue;
+    }
+    const rec = parseFaith(heading, body);
+    if (!rec) continue;
+    parsed.push(rec);
+    const { unknown } = parseClericDomains(body);
+    if (unknown.length > 0) domainWarnings.push({ name: rec.name, unknown });
+  }
+
+  log.info(
+    `parsed ${parsed.length} deities total; skipped ${skippedHeadings.length} non-deity headings (${skippedHeadings.join(", ") || "none"})`,
+  );
+
+  const supabase = createServiceClient();
+
+  // Step 1 — ensure the 3 canonical pantheons exist (idempotent). Required
+  // before planning, because every FaithRecord's `pantheon` string needs to
+  // resolve to a `pantheon_id` UUID.
+  //
+  // In dry-run mode, this returns placeholder UUIDs without touching the DB
+  // (so `--dry-run` is contractually read-only). The placeholders make it
+  // through planning + log output unchanged; only the actual UPDATE/INSERT
+  // statements would expand them to real IDs, and those don't run in dry-run.
+  const pantheonByName = await ensurePantheons(supabase, args.userId, args.campaignId, log, args.dryRun);
+
+  const existing = await fetchExistingDeities(supabase, args.userId, args.campaignId);
+  log.info(`DB state: ${existing.length} existing deities in campaign`);
+
+  const existingByNorm = new Map(existing.map((d) => [d.normalized, d]));
+  const existingNormalizedSet = new Set(existing.map((d) => d.normalized));
+
+  // Plan: 6 buckets — same enrich-merge model as the NPC importer, plus
+  // a separate "force-overwrite" bucket for per-record --force-from-source.
+  //  - toInsert: brand-new deities
+  //  - toEnrich: existing rows with one or more fields to fill (default merge)
+  //  - toForceOverwrite: existing rows overridden via --force-from-source
+  //  - alreadyComplete: existing rows where source has nothing new to add
+  //  - withConflicts: existing rows where source disagrees with user content
+  //  - blocked: substring-name collisions (separate concern)
+  const toInsert: FaithRecord[] = [];
+  const toEnrich: Array<{ record: FaithRecord; existing: ExistingDeity; plan: RowMergePlan }> = [];
+  const toForceOverwrite: Array<{ record: FaithRecord; existing: ExistingDeity; plan: RowMergePlan }> = [];
+  const alreadyComplete: Array<{ record: FaithRecord; existing: ExistingDeity }> = [];
+  const withConflicts: Array<{ record: FaithRecord; existing: ExistingDeity; plan: RowMergePlan }> = [];
+  const blocked: Array<{ record: FaithRecord; existing: string[] }> = [];
+
+  for (const r of parsed) {
+    const pantheonId = pantheonByName.get(r.pantheon);
+    if (!pantheonId) {
+      log.warn(`  ! ${r.name}: pantheon "${r.pantheon}" did not resolve to a UUID — skipping`);
+      continue;
+    }
+    const exact = existingByNorm.get(normalizeName(r.name));
+    if (exact) {
+      const sourcePayload: Record<string, unknown> = {
+        titles: r.titles,
+        alignment: r.alignment,
+        symbol: r.symbol,
+        domains: r.domains,
+        portfolio: r.portfolio,
+        description: r.description || null,
+        dm_notes: r.dm_notes,
+        tags: r.tags,
+        pantheon_id: pantheonId,
+      };
+      const existingAsRow = exact as unknown as Record<string, unknown>;
+      const useForceOverride = args.forceFromSource.has(normalizeName(r.name));
+
+      const mergePlan = useForceOverride
+        ? planForceOverwrite(existingAsRow, sourcePayload, DEITY_MERGE_FIELDS)
+        : planRowMerge(existingAsRow, sourcePayload, DEITY_MERGE_FIELDS);
+
+      if (useForceOverride) {
+        if (planHasWrites(mergePlan)) {
+          toForceOverwrite.push({ record: r, existing: exact, plan: mergePlan });
+        } else {
+          alreadyComplete.push({ record: r, existing: exact });
+        }
+      } else if (mergePlan.conflicts.length > 0) {
+        withConflicts.push({ record: r, existing: exact, plan: mergePlan });
+      } else if (planHasWrites(mergePlan)) {
+        toEnrich.push({ record: r, existing: exact, plan: mergePlan });
+      } else {
+        alreadyComplete.push({ record: r, existing: exact });
+      }
+      continue;
+    }
+    const dups = findPotentialDuplicates(r.name, existingNormalizedSet);
+    const allowed = dups.every((d) => args.allowDuplicatesOf.has(d));
+    if (dups.length > 0 && !allowed) {
+      blocked.push({ record: r, existing: dups });
+      continue;
+    }
+    toInsert.push(r);
+  }
+
+  log.info(
+    `plan: ${toInsert.length} new, ${toEnrich.length} to enrich, ` +
+    `${toForceOverwrite.length} to FORCE-OVERWRITE (per --force-from-source), ` +
+    `${alreadyComplete.length} already complete, ${withConflicts.length} with CONFLICTS, ${blocked.length} BLOCKED`,
+  );
+  for (const r of toInsert) {
+    log.info(`  + INSERT ${r.name.padEnd(36)} domains=[${r.domains.join(",")}] tags=${r.tags.length}`);
+  }
+  for (const e of toEnrich) {
+    log.info(`  ~ ENRICH ${e.existing.name.padEnd(36)} ${summarisePlan(e.plan)}`);
+  }
+  for (const e of toForceOverwrite) {
+    log.warn(`  ! FORCE-OVERWRITE ${e.existing.name.padEnd(36)} ${summarisePlan(e.plan)}`);
+    for (const field of e.plan.filled) {
+      const oldV = (e.existing as unknown as Record<string, unknown>)[field];
+      const newV = e.plan.updates[field];
+      const oldS = typeof oldV === "string" ? (oldV as string).slice(0, 80) : JSON.stringify(oldV);
+      const newS = typeof newV === "string" ? (newV as string).slice(0, 80) : JSON.stringify(newV);
+      log.warn(`      ${field}: existing=${JSON.stringify(oldS)} → source=${JSON.stringify(newS)}`);
+    }
+  }
+  for (const e of withConflicts) {
+    log.warn(`  ! CONFLICT ${e.existing.name.padEnd(36)} ${summarisePlan(e.plan)}`);
+    for (const c of e.plan.conflicts) {
+      const ex = typeof c.existing === "string" ? (c.existing as string).slice(0, 80) : JSON.stringify(c.existing);
+      const sr = typeof c.source === "string" ? (c.source as string).slice(0, 80) : JSON.stringify(c.source);
+      log.warn(`      ${c.field}: existing=${JSON.stringify(ex)} | source=${JSON.stringify(sr)}`);
+    }
+  }
+  for (const p of alreadyComplete) {
+    log.debug(`  = already complete: ${p.record.name}`);
+  }
+  for (const b of blocked) {
+    log.warn(
+      `  ! BLOCKED ${b.record.name} looks like duplicate of: ${b.existing.join(", ")}. ` +
+      `Re-run with --allow-duplicate-of="${b.existing[0]}" to force insert.`,
+    );
+  }
+  for (const w of domainWarnings) {
+    log.warn(`  ${w.name}: cleric-domain tokens not in ClericDomain enum: ${w.unknown.join(", ")} (dropped from insert)`);
+  }
+
+  if (toInsert.length === 0 && toEnrich.length === 0 && toForceOverwrite.length === 0) {
+    log.info("nothing to write");
+    return 0;
+  }
+
+  if (args.dryRun) {
+    log.info("dry-run: not touching DB");
+    console.log("=".repeat(60));
+    console.log("DRY-RUN PLAN (not executed)");
+    console.log("=".repeat(60));
+    console.log(JSON.stringify({
+      new_deities: toInsert.map((r) => ({
+        name: r.name,
+        domains: r.domains,
+        portfolio: r.portfolio,
+        description_len: r.description.length,
+        tags: r.tags,
+      })),
+      enrich_existing: toEnrich.map((e) => ({
+        name: e.existing.name,
+        id: e.existing.id,
+        filled: e.plan.filled,
+        appended: e.plan.appended,
+        unioned: e.plan.unioned,
+        unchanged: e.plan.unchanged,
+        update_fields: Object.keys(e.plan.updates),
+        previews: Object.fromEntries(
+          Object.entries(e.plan.updates).map(([k, v]) => [
+            k,
+            typeof v === "string" && v.length > 200 ? `${v.slice(0, 200)}…(${v.length}ch)` : v,
+          ]),
+        ),
+      })),
+      force_overwrite: toForceOverwrite.map((e) => ({
+        name: e.existing.name,
+        id: e.existing.id,
+        // Show before/after for every overwritten field so user can confirm.
+        overwrites: Object.fromEntries(
+          e.plan.filled.map((field) => {
+            const existingV = (e.existing as unknown as Record<string, unknown>)[field];
+            const newV = e.plan.updates[field];
+            const trunc = (x: unknown) =>
+              typeof x === "string" && x.length > 200 ? `${x.slice(0, 200)}…(${x.length}ch)` : x;
+            return [field, { from: trunc(existingV), to: trunc(newV) }];
+          }),
+        ),
+        unchanged: e.plan.unchanged,
+        protected_outside_schema: ["symbol_image_url", "portrait_url", "portrait_focal_point"],
+      })),
+      conflicts: withConflicts.map((e) => ({
+        name: e.existing.name,
+        id: e.existing.id,
+        details: e.plan.conflicts.map((c) => ({
+          field: c.field,
+          existing: typeof c.existing === "string" ? (c.existing as string).slice(0, 200) : c.existing,
+          source: typeof c.source === "string" ? (c.source as string).slice(0, 200) : c.source,
+        })),
+      })),
+      already_complete: alreadyComplete.map((p) => p.record.name),
+      blocked: blocked.map((b) => ({
+        candidate: b.record.name, looks_like_existing: b.existing,
+      })),
+    }, null, 2));
+    return 0;
+  }
+
+  // Execute — UPDATE existing rows (enriches + force-overwrites use the same
+  // UPDATE shape; only the plan-builder differed), then INSERT new rows.
+  let enrichedOk = 0;
+  for (const entry of toEnrich) {
+    const { error } = await supabase
+      .from("deities")
+      .update(entry.plan.updates)
+      .eq("id", entry.existing.id);
+    if (error) {
+      log.warn(`  enrich failed for ${entry.existing.name}: ${error.message}`);
+    } else {
+      enrichedOk++;
+      log.debug(`  enriched ${entry.existing.name}: ${summarisePlan(entry.plan)}`);
+    }
+  }
+  log.info(`enriched ${enrichedOk}/${toEnrich.length} existing deities`);
+
+  let forcedOk = 0;
+  for (const entry of toForceOverwrite) {
+    const { error } = await supabase
+      .from("deities")
+      .update(entry.plan.updates)
+      .eq("id", entry.existing.id);
+    if (error) {
+      log.warn(`  force-overwrite failed for ${entry.existing.name}: ${error.message}`);
+    } else {
+      forcedOk++;
+      log.debug(`  force-overwrote ${entry.existing.name}: ${summarisePlan(entry.plan)}`);
+    }
+  }
+  if (toForceOverwrite.length > 0) {
+    log.info(`force-overwrote ${forcedOk}/${toForceOverwrite.length} existing deities`);
+  }
+
+  if (toInsert.length > 0) {
+    const payload = toInsert.map((r) => ({
+      ...recordToInsert(r, args.campaignId, pantheonByName.get(r.pantheon) ?? null),
+      user_id: args.userId,
+    }));
+    const { data, error } = await supabase
+      .from("deities")
+      .insert(payload)
+      .select("id, name");
+    if (error) throw error;
+    log.info(`inserted ${data?.length ?? 0} new deities`);
+    for (const row of data ?? []) log.debug(`  ${row.name} → ${row.id}`);
+  }
+  return 0;
+}
+
+// Only run as CLI when this file is the entry point — guards against tests
+// (or other modules) that import `ensurePantheons` from this file triggering
+// the CLI flow.
+const invokedAsCli =
+  typeof process.argv[1] === "string" &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedAsCli) {
+  main().then(
+    (code) => process.exit(code),
+    (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`FATAL: ${msg}`);
+      if (err instanceof Error && err.stack) console.error(err.stack);
+      process.exit(2);
+    },
+  );
+}

--- a/scripts/lib/import-chapter-npcs-db.ts
+++ b/scripts/lib/import-chapter-npcs-db.ts
@@ -14,6 +14,7 @@ import type { NpcRelationship, NpcStatus } from "@/types/npc.types";
 import type { LocationSpec, NpcRecord } from "./parse-chapter-npcs";
 import { normalizeName } from "./parse-chapter-npcs";
 import { type FieldSpec, type RowMergePlan } from "./merge-fields";
+import { NPC_RICHTEXT_FIELDS, tiptapifyFields } from "./tiptap";
 
 /**
  * Field merge schema for the NPC enrich-merge path. Only fields the parser
@@ -229,16 +230,20 @@ export interface NpcInsertPayload {
 
 /**
  * Apply an enrich-merge to a single existing NPC row. Issues UPDATE with only
- * the fields in `plan.updates`. Returns the updated row's name (echo for log).
+ * the fields in `plan.updates`. Rich-text fields (appearance, personality,
+ * backstory, notes) are converted from plain markdown to Tiptap JSON at this
+ * write boundary so they render correctly in the `RichTextEditor` UI.
+ * Returns the updated row's name (echo for log).
  */
 export async function enrichNpc(
   supabase: SupabaseClient,
   npcId: string,
   plan: RowMergePlan,
 ): Promise<{ id: string; name: string }> {
+  const updates = tiptapifyFields(plan.updates, NPC_RICHTEXT_FIELDS);
   const { data, error } = await supabase
     .from("npcs")
-    .update(plan.updates)
+    .update(updates)
     .eq("id", npcId)
     .select("id, name")
     .single();
@@ -256,22 +261,29 @@ export async function insertNpcs(
 ): Promise<Array<{ id: string; name: string; location_id: string | null }>> {
   if (records.length === 0) return [];
 
-  const payload: NpcInsertPayload[] = records.map((r) => ({
-    user_id: userId,
-    campaign_id: campaignId,
-    location_id: r.location_key ? (locationByKey.get(r.location_key) ?? null) : null,
-    name: r.name,
-    race: r.race || null,
-    occupation: r.occupation || null,
-    appearance: r.appearance || null,
-    personality: r.personality || null,
-    backstory: r.backstory || null,
-    notes: r.notes || null,
-    status: r.status,
-    relationship: r.relationship,
-    relevance: r.relevance,
-    tags: r.tags,
-  }));
+  const payload = records.map((r) => {
+    const base: NpcInsertPayload = {
+      user_id: userId,
+      campaign_id: campaignId,
+      location_id: r.location_key ? (locationByKey.get(r.location_key) ?? null) : null,
+      name: r.name,
+      race: r.race || null,
+      occupation: r.occupation || null,
+      appearance: r.appearance || null,
+      personality: r.personality || null,
+      backstory: r.backstory || null,
+      notes: r.notes || null,
+      status: r.status,
+      relationship: r.relationship,
+      relevance: r.relevance,
+      tags: r.tags,
+    };
+    // Convert rich-text fields from plain markdown to Tiptap JSON at the
+    // write boundary so they land in a form the editor renders correctly.
+    // Cast to widen `NpcInsertPayload` (strict interface, no index signature)
+    // to the generic Record<string, unknown> that `tiptapifyFields` expects.
+    return tiptapifyFields(base as unknown as Record<string, unknown>, NPC_RICHTEXT_FIELDS) as unknown as NpcInsertPayload;
+  });
 
   const { data, error } = await supabase
     .from("npcs")

--- a/scripts/lib/import-chapter-npcs-db.ts
+++ b/scripts/lib/import-chapter-npcs-db.ts
@@ -1,0 +1,286 @@
+/**
+ * Supabase DB helpers for `scripts/import-chapter-npcs.ts`.
+ *
+ * Uses the service-role key (RLS bypass) so the script can read/write campaign
+ * data without an authenticated session. Reads VITE_SUPABASE_URL and
+ * SUPABASE_SERVICE_ROLE_KEY from the environment — invoke via:
+ *   tsx --env-file=.env.local scripts/import-chapter-npcs.ts ...
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { LocationType } from "@/types/location.types";
+import type { NpcRelationship, NpcStatus } from "@/types/npc.types";
+
+import type { LocationSpec, NpcRecord } from "./parse-chapter-npcs";
+import { normalizeName } from "./parse-chapter-npcs";
+import { type FieldSpec, type RowMergePlan } from "./merge-fields";
+
+/**
+ * Field merge schema for the NPC enrich-merge path. Only fields the parser
+ * actually produces appear here — other columns (portrait_url, stat_block,
+ * disguise_*, etc.) are deliberately untouched so the importer never overwrites
+ * manual UI work outside its scope.
+ */
+export const NPC_MERGE_FIELDS: Record<string, FieldSpec> = {
+  race: { kind: "scalar" },
+  occupation: { kind: "scalar" },
+  appearance: { kind: "prose" },
+  personality: { kind: "prose" },
+  backstory: { kind: "prose" },
+  notes: { kind: "prose" },
+  status: { kind: "scalar" },
+  relationship: { kind: "scalar" },
+  relevance: { kind: "scalar" },
+  tags: { kind: "array" },
+  location_id: { kind: "scalar" },
+};
+
+export function createServiceClient(): SupabaseClient {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Run via:\n" +
+      "  tsx --env-file=.env.local scripts/import-chapter-npcs.ts ...",
+    );
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+/**
+ * Existing NPC row content needed for the enrich-merge planning step.
+ *
+ * We fetch every field listed in `NPC_MERGE_FIELDS` so the planner can compare
+ * existing values against the source record. Untouched columns (stat_block,
+ * portrait_url, etc.) are left out — they're not part of the merge contract.
+ */
+export interface ExistingNpc {
+  id: string;
+  name: string;
+  normalized: string;
+  race: string | null;
+  occupation: string | null;
+  appearance: string | null;
+  personality: string | null;
+  backstory: string | null;
+  notes: string | null;
+  status: NpcStatus;
+  relationship: NpcRelationship;
+  relevance: number;
+  tags: string[];
+  location_id: string | null;
+}
+
+export interface ExistingLocation {
+  id: string;
+  name: string;
+}
+
+export interface DbState {
+  npcs: ExistingNpc[];
+  locations: ExistingLocation[];
+  /** Convenience map: location name → id. */
+  locationByName: Map<string, string>;
+  /** Convenience map: normalized NPC name → row. */
+  npcByNormalizedName: Map<string, ExistingNpc>;
+}
+
+export async function fetchDbState(
+  supabase: SupabaseClient,
+  userId: string,
+  campaignId: string,
+): Promise<DbState> {
+  const [npcRes, locRes] = await Promise.all([
+    supabase
+      .from("npcs")
+      .select("id, name, race, occupation, appearance, personality, backstory, notes, status, relationship, relevance, tags, location_id")
+      .eq("user_id", userId)
+      .eq("campaign_id", campaignId),
+    supabase.from("locations").select("id, name").eq("user_id", userId).eq("campaign_id", campaignId),
+  ]);
+  if (npcRes.error) throw npcRes.error;
+  if (locRes.error) throw locRes.error;
+
+  const npcs: ExistingNpc[] = (npcRes.data ?? []).map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+    normalized: normalizeName(r.name as string),
+    race: (r.race as string | null) ?? null,
+    occupation: (r.occupation as string | null) ?? null,
+    appearance: (r.appearance as string | null) ?? null,
+    personality: (r.personality as string | null) ?? null,
+    backstory: (r.backstory as string | null) ?? null,
+    notes: (r.notes as string | null) ?? null,
+    status: (r.status as NpcStatus) ?? "alive",
+    relationship: (r.relationship as NpcRelationship) ?? "neutral",
+    relevance: (r.relevance as number) ?? 3,
+    tags: (r.tags as string[] | null) ?? [],
+    location_id: (r.location_id as string | null) ?? null,
+  }));
+  const locations: ExistingLocation[] = (locRes.data ?? []).map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+  }));
+
+  const locationByName = new Map<string, string>();
+  for (const l of locations) locationByName.set(l.name, l.id);
+  const npcByNormalizedName = new Map<string, ExistingNpc>();
+  for (const n of npcs) npcByNormalizedName.set(n.normalized, n);
+
+  return { npcs, locations, locationByName, npcByNormalizedName };
+}
+
+export interface LocationInsertPayload {
+  user_id: string;
+  campaign_id: string;
+  parent_id: string | null;
+  name: string;
+  location_type: LocationType;
+  description: string;
+  tags: string[];
+}
+
+/**
+ * Create the locations that aren't already in the campaign.
+ * Returns a name→id map covering both newly-inserted and pre-existing locations.
+ */
+export async function ensureLocations(
+  supabase: SupabaseClient,
+  userId: string,
+  campaignId: string,
+  specs: LocationSpec[],
+  state: DbState,
+): Promise<{
+  created: ExistingLocation[];
+  reused: ExistingLocation[];
+  byKey: Map<string, string>;
+}> {
+  const created: ExistingLocation[] = [];
+  const reused: ExistingLocation[] = [];
+  const byKey = new Map<string, string>();
+  const toCreate: LocationInsertPayload[] = [];
+  const toCreateKeys: string[] = [];
+
+  for (const spec of specs) {
+    const existing = state.locationByName.get(spec.name);
+    if (existing) {
+      reused.push({ id: existing, name: spec.name });
+      byKey.set(spec.key, existing);
+      continue;
+    }
+    const parent_id = spec.parent_name ? (state.locationByName.get(spec.parent_name) ?? null) : null;
+    if (spec.parent_name && parent_id === null) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `WARN: location ${spec.name} has parent_name=${spec.parent_name} but no such location in campaign; parent_id=NULL`,
+      );
+    }
+    toCreate.push({
+      user_id: userId,
+      campaign_id: campaignId,
+      parent_id,
+      name: spec.name,
+      location_type: spec.type,
+      description: spec.description,
+      tags: spec.tags,
+    });
+    toCreateKeys.push(spec.key);
+  }
+
+  if (toCreate.length > 0) {
+    const { data, error } = await supabase
+      .from("locations")
+      .insert(toCreate)
+      .select("id, name");
+    if (error) throw error;
+    for (let i = 0; i < (data ?? []).length; i++) {
+      const row = data![i]!;
+      const key = toCreateKeys[i];
+      created.push({ id: row.id as string, name: row.name as string });
+      if (key) byKey.set(key, row.id as string);
+    }
+  }
+
+  return { created, reused, byKey };
+}
+
+export interface NpcInsertPayload {
+  user_id: string;
+  campaign_id: string;
+  location_id: string | null;
+  name: string;
+  race: string | null;
+  occupation: string | null;
+  appearance: string | null;
+  personality: string | null;
+  backstory: string | null;
+  notes: string | null;
+  status: NpcStatus;
+  relationship: NpcRelationship;
+  tags: string[];
+  // Other columns (alignment, age, portrait_*, disguise_*, is_revealed, stat_block,
+  // scriptorium_doc_id, player_visible_*) take DB defaults — see migrations.
+  // `relevance` is not in this payload because the column rejects writes from
+  // the service-role client unless we set it explicitly; we do that below.
+  relevance: number;
+}
+
+/**
+ * Apply an enrich-merge to a single existing NPC row. Issues UPDATE with only
+ * the fields in `plan.updates`. Returns the updated row's name (echo for log).
+ */
+export async function enrichNpc(
+  supabase: SupabaseClient,
+  npcId: string,
+  plan: RowMergePlan,
+): Promise<{ id: string; name: string }> {
+  const { data, error } = await supabase
+    .from("npcs")
+    .update(plan.updates)
+    .eq("id", npcId)
+    .select("id, name")
+    .single();
+  if (error) throw error;
+  return { id: data!.id as string, name: data!.name as string };
+}
+
+/** Insert NPCs in one batch. Returns inserted rows. */
+export async function insertNpcs(
+  supabase: SupabaseClient,
+  userId: string,
+  campaignId: string,
+  records: NpcRecord[],
+  locationByKey: Map<string, string>,
+): Promise<Array<{ id: string; name: string; location_id: string | null }>> {
+  if (records.length === 0) return [];
+
+  const payload: NpcInsertPayload[] = records.map((r) => ({
+    user_id: userId,
+    campaign_id: campaignId,
+    location_id: r.location_key ? (locationByKey.get(r.location_key) ?? null) : null,
+    name: r.name,
+    race: r.race || null,
+    occupation: r.occupation || null,
+    appearance: r.appearance || null,
+    personality: r.personality || null,
+    backstory: r.backstory || null,
+    notes: r.notes || null,
+    status: r.status,
+    relationship: r.relationship,
+    relevance: r.relevance,
+    tags: r.tags,
+  }));
+
+  const { data, error } = await supabase
+    .from("npcs")
+    .insert(payload)
+    .select("id, name, location_id");
+  if (error) throw error;
+  return (data ?? []).map((row) => ({
+    id: row.id as string,
+    name: row.name as string,
+    location_id: (row.location_id as string | null) ?? null,
+  }));
+}

--- a/scripts/lib/merge-fields.test.ts
+++ b/scripts/lib/merge-fields.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SOURCE_APPEND_SEPARATOR,
+  mergeField,
+  planForceOverwrite,
+  planRowMerge,
+  summarisePlan,
+  type FieldSpec,
+} from "./merge-fields";
+
+const SCALAR: FieldSpec = { kind: "scalar" };
+const ARRAY: FieldSpec = { kind: "array" };
+const PROSE: FieldSpec = { kind: "prose" };
+
+describe("mergeField — scalar", () => {
+  it("fills empty existing from source", () => {
+    expect(mergeField(null, "x", SCALAR)).toEqual({ action: "fill", newValue: "x" });
+    expect(mergeField(undefined, "x", SCALAR)).toEqual({ action: "fill", newValue: "x" });
+    expect(mergeField("", "x", SCALAR)).toEqual({ action: "fill", newValue: "x" });
+    expect(mergeField("   ", "x", SCALAR)).toEqual({ action: "fill", newValue: "x" });
+  });
+
+  it("never overwrites a non-empty existing scalar (noop when source is empty)", () => {
+    expect(mergeField("user", null, SCALAR)).toEqual({ action: "noop" });
+    expect(mergeField("user", "", SCALAR)).toEqual({ action: "noop" });
+  });
+
+  it("returns conflict when both have different non-empty values", () => {
+    const out = mergeField("Lawful Good", "True Neutral", SCALAR);
+    expect(out).toEqual({ action: "conflict", existing: "Lawful Good", source: "True Neutral" });
+  });
+
+  it("returns noop when both have the same value (whitespace-tolerant)", () => {
+    expect(mergeField("alive", "alive", SCALAR)).toEqual({ action: "noop" });
+    expect(mergeField("  alive ", "alive", SCALAR)).toEqual({ action: "noop" });
+  });
+});
+
+describe("mergeField — array", () => {
+  it("unions existing + source, preserving existing order then appending new items", () => {
+    const out = mergeField(["a", "b"], ["c", "b", "d"], ARRAY);
+    expect(out).toEqual({ action: "union", newValue: ["a", "b", "c", "d"], addedItems: ["c", "d"] });
+  });
+
+  it("noop when source contributes nothing", () => {
+    expect(mergeField(["a", "b"], ["a"], ARRAY)).toEqual({ action: "noop" });
+    expect(mergeField(["a", "b"], [], ARRAY)).toEqual({ action: "noop" });
+  });
+
+  it("fills from empty existing (union of [] with source = source)", () => {
+    const out = mergeField([], ["a", "b"], ARRAY);
+    expect(out).toEqual({ action: "union", newValue: ["a", "b"], addedItems: ["a", "b"] });
+  });
+
+  it("never dedupes-down (existing-only items survive)", () => {
+    const out = mergeField(["custom-tag", "x"], ["x"], ARRAY);
+    expect(out).toEqual({ action: "noop" });
+    const out2 = mergeField(["custom-tag", "x"], ["y"], ARRAY);
+    expect(out2.action).toBe("union");
+    if (out2.action === "union") {
+      expect(out2.newValue).toEqual(["custom-tag", "x", "y"]);
+    }
+  });
+
+  it("handles null existing as empty array", () => {
+    const out = mergeField(null, ["a"], ARRAY);
+    expect(out).toEqual({ action: "union", newValue: ["a"], addedItems: ["a"] });
+  });
+});
+
+describe("mergeField — prose", () => {
+  const big = "x".repeat(500);
+
+  it("fills empty existing", () => {
+    expect(mergeField(null, big, PROSE)).toEqual({ action: "fill", newValue: big });
+  });
+
+  it("appends source below separator when existing is a stub and source is substantially longer", () => {
+    const stub = "short user note";
+    const out = mergeField(stub, big, PROSE);
+    expect(out.action).toBe("append");
+    if (out.action === "append") {
+      expect(out.newValue).toBe(stub + SOURCE_APPEND_SEPARATOR + big);
+      expect(out.appended).toBe(big);
+    }
+  });
+
+  it("returns conflict when existing is long (not a stub) and differs from source", () => {
+    const longExisting = "x".repeat(300);
+    const longSource = "y".repeat(900);
+    const out = mergeField(longExisting, longSource, PROSE);
+    expect(out.action).toBe("conflict");
+  });
+
+  it("returns conflict when existing is a stub but source isn't substantially bigger (< 2× existing)", () => {
+    const out = mergeField("100 chars of user text padded out so it's exactly one hundred chars long for this test ABC", "150 chars of source content padded out so it sits below the 2× ratio for this test ABCDEFG", PROSE);
+    expect(out.action).toBe("conflict");
+  });
+
+  it("respects custom stubThresholdChars + stubMultiplier", () => {
+    const spec: FieldSpec = { kind: "prose", stubThresholdChars: 50, stubMultiplier: 5 };
+    const existing = "stub"; // 4 chars
+    const source = "x".repeat(40);  // 10× existing, well above multiplier
+    const out = mergeField(existing, source, spec);
+    expect(out.action).toBe("append");
+  });
+
+  it("returns noop when existing and source are identical", () => {
+    expect(mergeField("same prose", "same prose", PROSE)).toEqual({ action: "noop" });
+  });
+});
+
+describe("planRowMerge — Bell-Mother-style enrichment", () => {
+  it("fills description + portfolio + tags, leaves hand-set alignment + domains alone", () => {
+    const existing = {
+      name: "The Bell-Mother",
+      alignment: "Lawful Good",
+      domains: ["Light", "Order", "Peace"],
+      portfolio: null,
+      description: null,
+      symbol: null,
+      tags: [],
+    };
+    const source = {
+      name: "The Bell-Mother",
+      alignment: null,                    // source didn't set
+      domains: ["Light", "Peace"],        // subset of existing — union = existing, noop
+      portfolio: "The patron of welcoming, of the bell-note.",
+      description: "x".repeat(1000),
+      symbol: null,                       // source didn't set
+      tags: ["faith", "primary-sippet", "honored-by-brewlings"],
+    };
+    const plan = planRowMerge(existing, source, {
+      name: { kind: "scalar" },
+      alignment: { kind: "scalar" },
+      domains: { kind: "array" },
+      portfolio: { kind: "scalar" },
+      description: { kind: "prose" },
+      symbol: { kind: "scalar" },
+      tags: { kind: "array" },
+    });
+    expect(plan.filled.sort()).toEqual(["description", "portfolio"]);
+    expect(plan.unioned).toEqual(["tags"]);
+    expect(plan.conflicts).toEqual([]);
+    expect(plan.unchanged.sort()).toEqual(["alignment", "domains", "name", "symbol"]);
+    // Updates should ONLY contain the changed fields:
+    expect(Object.keys(plan.updates).sort()).toEqual(["description", "portfolio", "tags"]);
+    expect(plan.updates.tags).toEqual(["faith", "primary-sippet", "honored-by-brewlings"]);
+  });
+});
+
+describe("planRowMerge — conflict surfaces all mismatches", () => {
+  it("collects every conflicting field without writing any of them", () => {
+    const existing = { a: "user-A", b: "user-B", c: "user-C" };
+    const source =   { a: "src-A",  b: "user-B", c: "src-C"  };
+    const plan = planRowMerge(existing, source, {
+      a: { kind: "scalar" }, b: { kind: "scalar" }, c: { kind: "scalar" },
+    });
+    expect(plan.conflicts.map((c) => c.field).sort()).toEqual(["a", "c"]);
+    expect(plan.updates).toEqual({});
+    expect(plan.unchanged).toEqual(["b"]);
+  });
+});
+
+describe("planForceOverwrite — per-record override (Bell-Mother case)", () => {
+  it("overwrites differing non-empty fields with source values, including when source is null", () => {
+    // Bell-Mother: user typed alignment + domains from looking at the image,
+    // not from lore. They want lore (faiths.md) to overwrite.
+    const existing = {
+      alignment: "Lawful Good",                  // user-set from image, wants overwritten
+      domains: ["Light", "Order", "Peace"],      // user-set from image, wants overwritten
+      symbol: null,                              // empty in both, noop
+      portfolio: null,                           // empty existing, fill from source
+      description: null,                         // empty existing, fill from source
+      dm_notes: null,                            // empty in both, noop
+      tags: [],                                  // empty existing, fill from source
+    };
+    const source = {
+      alignment: null,                           // source has no alignment
+      domains: ["Light", "Peace"],
+      symbol: null,
+      portfolio: "The patron of welcoming.",
+      description: "x".repeat(800),
+      dm_notes: null,
+      tags: ["faith", "primary-sippet"],
+    };
+    const plan = planForceOverwrite(existing, source, {
+      alignment: { kind: "scalar" },
+      domains: { kind: "array" },
+      symbol: { kind: "scalar" },
+      portfolio: { kind: "scalar" },
+      description: { kind: "prose" },
+      dm_notes: { kind: "prose" },
+      tags: { kind: "array" },
+    });
+    expect(plan.filled.sort()).toEqual(["alignment", "description", "domains", "portfolio", "tags"]);
+    expect(plan.unchanged.sort()).toEqual(["dm_notes", "symbol"]);
+    expect(plan.conflicts).toEqual([]);
+    // alignment gets nulled out — user no longer wants "Lawful Good"
+    expect(plan.updates.alignment).toBe(null);
+    expect(plan.updates.domains).toEqual(["Light", "Peace"]);
+    expect(plan.updates.portfolio).toBe("The patron of welcoming.");
+    expect(plan.updates.tags).toEqual(["faith", "primary-sippet"]);
+  });
+
+  it("noop on identical arrays + identical scalars", () => {
+    const plan = planForceOverwrite(
+      { a: "x", b: ["1", "2"], c: null },
+      { a: "x", b: ["1", "2"], c: null },
+      { a: { kind: "scalar" }, b: { kind: "array" }, c: { kind: "scalar" } },
+    );
+    expect(plan.updates).toEqual({});
+    expect(plan.unchanged.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("never returns conflicts (the override IS the resolution)", () => {
+    const plan = planForceOverwrite(
+      { a: "user-A", b: "user-B" },
+      { a: "src-A",  b: "src-B" },
+      { a: { kind: "scalar" }, b: { kind: "scalar" } },
+    );
+    expect(plan.conflicts).toEqual([]);
+    expect(plan.updates).toEqual({ a: "src-A", b: "src-B" });
+  });
+
+  it("does not touch fields outside fieldSpecs (image protection by omission)", () => {
+    // image-like fields aren't in the spec → never written
+    const plan = planForceOverwrite(
+      { name: "X", symbol_image_url: "/canon/bell-mother.png", alignment: "Lawful Good" },
+      { name: "X", symbol_image_url: null, alignment: null },
+      { name: { kind: "scalar" }, alignment: { kind: "scalar" } }, // symbol_image_url NOT listed
+    );
+    expect(plan.updates).toEqual({ alignment: null });
+    expect("symbol_image_url" in plan.updates).toBe(false);
+  });
+});
+
+describe("summarisePlan", () => {
+  it("renders a compact log line", () => {
+    const plan = planRowMerge(
+      { x: null, y: ["a"], z: "user" },
+      { x: "filled", y: ["b"], z: "user" },
+      { x: { kind: "scalar" }, y: { kind: "array" }, z: { kind: "scalar" } },
+    );
+    const s = summarisePlan(plan);
+    expect(s).toContain("filled=[x]");
+    expect(s).toContain("unioned=[y]");
+    expect(s).not.toContain("conflicts");
+  });
+
+  it("returns 'no changes' when the plan is empty", () => {
+    expect(summarisePlan({ updates: {}, filled: [], appended: [], unioned: [], conflicts: [], unchanged: [] }))
+      .toBe("no changes");
+  });
+});

--- a/scripts/lib/merge-fields.ts
+++ b/scripts/lib/merge-fields.ts
@@ -1,0 +1,241 @@
+/**
+ * Generic field-by-field merge engine for "enrich existing rows from source".
+ *
+ * The user's workflow: stub out a row in the UI (just name + a few fields),
+ * then later run the importer to fill in the rest from source markdown. The
+ * importer must never overwrite manual edits. This module formalises that
+ * contract:
+ *
+ *   - SCALAR fields: if existing is empty → fill from source. If existing has
+ *     user content → leave it. If both have content and differ → CONFLICT
+ *     (don't write, surface to user).
+ *
+ *   - ARRAY fields: take the union (existing ∪ source), preserving order
+ *     from existing then appending new items from source. Never "dedupe down"
+ *     (i.e. never remove an existing tag just because source doesn't have it).
+ *
+ *   - PROSE fields: like scalar, but with a "stub" special case. If existing
+ *     is short (< stubThresholdChars) AND source is substantially longer
+ *     (>= existing.length * stubMultiplier), APPEND the source below a
+ *     clear separator (don't overwrite — preserve the user's stub note).
+ *     Otherwise behave like scalar (empty→fill; non-empty & differ→conflict).
+ *
+ * No I/O. Pure functions. Both the NPC importer and the faiths importer
+ * consume this module via `planRowMerge`.
+ */
+
+export type FieldKind = "scalar" | "array" | "prose";
+
+export interface FieldSpec {
+  kind: FieldKind;
+  /** Prose only. Existing length below this is considered a stub. Default: 200. */
+  stubThresholdChars?: number;
+  /** Prose only. Source must be >= existing.length * this to qualify as stub-append. Default: 2. */
+  stubMultiplier?: number;
+}
+
+export type FieldOutcome =
+  | { action: "noop" }
+  | { action: "fill"; newValue: unknown }
+  | { action: "append"; newValue: string; appended: string }
+  | { action: "union"; newValue: unknown[]; addedItems: unknown[] }
+  | { action: "conflict"; existing: unknown; source: unknown };
+
+export interface RowMergePlan {
+  /** Partial payload — only fields with non-conflict, non-noop actions. */
+  updates: Record<string, unknown>;
+  /** Fields that went from empty → source value. */
+  filled: string[];
+  /** Fields where source content was appended below a stub. */
+  appended: string[];
+  /** Array fields where source items were unioned in. */
+  unioned: string[];
+  /** Fields whose existing non-empty value differs from source — NOT written. */
+  conflicts: Array<{ field: string; existing: unknown; source: unknown }>;
+  /** Fields where existing already covers source (or source is empty). */
+  unchanged: string[];
+}
+
+/** Append separator for stub-prose-append. Centralized so tests + UI can recognize it. */
+export const SOURCE_APPEND_SEPARATOR = "\n\n---\n\n*From source:*\n\n";
+
+/** Treat null, undefined, empty string, and all-whitespace as empty. */
+function isEmptyScalar(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  if (typeof v === "string") return v.trim().length === 0;
+  return false;
+}
+
+function deepEqualPrimitive(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a === "string" && typeof b === "string") {
+    return a.trim() === b.trim();
+  }
+  return false;
+}
+
+export function mergeField(
+  existing: unknown,
+  source: unknown,
+  spec: FieldSpec,
+): FieldOutcome {
+  if (spec.kind === "array") {
+    const existingArr = Array.isArray(existing) ? existing : [];
+    const sourceArr = Array.isArray(source) ? source : [];
+    const union: unknown[] = [...existingArr];
+    const added: unknown[] = [];
+    for (const item of sourceArr) {
+      if (!union.some((e) => deepEqualPrimitive(e, item))) {
+        union.push(item);
+        added.push(item);
+      }
+    }
+    if (added.length === 0) return { action: "noop" };
+    return { action: "union", newValue: union, addedItems: added };
+  }
+
+  // scalar + prose share empty-handling
+  const existingEmpty = isEmptyScalar(existing);
+  const sourceEmpty = isEmptyScalar(source);
+
+  if (existingEmpty && sourceEmpty) return { action: "noop" };
+  if (existingEmpty && !sourceEmpty) return { action: "fill", newValue: source };
+  if (!existingEmpty && sourceEmpty) return { action: "noop" };
+  // Both non-empty
+  if (deepEqualPrimitive(existing, source)) return { action: "noop" };
+
+  if (spec.kind === "prose" && typeof existing === "string" && typeof source === "string") {
+    const stubThreshold = spec.stubThresholdChars ?? 200;
+    const stubMultiplier = spec.stubMultiplier ?? 2;
+    if (existing.length < stubThreshold && source.length >= existing.length * stubMultiplier) {
+      const merged = existing.trimEnd() + SOURCE_APPEND_SEPARATOR + source;
+      return { action: "append", newValue: merged, appended: source };
+    }
+  }
+  return { action: "conflict", existing, source };
+}
+
+/**
+ * Walk every field in `fieldSpecs` and merge `existing[field]` with `source[field]`.
+ * Returns a `RowMergePlan` summarising what would be written.
+ *
+ * Fields not in `fieldSpecs` are ignored entirely (so callers can scope the
+ * merge to the parser-produced field set without worrying about untouched
+ * columns like `created_at`, `user_id`, etc.).
+ */
+export function planRowMerge(
+  existing: Record<string, unknown>,
+  source: Record<string, unknown>,
+  fieldSpecs: Record<string, FieldSpec>,
+): RowMergePlan {
+  const plan: RowMergePlan = {
+    updates: {},
+    filled: [],
+    appended: [],
+    unioned: [],
+    conflicts: [],
+    unchanged: [],
+  };
+  for (const [field, spec] of Object.entries(fieldSpecs)) {
+    const outcome = mergeField(existing[field], source[field], spec);
+    switch (outcome.action) {
+      case "noop":
+        plan.unchanged.push(field);
+        break;
+      case "fill":
+        plan.updates[field] = outcome.newValue;
+        plan.filled.push(field);
+        break;
+      case "append":
+        plan.updates[field] = outcome.newValue;
+        plan.appended.push(field);
+        break;
+      case "union":
+        plan.updates[field] = outcome.newValue;
+        plan.unioned.push(field);
+        break;
+      case "conflict":
+        plan.conflicts.push({ field, existing: outcome.existing, source: outcome.source });
+        break;
+    }
+  }
+  return plan;
+}
+
+/** True if the plan has anything to write. */
+export function planHasWrites(plan: RowMergePlan): boolean {
+  return Object.keys(plan.updates).length > 0;
+}
+
+/**
+ * Per-record override: replace existing values with source values for every
+ * field in `fieldSpecs`, regardless of whether existing was a user-set value.
+ *
+ * Use case: the user manually filled a stub row from a non-canonical source
+ * (e.g. a placeholder image) and wants the canonical lore to overwrite their
+ * guesses. Image fields are protected by virtue of NOT being in `fieldSpecs`
+ * — keep them out of the schema and they'll never be touched.
+ *
+ * Differences from `planRowMerge`:
+ *   - Never returns conflicts (the override is the resolution).
+ *   - Writes source value verbatim — including null/empty — when it differs
+ *     from existing. (Empty-into-empty is still a noop.)
+ *   - All written fields are reported in `filled` (no append/union distinction;
+ *     the override is uniformly "take source").
+ */
+export function planForceOverwrite(
+  existing: Record<string, unknown>,
+  source: Record<string, unknown>,
+  fieldSpecs: Record<string, FieldSpec>,
+): RowMergePlan {
+  const plan: RowMergePlan = {
+    updates: {},
+    filled: [],
+    appended: [],
+    unioned: [],
+    conflicts: [],
+    unchanged: [],
+  };
+  for (const field of Object.keys(fieldSpecs)) {
+    const ev = existing[field];
+    const sv = source[field];
+
+    // Both empty (different empty representations are equivalent) — noop
+    const evEmpty = isEmptyScalar(ev) || (Array.isArray(ev) && ev.length === 0);
+    const svEmpty = isEmptyScalar(sv) || (Array.isArray(sv) && sv.length === 0);
+    if (evEmpty && svEmpty) {
+      plan.unchanged.push(field);
+      continue;
+    }
+
+    // Identical (array or scalar)? noop
+    if (Array.isArray(ev) && Array.isArray(sv)) {
+      if (
+        ev.length === sv.length &&
+        ev.every((x, i) => deepEqualPrimitive(x, sv[i]))
+      ) {
+        plan.unchanged.push(field);
+        continue;
+      }
+    } else if (deepEqualPrimitive(ev, sv)) {
+      plan.unchanged.push(field);
+      continue;
+    }
+
+    // Different — overwrite with source verbatim (may be null).
+    plan.updates[field] = sv ?? null;
+    plan.filled.push(field);
+  }
+  return plan;
+}
+
+/** Compact human-readable summary for log output. */
+export function summarisePlan(plan: RowMergePlan): string {
+  const parts: string[] = [];
+  if (plan.filled.length) parts.push(`filled=[${plan.filled.join(",")}]`);
+  if (plan.appended.length) parts.push(`appended=[${plan.appended.join(",")}]`);
+  if (plan.unioned.length) parts.push(`unioned=[${plan.unioned.join(",")}]`);
+  if (plan.conflicts.length) parts.push(`conflicts=[${plan.conflicts.map((c) => c.field).join(",")}]`);
+  return parts.length ? parts.join(" ") : "no changes";
+}

--- a/scripts/lib/name-matching.test.ts
+++ b/scripts/lib/name-matching.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findPotentialDuplicates,
+  levenshtein,
+  normalizeName,
+} from "./name-matching";
+
+describe("normalizeName", () => {
+  it("lowercases + trims + collapses internal whitespace", () => {
+    expect(normalizeName("  Madame   Petrichor  ")).toBe("madame petrichor");
+    expect(normalizeName("VELLETTE\tQUIVERGLASS")).toBe("vellette quiverglass");
+  });
+});
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshtein("", "")).toBe(0);
+    expect(levenshtein("abc", "abc")).toBe(0);
+  });
+
+  it("returns the length of the other string when one is empty", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+  });
+
+  it("counts single-character insertions, deletions, substitutions as distance 1", () => {
+    expect(levenshtein("velette", "vellette")).toBe(1);   // insertion
+    expect(levenshtein("sippet", "sipet")).toBe(1);       // deletion
+    expect(levenshtein("tippet", "sippet")).toBe(1);      // substitution
+  });
+
+  it("counts 2 for two-char edits", () => {
+    expect(levenshtein("anna", "annie")).toBe(2);
+    expect(levenshtein("kitten", "sittin")).toBe(2);
+  });
+
+  it("counts higher distance for structurally distinct names", () => {
+    // Bract → Bramble: replace c→m, replace t→b, insert l, insert e = 4
+    expect(levenshtein("bract", "bramble")).toBe(4);
+    // "madame petrichor" → "madame petrichor & cinder" = +9 chars
+    expect(levenshtein("madame petrichor", "madame petrichor & cinder")).toBe(9);
+  });
+
+  it("is symmetric", () => {
+    expect(levenshtein("velette", "vellette")).toBe(levenshtein("vellette", "velette"));
+    expect(levenshtein("anna", "annie")).toBe(levenshtein("annie", "anna"));
+  });
+});
+
+describe("findPotentialDuplicates — substring layer (existing behaviour preserved)", () => {
+  it("catches the Petrichor case (candidate is substring of existing)", () => {
+    const existing = ["madame petrichor & cinder"];
+    expect(findPotentialDuplicates("Madame Petrichor", existing)).toEqual([
+      "madame petrichor & cinder",
+    ]);
+  });
+
+  it("catches the reverse case (existing is substring of candidate)", () => {
+    expect(findPotentialDuplicates("Madame Petrichor", ["petrichor"])).toEqual(["petrichor"]);
+  });
+
+  it("ignores exact matches (caller handles those as silent idempotent skip)", () => {
+    expect(findPotentialDuplicates("Madame Petrichor", ["madame petrichor"])).toEqual([]);
+  });
+});
+
+describe("findPotentialDuplicates — fuzzy (Levenshtein) layer", () => {
+  // Regression: the Velette/Vellette case from production. The user hand-typed
+  // "Velette" (one L) when the source markdown has "Vellette" (two Ls). The
+  // substring detection couldn't catch this — neither is a substring of the
+  // other. Fuzzy matching catches the single-insertion typo class.
+  it("catches the Velette/Vellette case (1-char insertion typo)", () => {
+    const existing = ["velette quiverglass"];
+    expect(findPotentialDuplicates("Vellette Quiverglass", existing))
+      .toEqual(["velette quiverglass"]);
+  });
+
+  it("catches the reverse direction (typo'd candidate vs canonical existing)", () => {
+    const existing = ["vellette quiverglass"];
+    expect(findPotentialDuplicates("Velette Quiverglass", existing))
+      .toEqual(["vellette quiverglass"]);
+  });
+
+  it("catches the Tippet/Sippet class (1-char substitution typo)", () => {
+    expect(findPotentialDuplicates("Old Tippet", ["old sippet"]))
+      .toEqual(["old sippet"]);
+  });
+
+  it("catches 2-char-edit typos within threshold", () => {
+    expect(findPotentialDuplicates("Annie", ["anna"]))
+      .toEqual(["anna"]);
+  });
+
+  it("does NOT flag legitimately distinct names beyond distance 2", () => {
+    // Bract ↔ Bramble: distance 4. Both real NPCs in the campaign.
+    expect(findPotentialDuplicates("Bract", ["bramble"])).toEqual([]);
+    // Hush ↔ Holder: distance 5. Both real NPCs.
+    expect(findPotentialDuplicates("Hush", ["holder"])).toEqual([]);
+  });
+
+  it("respects the minLength floor for fuzzy matching (skips short names)", () => {
+    // "Sip" vs "Sup" are both 3-char names with distance 1 — would otherwise
+    // false-positive on every other 3-char name. Length floor of 4 filters.
+    expect(findPotentialDuplicates("Sip", ["sup"])).toEqual([]);
+    expect(findPotentialDuplicates("Pim", ["pip"])).toEqual([]);
+  });
+
+  it("does flag fuzzy matches once names cross the length floor", () => {
+    // 4-char names where the substring check doesn't fire (neither contains
+    // the other) and Levenshtein distance is ≤ 2.
+    expect(findPotentialDuplicates("anna", ["arna"])).toEqual(["arna"]); // substitute n→r
+  });
+});
+
+describe("findPotentialDuplicates — deduplication of multi-layer hits", () => {
+  it("returns each existing name at most once even if multiple layers would match", () => {
+    // "vellette" is substring of "vellette quiverglass" AND within Levenshtein
+    // distance — both layers fire. Should still be reported once.
+    const existing = ["vellette quiverglass"];
+    const hits = findPotentialDuplicates("Vellette", existing);
+    expect(hits).toEqual(["vellette quiverglass"]);
+    expect(hits.length).toBe(1);
+  });
+});

--- a/scripts/lib/name-matching.ts
+++ b/scripts/lib/name-matching.ts
@@ -1,0 +1,138 @@
+/**
+ * Name-matching primitives shared by the chapter-NPC and faiths importers.
+ *
+ * Previously each parser module carried its own copy of `normalizeName` and
+ * `findPotentialDuplicates`. Extracted here so the duplicate-detection logic
+ * lives in one place — particularly important when adding fuzzy matching, so
+ * both importers stay in sync.
+ *
+ * Detection layers (callers handle the routing):
+ *
+ *   1. Exact normalized match  — caller treats as idempotent skip
+ *   2. Substring match         — different exact names but one contains the
+ *                                other (e.g. "Madame Petrichor" vs
+ *                                "Madame Petrichor & Cinder"). Block-and-warn.
+ *   3. Fuzzy / near-match      — Levenshtein distance ≤ 2 with both names
+ *                                ≥ 4 chars (catches single-typo cases like
+ *                                "Velette" vs "Vellette", "Old Tippet" vs
+ *                                "Old Sippet"). Block-and-warn.
+ *
+ * Layers 2 and 3 both surface through `findPotentialDuplicates` — the caller
+ * doesn't need to know which detector fired, only that there's a near-match
+ * worth surfacing.
+ */
+
+/** Case-insensitive trimmed comparison key for idempotency checks. */
+export function normalizeName(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Levenshtein edit distance between two strings.
+ *
+ * Standard 2D dynamic-programming implementation, O(m·n) time + O(min(m,n))
+ * space (rolling rows). For NPC/deity names which are typically <50 chars,
+ * this is plenty fast.
+ *
+ * Returns 0 for identical strings, length of longer string for fully-distinct
+ * strings, 1 for single-character insertion/deletion/substitution.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Ensure a is the shorter one — minimizes the rolling-row size.
+  let s = a;
+  let t = b;
+  if (s.length > t.length) {
+    const tmp = s;
+    s = t;
+    t = tmp;
+  }
+
+  const prev = new Array<number>(s.length + 1);
+  const curr = new Array<number>(s.length + 1);
+  for (let i = 0; i <= s.length; i++) prev[i] = i;
+
+  for (let j = 1; j <= t.length; j++) {
+    curr[0] = j;
+    for (let i = 1; i <= s.length; i++) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1;
+      curr[i] = Math.min(
+        curr[i - 1]! + 1,         // insertion
+        prev[i]! + 1,             // deletion
+        prev[i - 1]! + cost,      // substitution
+      );
+    }
+    for (let i = 0; i <= s.length; i++) prev[i] = curr[i]!;
+  }
+  return prev[s.length]!;
+}
+
+/**
+ * Threshold config for fuzzy near-match detection. Tuned to catch single-typo
+ * cases without flagging legitimately distinct short names.
+ *
+ * Rationale for `minLengthForFuzzy = 4`:
+ *   - Names ≤3 chars (Sip, Pim, Bib) trivially fall within edit distance 1–2
+ *     of any other 3-char name. Flagging them all as suspected duplicates
+ *     would be pure noise.
+ *   - 4 chars is the smallest where a 1-char typo is more likely "same name,
+ *     typo" than "two different short names that happen to share letters."
+ *
+ * Rationale for `maxDistance = 2`:
+ *   - 1 covers true typos (Velette ↔ Vellette, Sippet ↔ Tippet)
+ *   - 2 catches slightly nastier ones (Anna ↔ Annie, common transpositions)
+ *   - 3+ starts catching legitimately different names (Bract ↔ Bramble,
+ *     distance 4) and floods the user with false positives.
+ */
+const FUZZY_CONFIG = {
+  maxDistance: 2,
+  minLengthForFuzzy: 4,
+} as const;
+
+/**
+ * Find existing names that look like potential duplicates of `candidate`.
+ *
+ * Caller handles the routing — typically:
+ *   - exact normalized matches are filtered upstream (idempotent skip)
+ *   - everything this function returns is treated as a near-match worth
+ *     blocking and surfacing for user decision (or overriding via a flag
+ *     like `--allow-duplicate-of`)
+ *
+ * Three detection layers, in priority order:
+ *   1. Substring (either direction)         — different exact names but
+ *                                              one contains the other
+ *   2. Levenshtein ≤ FUZZY_CONFIG.maxDistance — single-typo class
+ *
+ * Returns deduplicated normalized-name strings for caller log readability.
+ */
+export function findPotentialDuplicates(
+  candidate: string,
+  existingNormalizedNames: Iterable<string>,
+): string[] {
+  const candNorm = normalizeName(candidate);
+  if (!candNorm) return [];
+
+  const hits = new Set<string>();
+  for (const existing of existingNormalizedNames) {
+    if (existing === candNorm) continue; // exact match — caller handles upstream
+
+    // Layer 1: substring (either direction)
+    if (existing.includes(candNorm) || candNorm.includes(existing)) {
+      hits.add(existing);
+      continue;
+    }
+
+    // Layer 2: Levenshtein near-match. Length floor avoids flagging
+    // legitimately distinct short names.
+    if (
+      Math.min(existing.length, candNorm.length) >= FUZZY_CONFIG.minLengthForFuzzy &&
+      levenshtein(existing, candNorm) <= FUZZY_CONFIG.maxDistance
+    ) {
+      hits.add(existing);
+    }
+  }
+  return [...hits];
+}

--- a/scripts/lib/parse-chapter-npcs.test.ts
+++ b/scripts/lib/parse-chapter-npcs.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applySidecar,
+  findPotentialDuplicates,
+  isSkipHeading,
+  normalizeName,
+  parseNpc,
+  resolveLocationSpecs,
+  slug,
+  splitNpcBlocks,
+  type NpcRecord,
+  type SidecarConfig,
+} from "./parse-chapter-npcs";
+
+describe("slug", () => {
+  it("lowercases and replaces non-alnum runs with single hyphens", () => {
+    expect(slug("The Sugar Carnival")).toBe("the-sugar-carnival");
+    expect(slug("  Late-Stage Advanced!  ")).toBe("late-stage-advanced");
+    expect(slug("Sugarspun (Tuft)")).toBe("sugarspun-tuft");
+    expect(slug("")).toBe("");
+  });
+});
+
+describe("normalizeName", () => {
+  it("is case-insensitive + whitespace-tolerant", () => {
+    expect(normalizeName("Madame Petrichor")).toBe(normalizeName("  madame  PETRICHOR "));
+    expect(normalizeName("Brittle")).not.toBe(normalizeName("Brittle (Reborn)"));
+  });
+});
+
+describe("isSkipHeading", () => {
+  it("filters non-NPC section headings used across Ch1-5 + prologue", () => {
+    expect(isSkipHeading("Chapter Five — NPCs")).toBe(true);
+    expect(isSkipHeading("Atlas Update Summary")).toBe(true);
+    expect(isSkipHeading("NPC Atlas — Update Summary")).toBe(true);
+    expect(isSkipHeading("Locus NPCs — Full Entries")).toBe(true);
+    expect(isSkipHeading("Additional Locus NPCs (Background, Lightly Sketched)")).toBe(true);
+    expect(isSkipHeading("Prologue — NPCs")).toBe(true);
+    expect(isSkipHeading("Encountered in the Session")).toBe(true);
+    expect(isSkipHeading("Available for Revisit")).toBe(true);
+
+    expect(isSkipHeading("Brittle")).toBe(false);
+    expect(isSkipHeading("Madame Petrichor (Terminal Entry)")).toBe(false);
+    expect(isSkipHeading("Brine (Glissade Junior)")).toBe(false);
+  });
+});
+
+describe("presence-check rule — only `## NAME` top-level headings become NPCs", () => {
+  // Regression: during audit of past imports we found 7 names that had been
+  // inserted by the ad-hoc Python Ch4 importer despite only appearing in the
+  // source as inline `**Name**` bold within prose paragraphs (not as section
+  // headers). The TS importer must NOT do this — NPCs need their own `##`
+  // heading or they're not extracted.
+  const md = `# Title
+
+## Real Npc Alpha
+**Race:** Goliath
+
+### Visual
+Tall.
+
+## Real Npc Beta
+**Race:** Halfling
+
+### Visual
+Short.
+
+### The Channel Camp's other Slips
+
+Three adult Slips at the Channel Camp: **Reed** (background), **Pour** (background), and **Sieve** (background).
+
+### Vela (Holder's wife) and Vow (Holder's daughter)
+
+Both walked. **Vela** four years ago; **Vow** last summer.
+
+- **Inline Reference Name** — a cross-reference, not an NPC entry.
+`;
+
+  it("extracts only the two `## NAME` top-level entries", () => {
+    const blocks = splitNpcBlocks(md);
+    const names = blocks.map((b) => b.heading);
+    expect(names).toEqual(["Real Npc Alpha", "Real Npc Beta"]);
+  });
+
+  it("does NOT extract `### NAME` sub-headings as separate NPCs", () => {
+    const blocks = splitNpcBlocks(md);
+    const names = blocks.map((b) => b.heading);
+    expect(names).not.toContain("The Channel Camp's other Slips");
+    expect(names).not.toContain("Vela (Holder's wife) and Vow (Holder's daughter)");
+  });
+
+  it("does NOT extract inline **Name** bold names from body prose", () => {
+    const blocks = splitNpcBlocks(md);
+    const names = blocks.map((b) => b.heading);
+    for (const inlineName of ["Reed", "Pour", "Sieve", "Vela", "Vow", "Inline Reference Name"]) {
+      expect(names).not.toContain(inlineName);
+    }
+  });
+});
+
+describe("splitNpcBlocks", () => {
+  it("splits on top-level `## ` and preserves heading + body separation", () => {
+    const md = `# Title
+
+## Spangle
+**Race:** Sugarspun
+
+### Visual
+Tall.
+
+## Glissade
+**Race:** Sugarspun
+
+### Visual
+Seated.
+`;
+    const blocks = splitNpcBlocks(md);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]?.heading).toBe("Spangle");
+    expect(blocks[1]?.heading).toBe("Glissade");
+    expect(blocks[0]?.body).toMatch(/Race:/);
+    expect(blocks[1]?.body).toMatch(/Seated\./);
+  });
+});
+
+describe("parseNpc — Ch5 standard format", () => {
+  const body = `**ID:** spangle_stagemistress
+**Race:** Sugarspun (Tuft)
+**Stage:** Middle-stage
+**Apparent age:** 40s
+**Role:** Stagemistress of the Sugar Carnival.
+
+### Visual
+
+Tall, cream coat. Glitter on the cuffs.
+
+### Personality
+
+Articulate, warm, observant, deliberate.
+
+### Background
+
+Born in the Carnival. Trained as a juggler.
+
+### Speech and Mannerisms
+
+Deliberate stage voice.
+
+### Lens Variations
+
+**Bright Lens.** Warm host.
+**Deep Lens.** Antibody.
+
+### Emotional Core
+
+_She believes the carnival is a kindness._
+
+### Encounter Scenes
+
+- **Scene One.** Welcome speech.
+
+### Cross-Chapter Carries
+
+- Brass token to Ch9.
+
+---
+`;
+
+  it("extracts metadata fields", () => {
+    const npc = parseNpc("Spangle", body, 5, "carnival");
+    expect(npc).not.toBeNull();
+    expect(npc!.name).toBe("Spangle");
+    expect(npc!.race).toBe("Sugarspun (Tuft)");
+    expect(npc!.occupation).toBe("Stagemistress of the Sugar Carnival.");
+  });
+
+  it("extracts section content", () => {
+    const npc = parseNpc("Spangle", body, 5, "carnival")!;
+    expect(npc.appearance).toBe("Tall, cream coat. Glitter on the cuffs.");
+    expect(npc.personality).toBe("Articulate, warm, observant, deliberate.");
+    expect(npc.backstory).toBe("Born in the Carnival. Trained as a juggler.");
+  });
+
+  it("synthesizes notes with **Emotional Core** lead", () => {
+    const npc = parseNpc("Spangle", body, 5, "carnival")!;
+    expect(npc.notes.startsWith("**Emotional Core**")).toBe(true);
+    expect(npc.notes).toMatch(/\*\*Stage\*\*/);
+    expect(npc.notes).toMatch(/\*\*Apparent age\*\*/);
+    expect(npc.notes).toMatch(/\*\*Speech and Mannerisms\*\*/);
+    expect(npc.notes).toMatch(/\*\*Lens Variations\*\*/);
+    expect(npc.notes).toMatch(/\*\*Encounter Scenes\*\*/);
+    expect(npc.notes).toMatch(/\*\*Cross-Chapter Carries\*\*/);
+  });
+
+  it("strips trailing `---` from sections", () => {
+    const npc = parseNpc("Spangle", body, 5, "carnival")!;
+    expect(npc.notes.endsWith("---")).toBe(false);
+  });
+
+  it("generates baseline tags from metadata", () => {
+    const npc = parseNpc("Spangle", body, 5, "carnival")!;
+    expect(npc.tags).toContain("chapter-5");
+    expect(npc.tags).toContain("sugarspun");
+    expect(npc.tags).toContain("tuft");
+    expect(npc.tags).toContain("carnival");
+  });
+
+  it("returns null for skip-headings", () => {
+    expect(parseNpc("Chapter Five — NPCs", body, 5, null)).toBeNull();
+    expect(parseNpc("Atlas Update Summary", body, 5, null)).toBeNull();
+  });
+});
+
+describe("parseNpc — multi-paragraph sections", () => {
+  // Regression: an earlier version used the regex `m` flag, which made `$` in
+  // the lookahead match end-of-line rather than end-of-string. Non-greedy
+  // captures truncated at the first paragraph break.
+  const body = `**Race:** Test
+
+### Visual
+
+First paragraph of the visual section.
+
+Second paragraph, after a blank line.
+
+Third paragraph, still in Visual.
+
+### Personality
+
+P1.
+
+P2.
+`;
+
+  it("captures all paragraphs in a single section, not just the first", () => {
+    const npc = parseNpc("Subject", body, 6, null)!;
+    expect(npc.appearance).toMatch(/First paragraph/);
+    expect(npc.appearance).toMatch(/Second paragraph/);
+    expect(npc.appearance).toMatch(/Third paragraph/);
+    expect(npc.personality).toMatch(/P1\./);
+    expect(npc.personality).toMatch(/P2\./);
+  });
+
+  it("preserves blank-line separators between paragraphs", () => {
+    const npc = parseNpc("Subject", body, 6, null)!;
+    expect(npc.appearance).toContain("\n\n");
+  });
+});
+
+describe("parseNpc — Ch4 tolerance (no meta lines, Visual + Appearance split)", () => {
+  const body = `### Visual
+Pale green wrap. Mended.
+
+### Personality
+Soft. Distracted.
+
+### Appearance
+A small leather apron over the wrap.
+
+### Background
+Born at Brewer's Brand.
+
+### Emotional Core
+_He walked away from a kindly contract._
+`;
+
+  it("works without **Race:/Stage:/Role:** meta lines", () => {
+    const npc = parseNpc("Bramble", body, 4, null)!;
+    expect(npc.race).toBe("");
+    expect(npc.occupation).toBe("");
+    expect(npc.personality).toBe("Soft. Distracted.");
+    expect(npc.backstory).toBe("Born at Brewer's Brand.");
+  });
+
+  it("concatenates Visual + Appearance sections", () => {
+    const npc = parseNpc("Bramble", body, 4, null)!;
+    expect(npc.appearance).toContain("Pale green wrap");
+    expect(npc.appearance).toContain("leather apron");
+  });
+
+  it("tolerates parenthetical heading suffixes", () => {
+    const bodyWithParens = body.replace("### Personality", "### Personality (When He Was at the Camp)");
+    const npc = parseNpc("Drift", bodyWithParens, 4, null)!;
+    expect(npc.personality).toBe("Soft. Distracted.");
+  });
+});
+
+describe("applySidecar", () => {
+  function freshRecord(): NpcRecord {
+    return {
+      name: "Brittle",
+      raw_heading: "Brittle",
+      race: "Sugarspun (Tuft)",
+      occupation: "Right-side lemonade-girl.",
+      appearance: "",
+      personality: "",
+      backstory: "",
+      notes: "",
+      status: "alive",
+      relationship: "neutral",
+      relevance: 3,
+      tags: ["chapter-5", "sugarspun", "tuft"],
+      location_key: null,
+    };
+  }
+
+  it("applies status, relationship, relevance, tag replacement, display_name", () => {
+    const r = freshRecord();
+    const cfg: SidecarConfig = {
+      npcs: {
+        Brittle: {
+          status: "alive",
+          relationship: "ally",
+          relevance: 4,
+          tags: ["chapter-5", "sugarspun", "child", "bow-keeper"],
+          location: "carnival",
+        },
+      },
+    };
+    applySidecar([r], cfg);
+    expect(r.relationship).toBe("ally");
+    expect(r.relevance).toBe(4);
+    expect(r.tags).toEqual(["chapter-5", "sugarspun", "child", "bow-keeper"]);
+    expect(r.location_key).toBe("carnival");
+  });
+
+  it("merges extra_tags without dupes", () => {
+    const r = freshRecord();
+    applySidecar([r], { npcs: { Brittle: { extra_tags: ["new-tag", "sugarspun"] } } });
+    expect(r.tags).toContain("new-tag");
+    expect(r.tags.filter((t) => t === "sugarspun").length).toBe(1);
+  });
+
+  it("renames via display_name and looks up by raw_heading", () => {
+    const r = freshRecord();
+    r.raw_heading = "Madame Petrichor (Terminal Entry)";
+    r.name = "Madame Petrichor (Terminal Entry)";
+    const cfg: SidecarConfig = {
+      npcs: {
+        "Madame Petrichor (Terminal Entry)": { display_name: "Madame Petrichor", relevance: 5 },
+      },
+    };
+    applySidecar([r], cfg);
+    expect(r.name).toBe("Madame Petrichor");
+    expect(r.relevance).toBe(5);
+  });
+});
+
+describe("findPotentialDuplicates", () => {
+  // Regression: yesterday's Ch5 import created a "Madame Petrichor" NPC even
+  // though an older "Madame Petrichor & Cinder" was already in the DB. Exact
+  // and normalized name matches both missed it; substring detection catches it.
+  it("catches the Petrichor case (candidate is substring of existing)", () => {
+    const existing = ["madame petrichor & cinder"].map(normalizeName);
+    expect(findPotentialDuplicates("Madame Petrichor", existing)).toEqual([
+      "madame petrichor & cinder",
+    ]);
+  });
+
+  it("catches the reverse case (existing is substring of candidate)", () => {
+    const existing = ["petrichor"];
+    expect(findPotentialDuplicates("Madame Petrichor", existing)).toEqual(["petrichor"]);
+  });
+
+  it("ignores exact matches (caller handles those as silent idempotent skip)", () => {
+    const existing = ["madame petrichor"];
+    expect(findPotentialDuplicates("Madame Petrichor", existing)).toEqual([]);
+  });
+
+  it("returns empty for unrelated names", () => {
+    const existing = ["brittle", "spangle", "glissade"].map(normalizeName);
+    expect(findPotentialDuplicates("Marzipane", existing)).toEqual([]);
+  });
+
+  it("does not false-positive on common short prefixes", () => {
+    // "Bract" and "Bramble" share the prefix "br" but neither is a substring
+    // of the other.
+    const existing = ["bract"];
+    expect(findPotentialDuplicates("Bramble", existing)).toEqual([]);
+  });
+});
+
+describe("resolveLocationSpecs", () => {
+  it("applies default parent + type when sidecar omits them", () => {
+    const cfg: SidecarConfig = {
+      locations: [{ key: "carnival", name: "The Sugar Carnival" }],
+    };
+    const specs = resolveLocationSpecs(cfg, "Sothery");
+    expect(specs.length).toBe(1);
+    expect(specs[0]!.parent_name).toBe("Sothery");
+    expect(specs[0]!.type).toBe("other"); // default fallback
+    expect(specs[0]!.tags).toEqual([]);
+  });
+
+  it("respects sidecar-supplied type and parent", () => {
+    const cfg: SidecarConfig = {
+      locations: [
+        { key: "carnival", name: "The Sugar Carnival", type: "town", parent_name: "Sothery", tags: ["a", "b"] },
+      ],
+    };
+    const specs = resolveLocationSpecs(cfg, "DefaultParent");
+    expect(specs[0]!.type).toBe("town");
+    expect(specs[0]!.parent_name).toBe("Sothery");
+    expect(specs[0]!.tags).toEqual(["a", "b"]);
+  });
+});

--- a/scripts/lib/parse-chapter-npcs.ts
+++ b/scripts/lib/parse-chapter-npcs.ts
@@ -125,35 +125,12 @@ export function slug(s: string): string {
   return s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-/** Case-insensitive trimmed comparison key for idempotency checks. */
-export function normalizeName(s: string): string {
-  return s.trim().toLowerCase().replace(/\s+/g, " ");
-}
-
-/**
- * Find existing NPC names that look like potential duplicates of `candidate`.
- *
- * Catches the "Madame Petrichor" vs "Madame Petrichor & Cinder" class of bug —
- * different exact names that obviously refer to the same character. Returns
- * any existing name where one is a substring of the other (case-insensitive),
- * minus exact matches (those are handled separately as the idempotent-skip
- * path).
- */
-export function findPotentialDuplicates(
-  candidate: string,
-  existingNormalizedNames: Iterable<string>,
-): string[] {
-  const candNorm = normalizeName(candidate);
-  if (!candNorm) return [];
-  const hits: string[] = [];
-  for (const existing of existingNormalizedNames) {
-    if (existing === candNorm) continue; // exact match — caller handles
-    if (existing.includes(candNorm) || candNorm.includes(existing)) {
-      hits.push(existing);
-    }
-  }
-  return hits;
-}
+// Re-export the shared name-matching primitives so existing import sites
+// (`import { normalizeName, findPotentialDuplicates } from "./parse-chapter-npcs"`)
+// keep working. The actual implementation — substring + Levenshtein fuzzy
+// matching — lives in `./name-matching.ts` and is shared with the faiths
+// importer's parser.
+export { normalizeName, findPotentialDuplicates } from "./name-matching";
 
 /** Remove a trailing `---` horizontal-rule fragment. */
 function stripTrailingHr(text: string): string {

--- a/scripts/lib/parse-chapter-npcs.ts
+++ b/scripts/lib/parse-chapter-npcs.ts
@@ -1,0 +1,381 @@
+/**
+ * Pure parsing logic for chapter NPC markdown files.
+ *
+ * No I/O, no Supabase, no console output — keep this module testable.
+ * The CLI entry point (`scripts/import-chapter-npcs.ts`) and the DB helpers
+ * (`scripts/lib/import-chapter-npcs-db.ts`) consume what this module returns.
+ *
+ * ── Presence-check rule (REQUIRED INVARIANT) ──────────────────────────────
+ *
+ * Only NPCs with a top-level `## NAME` section header in the source markdown
+ * are extracted. We do NOT infer NPCs from:
+ *
+ *   - `### NAME` subsection headers (used for nested groups like
+ *     "### The Channel Camp's other Slips" — these are group prose, not
+ *     individual NPC entries)
+ *   - Inline `**Name**` bold within paragraphs (used in Ch4 to list
+ *     background slips in a single sentence)
+ *   - Bullet-point references (`- **Name** — ...`) used as cross-references
+ *   - Body mentions of names already established elsewhere
+ *
+ * This is enforced by `splitNpcBlocks` splitting only on `\n## ` markers.
+ * Do not relax this. Past ad-hoc imports inserted some inline-bold names by
+ * hand; future imports should require those NPCs to be given their own
+ * `## NAME` heading in the source if they're meant to exist as DB rows.
+ */
+
+import type { NpcRelationship, NpcStatus } from "@/types/npc.types";
+import type { LocationType } from "@/types/location.types";
+
+/** Top-level `## NAME` headings that are NOT NPCs and must be skipped. */
+const SKIP_HEADING_PREFIXES = [
+  "Chapter ",         // "Chapter One NPCs", "Chapter Five — NPCs"
+  "Atlas Update",     // "Atlas Update Summary" (Ch5)
+  "NPC Atlas",        // "NPC Atlas — Update Summary" (Ch4 variant)
+  "Encountered ",     // prologue group heading
+  "Available for ",   // prologue group heading
+  "Locus NPCs",       // "Locus NPCs (Prologue Gazetteer)" + Ch4 "Locus NPCs — Full Entries"
+  "Additional Locus", // Ch4 "Additional Locus NPCs (Background, Lightly Sketched)" group
+  "Prologue ",        // prologue file title heading
+];
+
+/** Section headings we extract. Patterns tolerate trailing parentheticals. */
+const SECTION_PATTERNS = {
+  visual:      "(?:Visual(?:\\s+Description)?|Appearance)\\b",
+  personality: "Personality\\b",
+  background:  "Background\\b",
+  speech:      "Speech and Mannerisms\\b",
+  lens:        "Lens Variations\\b",
+  emotional:   "Emotional Core\\b",
+  encounters:  "Encounter Scenes\\b",
+  carries:     "Cross-Chapter Carries\\b",
+} as const;
+
+/** Per-NPC override from a sidecar config file. */
+export interface NpcOverride {
+  display_name?: string;
+  location?: string;
+  status?: NpcStatus;
+  relationship?: NpcRelationship;
+  relevance?: number;
+  /** Full tag replacement. */
+  tags?: string[];
+  /** Append-only tag merge. */
+  extra_tags?: string[];
+  race?: string;
+  occupation?: string;
+}
+
+/** A location to create or reuse, declared in the sidecar config. */
+export interface LocationSpec {
+  key: string;
+  name: string;
+  type: LocationType;
+  parent_name: string | null;
+  description: string;
+  tags: string[];
+}
+
+/** Shape of the sidecar JSON config (all fields optional). */
+export interface SidecarConfig {
+  default_location_key?: string;
+  locations?: Array<{
+    key: string;
+    name: string;
+    type?: LocationType;
+    parent_name?: string;
+    description?: string;
+    tags?: string[];
+  }>;
+  npcs?: Record<string, NpcOverride>;
+}
+
+/**
+ * A parsed NPC ready for insertion (or comparison against an existing DB row).
+ * Fields are a strict subset of `NpcInsert` plus the unresolved `location_key`.
+ */
+export interface NpcRecord {
+  /** Display name written to `npcs.name`. */
+  name: string;
+  /** Original `## ...` heading text, used to look up sidecar overrides. */
+  raw_heading: string;
+  race: string;
+  occupation: string;
+  appearance: string;
+  personality: string;
+  backstory: string;
+  notes: string;
+  status: NpcStatus;
+  relationship: NpcRelationship;
+  relevance: number;
+  tags: string[];
+  /** Key into the sidecar config's `locations` array (resolved to a UUID later). */
+  location_key: string | null;
+}
+
+const VALID_STATUS: ReadonlySet<NpcStatus> = new Set(["alive", "dead", "missing", "unknown"]);
+const VALID_RELATIONSHIP: ReadonlySet<NpcRelationship> = new Set(["ally", "enemy", "neutral", "unknown"]);
+
+// ────────────────────────────────────────────────────────────────────────────
+// String helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Lowercase, collapse non-alphanumeric runs to single hyphens, trim. */
+export function slug(s: string): string {
+  return s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/** Case-insensitive trimmed comparison key for idempotency checks. */
+export function normalizeName(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Find existing NPC names that look like potential duplicates of `candidate`.
+ *
+ * Catches the "Madame Petrichor" vs "Madame Petrichor & Cinder" class of bug —
+ * different exact names that obviously refer to the same character. Returns
+ * any existing name where one is a substring of the other (case-insensitive),
+ * minus exact matches (those are handled separately as the idempotent-skip
+ * path).
+ */
+export function findPotentialDuplicates(
+  candidate: string,
+  existingNormalizedNames: Iterable<string>,
+): string[] {
+  const candNorm = normalizeName(candidate);
+  if (!candNorm) return [];
+  const hits: string[] = [];
+  for (const existing of existingNormalizedNames) {
+    if (existing === candNorm) continue; // exact match — caller handles
+    if (existing.includes(candNorm) || candNorm.includes(existing)) {
+      hits.push(existing);
+    }
+  }
+  return hits;
+}
+
+/** Remove a trailing `---` horizontal-rule fragment. */
+function stripTrailingHr(text: string): string {
+  return text.replace(/\n*-{3,}\s*$/, "").replace(/\s+$/, "");
+}
+
+/** First sentence, capped. */
+function truncateFirstSentence(s: string, cap = 200): string {
+  if (!s) return "";
+  const m = s.match(/^[^.!?]*[.!?]/);
+  const first = m ? m[0] : s;
+  return first.slice(0, cap);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Markdown extraction
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Split markdown on top-level `## ` headings. */
+export function splitNpcBlocks(text: string): Array<{ heading: string; body: string }> {
+  const parts = text.split(/\n## /);
+  const out: Array<{ heading: string; body: string }> = [];
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i] ?? "";
+    const nlIdx = part.indexOf("\n");
+    const heading = (nlIdx === -1 ? part : part.slice(0, nlIdx)).trim();
+    const body = nlIdx === -1 ? "" : part.slice(nlIdx + 1);
+    out.push({ heading, body });
+  }
+  return out;
+}
+
+export function isSkipHeading(heading: string): boolean {
+  return SKIP_HEADING_PREFIXES.some((p) => heading.startsWith(p));
+}
+
+/** Extract a `**Field:** value` line under an NPC heading. */
+function parseMeta(body: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^\\*\\*${escaped}:\\*\\*\\s*(.*?)$`, "m");
+  const m = body.match(re);
+  return m ? (m[1] ?? "").trim() : "";
+}
+
+/**
+ * Extract content of all `### <regex>` sections; concatenate with blank line.
+ *
+ * Note: we deliberately use the `g` flag without `m`. With `m`, `$` matches
+ * end-of-line and the non-greedy capture truncates at the first paragraph
+ * break. Without `m`, `$` matches end-of-string. We compensate for `^`'s
+ * loss by using `(?:^|\n)` to anchor to line start.
+ */
+function parseSection(body: string, regex: string): string {
+  const re = new RegExp(
+    `(?:^|\\n)### (?:${regex})(?:\\s*\\([^)]*\\))?\\s*\\n([\\s\\S]*?)(?=\\n### |\\n## |$)`,
+    "g",
+  );
+  const parts: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const chunk = (m[1] ?? "").trim();
+    if (chunk) parts.push(chunk);
+  }
+  return parts.join("\n\n");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tag derivation
+// ────────────────────────────────────────────────────────────────────────────
+
+function deriveDefaultTags(
+  chapter: number,
+  race: string,
+  stage: string,
+  role: string,
+  locationKey: string | null,
+): string[] {
+  const tags: string[] = [`chapter-${chapter}`];
+  const push = (t: string) => {
+    if (t && !tags.includes(t)) tags.push(t);
+  };
+
+  if (race) {
+    for (const tok of race.match(/[A-Za-z]+/g) ?? []) push(tok.toLowerCase());
+  }
+  if (stage) {
+    const head = stage.split(/[(;.]/)[0] ?? "";
+    const toks = (head.match(/[A-Za-z][A-Za-z-]+/g) ?? []).map(slug);
+    for (const t of toks.slice(0, 3)) push(t);
+  }
+  if (role) {
+    const head = role.split(/[.;,]/)[0] ?? "";
+    const stop = new Set(["the", "a", "an", "of", "at", "in", "to", "for", "and", "or"]);
+    const toks = (head.match(/[A-Za-z][A-Za-z-]+/g) ?? [])
+      .map(slug)
+      .filter((t) => t && !stop.has(t));
+    for (const t of toks.slice(0, 2)) push(t);
+  }
+  if (locationKey) push(slug(locationKey));
+  return tags;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Per-NPC parsing
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse one `## NAME` block. Returns null for skip-headings.
+ * Default status/relationship/relevance are applied here and may be overridden
+ * by `applySidecar` later.
+ */
+export function parseNpc(
+  heading: string,
+  body: string,
+  chapter: number,
+  defaultLocationKey: string | null,
+): NpcRecord | null {
+  if (isSkipHeading(heading)) return null;
+
+  const race = parseMeta(body, "Race");
+  const stage = parseMeta(body, "Stage");
+  const role = parseMeta(body, "Role");
+  const age = parseMeta(body, "Apparent age");
+
+  const appearance = stripTrailingHr(parseSection(body, SECTION_PATTERNS.visual));
+  const personality = stripTrailingHr(parseSection(body, SECTION_PATTERNS.personality));
+  const backstory = stripTrailingHr(parseSection(body, SECTION_PATTERNS.background));
+  const speech = stripTrailingHr(parseSection(body, SECTION_PATTERNS.speech));
+  const lens = stripTrailingHr(parseSection(body, SECTION_PATTERNS.lens));
+  const emotional = stripTrailingHr(parseSection(body, SECTION_PATTERNS.emotional));
+  const encounters = stripTrailingHr(parseSection(body, SECTION_PATTERNS.encounters));
+  const carries = stripTrailingHr(parseSection(body, SECTION_PATTERNS.carries));
+
+  const occupation = truncateFirstSentence(role);
+
+  const notesParts: string[] = [];
+  const pushBlock = (label: string, val: string) => {
+    if (val) notesParts.push(`**${label}**\n${val}`);
+  };
+  pushBlock("Emotional Core", emotional);
+  pushBlock("Stage", stage);
+  pushBlock("Apparent age", age);
+  if (role && role.length > occupation.length) pushBlock("Role", role);
+  pushBlock("Speech and Mannerisms", speech);
+  pushBlock("Lens Variations", lens);
+  pushBlock("Encounter Scenes", encounters);
+  pushBlock("Cross-Chapter Carries", carries);
+  const notes = notesParts.join("\n\n");
+
+  return {
+    name: heading,
+    raw_heading: heading,
+    race,
+    occupation,
+    appearance,
+    personality,
+    backstory,
+    notes,
+    status: "alive",
+    relationship: "neutral",
+    relevance: 3,
+    tags: deriveDefaultTags(chapter, race, stage, role, defaultLocationKey),
+    location_key: defaultLocationKey,
+  };
+}
+
+/** Merge sidecar overrides into parsed records. Mutates in place. */
+export function applySidecar(records: NpcRecord[], config: SidecarConfig): void {
+  const overrides = config.npcs ?? {};
+  for (const r of records) {
+    const ov = overrides[r.raw_heading];
+    if (!ov) continue;
+
+    if (ov.display_name) r.name = ov.display_name;
+    if (ov.location !== undefined) r.location_key = ov.location;
+
+    if (ov.status !== undefined) {
+      if (!VALID_STATUS.has(ov.status)) {
+        // eslint-disable-next-line no-console
+        console.warn(`WARN: ${r.name}: status ${ov.status} not in ${[...VALID_STATUS].join("|")}`);
+      }
+      r.status = ov.status;
+    }
+    if (ov.relationship !== undefined) {
+      if (!VALID_RELATIONSHIP.has(ov.relationship)) {
+        // eslint-disable-next-line no-console
+        console.warn(`WARN: ${r.name}: relationship ${ov.relationship} not in ${[...VALID_RELATIONSHIP].join("|")}`);
+      }
+      r.relationship = ov.relationship;
+    }
+    if (ov.relevance !== undefined) r.relevance = ov.relevance;
+
+    if (ov.tags) {
+      r.tags = [...ov.tags];
+    } else if (ov.extra_tags) {
+      for (const t of ov.extra_tags) {
+        if (!r.tags.includes(t)) r.tags.push(t);
+      }
+    }
+    if (ov.race !== undefined) r.race = ov.race;
+    if (ov.occupation !== undefined) r.occupation = ov.occupation;
+
+    // If config moved the NPC to a different location and didn't set tags,
+    // tag the new location key.
+    if (ov.location !== undefined && !ov.tags && !ov.extra_tags && r.location_key) {
+      const lk = slug(r.location_key);
+      if (lk && !r.tags.includes(lk)) r.tags.push(lk);
+    }
+  }
+}
+
+/** Resolve `LocationSpec`s from sidecar config + apply CLI default parent. */
+export function resolveLocationSpecs(
+  config: SidecarConfig,
+  defaultParent: string | null,
+): LocationSpec[] {
+  return (config.locations ?? []).map((entry) => ({
+    key: entry.key,
+    name: entry.name,
+    type: entry.type ?? "other",
+    parent_name: entry.parent_name ?? defaultParent,
+    description: entry.description ?? "",
+    tags: [...(entry.tags ?? [])],
+  }));
+}

--- a/scripts/lib/parse-faiths.test.ts
+++ b/scripts/lib/parse-faiths.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PANTHEON_FOLK,
+  PANTHEON_HEAVENLY,
+  PANTHEON_LESSER,
+  findPotentialDuplicates,
+  isSkipHeading,
+  normalizeName,
+  parseClericDomains,
+  parseFaith,
+  parseFolkAndMargin,
+  parsePreambleSuns,
+  slug,
+  splitFaithBlocks,
+} from "./parse-faiths";
+
+describe("isSkipHeading", () => {
+  it("skips meta headings only; Folk and Margin Figures is now PARSED, not skipped", () => {
+    expect(isSkipHeading("A Note for Players")).toBe(true);
+    expect(isSkipHeading("Appendix C")).toBe(true);
+
+    // Routed to parseFolkAndMargin by the CLI, not skipped at parser level
+    expect(isSkipHeading("Folk and Margin Figures")).toBe(false);
+
+    expect(isSkipHeading("The Saucer")).toBe(false);
+    expect(isSkipHeading("The Bell-Mother")).toBe(false);
+    expect(isSkipHeading("Old Tippet")).toBe(false);
+  });
+});
+
+describe("splitFaithBlocks", () => {
+  it("splits on top-level `## ` and preserves heading + body", () => {
+    const md = `# FAITHS
+
+preamble paragraph...
+
+## The Hearth
+
+body of hearth.
+
+## The Bell-Mother
+
+body of bell-mother.
+`;
+    const blocks = splitFaithBlocks(md);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]?.heading).toBe("The Hearth");
+    expect(blocks[1]?.heading).toBe("The Bell-Mother");
+    expect(blocks[0]?.body).toMatch(/body of hearth/);
+  });
+});
+
+describe("parseClericDomains", () => {
+  it("extracts a simple comma list", () => {
+    const body = "**Cleric domains:** Life, Order, Peace. **Paladin Oath of X** sits naturally here.";
+    const { domains } = parseClericDomains(body);
+    expect(domains).toEqual(["Life", "Order", "Peace"]);
+  });
+
+  it("strips parenthetical asides and `**Paladin**` follow-ons", () => {
+    const body = "**Cleric domains:** Trickery (the saint of gentle losses), Twilight (the threshold of steam). **Bards** and **Rogues** are the more usual servants.";
+    const { domains } = parseClericDomains(body);
+    expect(domains).toEqual(["Trickery", "Twilight"]);
+  });
+
+  it("handles the dual-faced Doors form: 'The Open — Life, Knowledge. The Close — Grave, Death (carefully).'", () => {
+    const body = "**Cleric domains:** The Open — Life, Knowledge. The Close — Grave, Death (carefully). **Paladin Oath of Walk Through** sits naturally with the Close.";
+    const { domains } = parseClericDomains(body);
+    expect(domains.sort()).toEqual(["Death", "Grave", "Knowledge", "Life"]);
+  });
+
+  it("reports unknown tokens (homebrew names not in the ClericDomain enum) without crashing", () => {
+    const body = "**Cleric domains:** Peace, Twilight, Hospitality. **Paladin Oath of Kindness**";
+    const { domains, unknown } = parseClericDomains(body);
+    expect(domains).toEqual(["Peace", "Twilight"]);
+    expect(unknown).toContain("hospitality");
+  });
+
+  it("returns empty when no domains line is present", () => {
+    expect(parseClericDomains("just a body.").domains).toEqual([]);
+  });
+});
+
+describe("parseFaith — standard entry", () => {
+  const body = `_Primary: Brewling. Honored variously by: Sippets, Marrows._
+
+The patron of patience, of the slow circulation of the marmalade rivers.
+
+A Long Steep cleric's healing works slowly and durably.
+
+**Cleric domains:** Peace, Twilight, Mercy, Hospitality. **Paladin Oath of Kindness** is the natural pairing.
+
+_Among other peoples:_ Sippets honor the Long Steep as "the Sleeping Tea".
+
+---
+`;
+
+  it("returns a record with name + raw_heading from the `##` text", () => {
+    const r = parseFaith("The Long Steep", body)!;
+    expect(r.name).toBe("The Long Steep");
+    expect(r.raw_heading).toBe("The Long Steep");
+  });
+
+  it("filters domains to valid ClericDomain enum values, dropping homebrew tokens", () => {
+    const r = parseFaith("The Long Steep", body)!;
+    // Peace, Twilight, Mercy are all in the enum; Hospitality is not and is dropped.
+    expect(r.domains).toEqual(["Peace", "Twilight", "Mercy"]);
+  });
+
+  it("extracts portfolio summary from the first body sentence", () => {
+    const r = parseFaith("The Long Steep", body)!;
+    expect(r.portfolio).toMatch(/patron of patience/);
+  });
+
+  it("includes 'faith' + primary-race + honored-by + name-slug tags", () => {
+    const r = parseFaith("The Long Steep", body)!;
+    expect(r.tags).toContain("faith");
+    expect(r.tags).toContain("primary-brewling");
+    expect(r.tags).toContain("honored-by-sippets");
+    expect(r.tags).toContain("honored-by-marrows");
+    expect(r.tags).toContain("the-long-steep");
+  });
+
+  it("strips `---` trailers and the cleric-domains line from description", () => {
+    const r = parseFaith("The Long Steep", body)!;
+    expect(r.description.endsWith("---")).toBe(false);
+    expect(r.description).not.toMatch(/\*\*Cleric domains:\*\*/);
+  });
+
+  it("preserves multi-paragraph body content in description", () => {
+    const r = parseFaith("The Long Steep", body)!;
+    expect(r.description).toMatch(/patron of patience/);
+    expect(r.description).toMatch(/slowly and durably/);
+    expect(r.description).toMatch(/Sleeping Tea/);
+  });
+
+  it("returns null for skip-headings (A Note / Appendix only — Folk and Margin is now routed elsewhere by the CLI)", () => {
+    expect(parseFaith("A Note for Players", body)).toBeNull();
+    expect(parseFaith("Appendix C: Songs", body)).toBeNull();
+  });
+});
+
+describe("parseFaith — _Primary_ line variants", () => {
+  it("handles the vague form (no people-list) — 'Rarely honored elsewhere.'", () => {
+    const body = `_Primary: Wick. Rarely honored elsewhere._
+
+The patron of those who burn for others.
+
+**Cleric domains:** Light, Mercy.
+`;
+    const r = parseFaith("The Long Dark Mother", body)!;
+    expect(r.tags).toContain("primary-wick");
+    // No clean people-list, so no honored-by tags
+    expect(r.tags.some((t) => t.startsWith("honored-by-"))).toBe(false);
+  });
+
+  it("strips parentheticals from primary race (e.g. 'Slip (uneasy devotion)' → 'slip')", () => {
+    const body = `_Primary: Slip (uneasy devotion). Honored elsewhere mostly with fear._
+
+The dissolution.
+
+**Cleric domains:** Death, Grave.
+`;
+    const r = parseFaith("The Smudge", body)!;
+    expect(r.tags).toContain("primary-slip");
+    expect(r.tags.some((t) => t.includes("uneasy"))).toBe(false);
+  });
+
+  it("extracts honored-by list only from canonical 'Honored variously by:' form", () => {
+    const body = `_Primary: Hatchling. Honored variously by: Sippets (Open), Marrows (Close)._
+
+Twinned.
+
+**Cleric domains:** Life.
+`;
+    const r = parseFaith("The Doors That Open and Close", body)!;
+    expect(r.tags).toContain("primary-hatchling");
+    expect(r.tags).toContain("honored-by-sippets");
+    expect(r.tags).toContain("honored-by-marrows");
+  });
+});
+
+describe("parseFaith — entry without _Primary_ line (The Saucer)", () => {
+  const body = `The dish on which everything stands. Cracked along its rim.
+
+Most peoples nod to the Saucer without naming it.
+
+**Cleric domains:** Nature, Life, Order, Forge. **Druids** of any Circle may consider themselves saucer-druids.
+`;
+  it("still parses domains + description without a _Primary_ line", () => {
+    const r = parseFaith("The Saucer", body)!;
+    expect(r.domains).toEqual(["Nature", "Life", "Order", "Forge"]);
+    expect(r.description).toMatch(/dish on which everything stands/);
+    expect(r.tags).toContain("faith");
+    expect(r.tags).toContain("the-saucer");
+    expect(r.tags.some((t) => t.startsWith("primary-"))).toBe(false);
+  });
+});
+
+describe("findPotentialDuplicates", () => {
+  it("catches substring matches across faith names", () => {
+    const existing = ["the bell-mother"];
+    // "bell-mother" is a substring of "the bell-mother" — same class of bug as Petrichor.
+    expect(findPotentialDuplicates("Bell-Mother", existing)).toEqual(["the bell-mother"]);
+  });
+
+  it("ignores exact matches (silent idempotent skip path)", () => {
+    expect(findPotentialDuplicates("The Bell-Mother", ["the bell-mother"])).toEqual([]);
+  });
+
+  it("normalizes case + whitespace before comparing", () => {
+    expect(normalizeName("THE LONG STEEP")).toBe(normalizeName("  the long steep "));
+  });
+});
+
+describe("parseFaith — pantheon assignment", () => {
+  const minimalBody = `_Primary: Sippet._\n\nThe patron of welcoming.\n\n**Cleric domains:** Light, Peace.\n`;
+
+  it("defaults to Lesser Deities for unrecognized headings", () => {
+    const r = parseFaith("The Bell-Mother", minimalBody)!;
+    expect(r.pantheon).toBe(PANTHEON_LESSER);
+  });
+
+  it("overrides The Saucer → Heavenly Bodies", () => {
+    const r = parseFaith("The Saucer", minimalBody)!;
+    expect(r.pantheon).toBe(PANTHEON_HEAVENLY);
+  });
+
+  it("overrides Old Tippet → Folk and Margin Figures", () => {
+    const r = parseFaith("Old Tippet", minimalBody)!;
+    expect(r.pantheon).toBe(PANTHEON_FOLK);
+  });
+});
+
+describe("parsePreambleSuns", () => {
+  it("produces 3 Heavenly-Bodies sun records when preamble names the suns", () => {
+    const text = `# FAITHS\n\nAbove all the lesser deities are the **Three Suns** — the gold, the rose, and the purple.\n\n## The Hearth\n...`;
+    const suns = parsePreambleSuns(text);
+    expect(suns.length).toBe(3);
+    expect(suns.map((s) => s.name).sort()).toEqual(["Gold Sun", "Purple Sun", "Rose Sun"]);
+    for (const s of suns) {
+      expect(s.pantheon).toBe(PANTHEON_HEAVENLY);
+      expect(s.description.length).toBeGreaterThan(50);
+      expect(s.dm_notes).not.toBeNull();
+      expect(s.tags).toContain("faith");
+      expect(s.tags).toContain("heavenly-body");
+      expect(s.tags).toContain("sun");
+      // No `stub` tag — these have real content now
+      expect(s.tags).not.toContain("stub");
+    }
+  });
+
+  it("returns empty when preamble does NOT mention the canonical sun trio", () => {
+    const text = `# DIFFERENT CAMPAIGN\n\nNo suns here.\n\n## Some Deity\n...`;
+    expect(parsePreambleSuns(text)).toEqual([]);
+  });
+
+  it("does not look past the first `##` heading", () => {
+    // Sun reference appears AFTER the first heading — should be ignored.
+    const text = `# FAITHS\n\nNo suns here.\n\n## The Hearth\n\nthe gold, the rose, and the purple are mentioned in this entry but not in the preamble.`;
+    expect(parsePreambleSuns(text)).toEqual([]);
+  });
+});
+
+describe("parseFolkAndMargin", () => {
+  const body = `These are not lesser deities exactly. They are figures the country talks about and sometimes prays to without quite admitting it.
+
+**The Witch.** A figure everyone has heard of and very few have met. Sippet folk-tradition prays to the Witch for lost things.
+
+**The Three Suns directly.** Some clerics serve a sun rather than a lesser deity. (This is meta and should be skipped.)
+
+**The Stain.** There are priests who serve the Stain. They are extraordinarily rare.
+
+---
+`;
+
+  it("produces one record per bold-lead paragraph", () => {
+    const records = parseFolkAndMargin(body);
+    expect(records.map((r) => r.name).sort()).toEqual(["The Stain", "The Witch"]);
+  });
+
+  it("skips the meta-paragraph 'The Three Suns directly' (covered by Heavenly Bodies)", () => {
+    const records = parseFolkAndMargin(body);
+    expect(records.find((r) => r.name === "The Three Suns directly")).toBeUndefined();
+  });
+
+  it("strips the bold-lead and trailing `---` from description", () => {
+    const records = parseFolkAndMargin(body);
+    const witch = records.find((r) => r.name === "The Witch")!;
+    expect(witch.description.startsWith("A figure everyone")).toBe(true);
+    expect(witch.description).not.toContain("**The Witch.**");
+    expect(witch.description.endsWith("---")).toBe(false);
+  });
+
+  it("assigns Folk and Margin Figures pantheon + appropriate tags", () => {
+    const records = parseFolkAndMargin(body);
+    for (const r of records) {
+      expect(r.pantheon).toBe(PANTHEON_FOLK);
+      expect(r.tags).toContain("faith");
+      expect(r.tags).toContain("folk-figure");
+      expect(r.tags).toContain("session-zero-discussion");
+    }
+  });
+});
+
+describe("slug", () => {
+  it("kebab-cases names with punctuation", () => {
+    expect(slug("The Bell-Mother")).toBe("the-bell-mother");
+    expect(slug("Old Tippet")).toBe("old-tippet");
+    expect(slug("The Doors That Open and Close")).toBe("the-doors-that-open-and-close");
+  });
+});

--- a/scripts/lib/parse-faiths.ts
+++ b/scripts/lib/parse-faiths.ts
@@ -98,24 +98,10 @@ export function slug(s: string): string {
   return s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-export function normalizeName(s: string): string {
-  return s.trim().toLowerCase().replace(/\s+/g, " ");
-}
-
-/** Substring-name duplicate detection (matches NPC importer behaviour). */
-export function findPotentialDuplicates(
-  candidate: string,
-  existingNormalizedNames: Iterable<string>,
-): string[] {
-  const candNorm = normalizeName(candidate);
-  if (!candNorm) return [];
-  const hits: string[] = [];
-  for (const existing of existingNormalizedNames) {
-    if (existing === candNorm) continue;
-    if (existing.includes(candNorm) || candNorm.includes(existing)) hits.push(existing);
-  }
-  return hits;
-}
+// Re-export the shared name-matching primitives so existing import sites
+// keep working. Implementation (substring + Levenshtein fuzzy matching)
+// lives in `./name-matching.ts` and is shared with the chapter-NPC importer.
+export { normalizeName, findPotentialDuplicates } from "./name-matching";
 
 /** Split markdown on top-level `## ` headings. Returns (heading, body) pairs. */
 export function splitFaithBlocks(text: string): Array<{ heading: string; body: string }> {

--- a/scripts/lib/parse-faiths.ts
+++ b/scripts/lib/parse-faiths.ts
@@ -1,0 +1,420 @@
+/**
+ * Pure parsing logic for a campaign faiths/deities markdown file.
+ *
+ * Expected source structure (one `## NAME` per deity, free-form body):
+ *
+ *   # FAITHS OF X
+ *   ...preamble paragraphs...
+ *
+ *   ## Deity Name
+ *
+ *   _Primary: PeopleA. Honored variously by: PeopleB, PeopleC._
+ *
+ *   Bright-reading paragraph...
+ *
+ *   Deep-reading paragraph(s)...
+ *
+ *   **Cleric domains:** Life, Order, Peace. **Paladin Oath of X** sits naturally here.
+ *
+ *   _Among other peoples:_ extra cross-people notes.
+ *
+ *   _Closing italicized reading._
+ *
+ *   ---
+ *
+ *   ## Next Deity ...
+ *
+ * Skips top-level headings matching `SKIP_HEADING_PREFIXES` (group sections,
+ * GM notes, player-facing meta blurbs).
+ */
+
+// Relative import (not `@/`): we need the runtime value CLERIC_DOMAINS, and
+// tsx only resolves the `@/` alias for type-only imports — value imports must
+// use a relative path that node can resolve at runtime.
+import { CLERIC_DOMAINS, type ClericDomain } from "../../src/types/deity.types";
+
+/** Top-level `## NAME` headings that are NOT individual deities. */
+const SKIP_HEADING_PREFIXES = [
+  "A Note",            // "A Note for Players"
+  "Appendix",
+];
+
+/**
+ * Heading text for the Folk and Margin Figures group section. The importer
+ * routes `## Folk and Margin Figures` blocks to `parseFolkAndMargin` instead
+ * of `parseFaith` (it contains multiple bold-lead paragraph entities).
+ */
+export const FOLK_AND_MARGIN_HEADING = "Folk and Margin Figures";
+
+/** Canonical pantheon names — used as keys throughout and as DB row names. */
+export const PANTHEON_HEAVENLY = "Heavenly Bodies";
+export const PANTHEON_LESSER = "Lesser Deities";
+export const PANTHEON_FOLK = "Folk and Margin Figures";
+
+/**
+ * Per-deity overrides for pantheon assignment. The `faiths.md` file's
+ * structural categorization (top-level `## NAME` vs bold-lead in Folk section)
+ * doesn't always match the lore-tier categorization the user wants in the DB.
+ *
+ *  - "The Saucer" has a full `## NAME` section but the preamble explicitly
+ *    places her "below the lesser deities", part of the Heavenly Bodies tier.
+ *  - "Old Tippet" has a full `## NAME` section because his entry is too rich
+ *    for the bold-lead format, but the lore frames him as a folk-figure ("most
+ *    of his people honor him the way folk-figures are honored" — line 65).
+ *
+ * Add new entries here when the lore-tier diverges from the file structure.
+ */
+const PANTHEON_OVERRIDES: Record<string, string> = {
+  "The Saucer": PANTHEON_HEAVENLY,
+  "Old Tippet": PANTHEON_FOLK,
+};
+
+/** A parsed deity ready for insertion or DB comparison. */
+export interface FaithRecord {
+  /** Display name written to `deities.name`. */
+  name: string;
+  /** Original `## ...` heading text (for sidecar lookup + idempotency). */
+  raw_heading: string;
+  /** Pantheon this deity belongs to — resolved to `pantheon_id` by the importer. */
+  pantheon: string;
+  titles: string | null;
+  symbol: string | null;
+  alignment: string | null;
+  /** Filtered to `ClericDomain` enum values; unknown tokens (e.g. homebrew names) logged + dropped. */
+  domains: ClericDomain[];
+  /** Short prose summary of what the deity is "the patron of". */
+  portfolio: string | null;
+  /** Full body text concatenated into a single plain-text blob (matches NPC importer style). */
+  description: string;
+  /** GM-only notes (used for Three Suns to carry the campaign_book.md reveal content). */
+  dm_notes: string | null;
+  /** Tokens derived from `_Primary: X._` line + thematic keywords. */
+  tags: string[];
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+export function slug(s: string): string {
+  return s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+export function normalizeName(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/** Substring-name duplicate detection (matches NPC importer behaviour). */
+export function findPotentialDuplicates(
+  candidate: string,
+  existingNormalizedNames: Iterable<string>,
+): string[] {
+  const candNorm = normalizeName(candidate);
+  if (!candNorm) return [];
+  const hits: string[] = [];
+  for (const existing of existingNormalizedNames) {
+    if (existing === candNorm) continue;
+    if (existing.includes(candNorm) || candNorm.includes(existing)) hits.push(existing);
+  }
+  return hits;
+}
+
+/** Split markdown on top-level `## ` headings. Returns (heading, body) pairs. */
+export function splitFaithBlocks(text: string): Array<{ heading: string; body: string }> {
+  const parts = text.split(/\n## /);
+  const out: Array<{ heading: string; body: string }> = [];
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i] ?? "";
+    const nlIdx = part.indexOf("\n");
+    const heading = (nlIdx === -1 ? part : part.slice(0, nlIdx)).trim();
+    const body = nlIdx === -1 ? "" : part.slice(nlIdx + 1);
+    out.push({ heading, body });
+  }
+  return out;
+}
+
+export function isSkipHeading(heading: string): boolean {
+  return SKIP_HEADING_PREFIXES.some((p) => heading.startsWith(p));
+}
+
+// ─── per-deity extraction ───────────────────────────────────────────────────
+
+const DOMAIN_LOOKUP = new Map<string, ClericDomain>(
+  CLERIC_DOMAINS.map((d) => [d.toLowerCase(), d]),
+);
+
+/**
+ * Extract the cleric domains from a `**Cleric domains:**` line.
+ *
+ * The line may contain mixed natural language ("The Open — Life, Knowledge.
+ * The Close — Grave, Death (carefully)") plus follow-on sentences about
+ * paladins/bards that we should ignore. We:
+ *
+ *  - Take only the first sentence ending with `.` or up to the next `**...**`.
+ *  - Strip parenthetical asides.
+ *  - Tokenize on commas + "and" + "—" + colons.
+ *  - Filter to known `ClericDomain` enum values.
+ *
+ * `unknown` collects tokens that LOOK like domain proposals but aren't in the
+ * canonical enum (e.g. "Mercy"), for the caller to surface as a warning.
+ */
+export function parseClericDomains(body: string): { domains: ClericDomain[]; unknown: string[] } {
+  const m = body.match(/\*\*Cleric domains:\*\*\s*(.*?)(?=\n|$)/m);
+  if (!m) return { domains: [], unknown: [] };
+  let line = m[1] ?? "";
+
+  // Cut off at the first follow-on `**X**` (e.g. "**Paladin Oath of Kindness**").
+  const followOn = line.indexOf("**");
+  if (followOn !== -1) line = line.slice(0, followOn);
+
+  // Strip parentheticals
+  line = line.replace(/\([^)]*\)/g, "");
+
+  // Tokenize aggressively
+  const tokens = line
+    .split(/[,;:.—\-]| and /i)
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const domains: ClericDomain[] = [];
+  const unknown: string[] = [];
+  for (const tok of tokens) {
+    const norm = tok.toLowerCase();
+    // Strip leading articles like "The Open" → "open"
+    const stripped = norm.replace(/^the\s+/, "").trim();
+    const hit = DOMAIN_LOOKUP.get(stripped) ?? DOMAIN_LOOKUP.get(norm);
+    if (hit) {
+      if (!domains.includes(hit)) domains.push(hit);
+    } else if (/^[a-z][a-z\s'-]+$/.test(stripped) && stripped.length >= 4 && stripped.length <= 20) {
+      // Looks like a single-word domain candidate (not a sentence fragment)
+      if (!/\b(the|of|with|that|sits|natural|pairing|paladin|cleric|bard|domain)\b/.test(stripped)) {
+        if (!unknown.includes(stripped)) unknown.push(stripped);
+      }
+    }
+  }
+  return { domains, unknown };
+}
+
+/**
+ * Parse the optional `_Primary: X. ..._` lead line.
+ *
+ * Variants seen in the wild:
+ *   _Primary: Sippet. Honored variously by: Brewlings, Wicks._
+ *   _Primary: Wick. Rarely honored elsewhere._               ← no people list
+ *   _Primary: Slip (uneasy devotion). Honored elsewhere mostly with fear._
+ *   _Primary: Hatchling. Honored variously by: Sippets (Open), Marrows (Close)._
+ *
+ * We extract `primary` from any of these. We only populate `honored_by` from
+ * the canonical `Honored variously by: A, B, C.` form — vague phrasing like
+ * "elsewhere mostly with fear" doesn't yield clean people-list tags.
+ */
+function parsePrimaryLine(body: string): { primary: string | null; honored_by: string[] } {
+  // Greedy-but-not-past-`_`: match the whole italicized lead line.
+  const m = body.match(/^_Primary:\s*([^.]+?)\.\s*([^_]*)_/m);
+  if (!m) return { primary: null, honored_by: [] };
+  const primary = (m[1] ?? "").replace(/\s*\([^)]*\)/g, "").trim();
+  const rest = m[2] ?? "";
+
+  const honoredMatch = rest.match(/Honored\s+variously\s+by:\s*([^.]+?)\./);
+  const honored_by: string[] = [];
+  if (honoredMatch) {
+    const list = (honoredMatch[1] ?? "")
+      .replace(/\s*\([^)]*\)/g, "")
+      .split(/,| and /)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    honored_by.push(...list);
+  }
+  return { primary: primary || null, honored_by };
+}
+
+/** Extract a short portfolio summary from "The patron of X" or similar opener. */
+function extractPortfolio(description: string): string | null {
+  // The first body sentence after the _Primary_ line usually starts with "The patron of"
+  // or "The X-spirit and the Y-spirit" etc. Grab the first sentence.
+  const m = description.match(/^(?:[^_\n][^\n]*?[.!?])(?:\s|$)/);
+  if (!m) return null;
+  const sentence = m[0].trim();
+  if (sentence.length > 250 || sentence.length < 15) return null;
+  return sentence;
+}
+
+/** Strip the `_Primary..._` lead line + `_Among other peoples:_` markers + `---` trailers. */
+function cleanDescriptionBody(body: string): string {
+  return body
+    .replace(/^_Primary:[^_]*_\s*\n*/m, "")
+    .replace(/\n*-{3,}\s*$/, "")
+    .replace(/\*\*Cleric domains:\*\*\s*[^\n]*\n*/g, "")
+    .trim();
+}
+
+/** Build the tag set from primary race + honored-by peoples + name slug. */
+function buildTags(primary: string | null, honored_by: string[], name: string): string[] {
+  const tags: string[] = ["faith"];
+  if (primary) {
+    tags.push(`primary-${slug(primary)}`);
+  }
+  for (const p of honored_by) {
+    const t = `honored-by-${slug(p)}`;
+    if (!tags.includes(t)) tags.push(t);
+  }
+  // Add name slug for cross-referencing
+  const nameSlug = slug(name);
+  if (nameSlug && !tags.includes(nameSlug)) tags.push(nameSlug);
+  return tags;
+}
+
+export function parseFaith(heading: string, body: string): FaithRecord | null {
+  if (isSkipHeading(heading)) return null;
+
+  const { primary, honored_by } = parsePrimaryLine(body);
+  const { domains } = parseClericDomains(body);
+  const description = cleanDescriptionBody(body);
+  const portfolio = extractPortfolio(description);
+  const tags = buildTags(primary, honored_by, heading);
+  const pantheon = PANTHEON_OVERRIDES[heading] ?? PANTHEON_LESSER;
+
+  return {
+    name: heading,
+    raw_heading: heading,
+    pantheon,
+    titles: null,
+    symbol: null,
+    alignment: null,
+    domains,
+    portfolio,
+    description,
+    dm_notes: null,
+    tags,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Preamble parser — produces Three Suns from the lead-in paragraphs
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Detect the preamble's Three Suns reference and produce 3 stub-but-populated
+ * records. `faiths.md` itself only mentions the Suns in passing; the meaningful
+ * per-sun content comes from `campaign_book.md` (Part II, "The Three Suns" +
+ * "What the Suns Are" + "How to Run the Suns"). That content is hardcoded
+ * below — it's narrative reveal text the GM is expected to memorize, not
+ * something that drifts. If campaign_book.md substantially revises the suns,
+ * update this constant.
+ *
+ * The function activates only when the faiths.md preamble actually names the
+ * Three Suns (looking for the canonical "the gold, the rose, and the purple"
+ * phrasing). Returns [] if not found, so future campaigns whose faiths.md
+ * doesn't have suns get no spurious rows.
+ */
+export function parsePreambleSuns(fullText: string): FaithRecord[] {
+  // Slice to everything before first `## ` heading
+  const firstHeading = fullText.indexOf("\n## ");
+  const preamble = firstHeading === -1 ? fullText : fullText.slice(0, firstHeading);
+  if (!/the gold,\s+the rose,\s+and the purple/i.test(preamble)) return [];
+  return SUN_RECORDS;
+}
+
+const SUN_RECORDS: FaithRecord[] = [
+  {
+    name: "Gold Sun",
+    raw_heading: "Gold Sun",
+    pantheon: PANTHEON_HEAVENLY,
+    titles: null,
+    symbol: null,
+    alignment: null,
+    domains: [],
+    portfolio: "The dream-self — the compensatory shape the dream gave the sleeper.",
+    description:
+      "A gold one, low and warm — the sun the Sothern think of when they think of the sun, the one that ripens the marmalade and lights the windows of Cup Town in the late afternoon.",
+    dm_notes:
+      "**What it is (GM-only)**\n\n" +
+      "The gold sun is the dream-self. The Sippet, the Wick, the Brewling, the beautiful compensatory shape the dream gave the sleeper. It is low and warm because the dream loves this self. It is the one the Sothern think of when they think of the sun, because the dream-self is the only self the Sothern are. It rises and sets on the body the PC is currently inhabiting. The gold sun is what the PC sees in the mirror.\n\n" +
+      "**Practical: name the light**\n\n" +
+      "A scene at golden hour is lit by the gold sun, low and warm.",
+    tags: ["faith", "heavenly-body", "sun", "gold", "high-cosmology", "dream-self", "session-zero-discussion"],
+  },
+  {
+    name: "Rose Sun",
+    raw_heading: "Rose Sun",
+    pantheon: PANTHEON_HEAVENLY,
+    titles: null,
+    symbol: null,
+    alignment: null,
+    domains: [],
+    portfolio: "The pair-self — the waking person, the one in the envelope. Rose-tinted memory of who you were before the wound.",
+    description:
+      "A rose one, higher and smaller, softer — a steady pink-orange that travels slower across the sky than the gold one does.",
+    dm_notes:
+      "**What it is (GM-only)**\n\n" +
+      "The rose sun is the pair-self. The waking person, the one in the envelope. It is higher and smaller because the waking self is farther away than the dream-self, viewed from inside the dream. It is softer because the dream renders the waking self in flattering light, rose-tinted memory, the romanticized version of the person you used to be before the wound. It travels slower across the sky because the waking world moves at its own pace, which is not the dream's pace. The rose sun is what the PC sees when they catch their reflection in a pool of marmalade and find someone almost familiar looking back. It is the sun whose light is gentlest in the prologue's tea, the tea that is \"the exact tea each PC would have wanted to be drinking right now.\"\n\n" +
+      "**Practical: long-rest dreams**\n\n" +
+      "Long-rest dreams happen under the rose sun. When a PC dreams of rectangular windows, a beeping sound, hands they do not recognize, that is the rose sun's light, briefly closer than usual. The deep-lens glimpses always happen in that light. A PC who eventually notices the connection has earned a real piece of the campaign's structure.\n\n" +
+      "A scene of remembered tenderness, or of catching one's reflection unexpectedly, has the rose sun in it somewhere.",
+    tags: ["faith", "heavenly-body", "sun", "rose", "high-cosmology", "pair-self", "long-rest-dreams", "session-zero-discussion"],
+  },
+  {
+    name: "Purple Sun",
+    raw_heading: "Purple Sun",
+    pantheon: PANTHEON_HEAVENLY,
+    titles: null,
+    symbol: null,
+    alignment: null,
+    domains: [],
+    portfolio: "The act of dreaming — the sustained, costly holding of the dream open. Wrong in the way a kindness gone on too long is wrong.",
+    description:
+      "A third one, off to the side, that is purple in a way that is wrong.\n\n" +
+      "The wrong purple is not a color the eye wants. It is not bright. It is not painful in the ordinary way. It is the color of something left out too long, the inside of a bruise, the stain at the bottom of a cup nobody washed, the sky in a photograph taken in a year the viewer cannot quite place. Sothern have decided, collectively and without ever discussing it, not to look at that sun directly. They will tell you it is there. They will not tell you what color it is.",
+    dm_notes:
+      "**What it is (GM-only)**\n\n" +
+      "The purple sun is the act of dreaming. Not the dreamer, not the dream-self, the dreaming. The sustained, costly, generations-long act of holding the dream open. The purple is wrong because the dreaming is wrong: not evil, not malicious, but wrong in the way a kindness that has gone on too long is wrong. It has been left out too long. It is the color of a bruise because somebody is bruising themselves to keep the dream up, and the PCs have decided, with the rest of Sothery, not to look at who.\n\n" +
+      "This is what makes the purple sun bearable in the prologue: the PCs (and the players) genuinely cannot bear to look at it yet, because they do not know what it is, and the dream protects them from looking by ensuring they forget they decided not to. The dream is gentle with its own truth. The purple sun is the same kind of mercy as the lantern log entry with no word after it, the campaign showing you the shape of the answer before you can hold it.\n\n" +
+      "**Practical: how to handle**\n\n" +
+      "The Sothern never name the purple sun. They will say \"the wrong one\" if they say anything. Most will not say anything. A Sippet asked directly about it will go quiet, look down at their tea, and the moment will pass.\n\n" +
+      "PCs can ask. NPCs cannot answer. No NPC in the campaign has words for the purple sun, including the Witch, until the climax. If a PC presses, the NPC's confusion is sincere. They have lived their whole lives under this sky. The wrong sun is just the sky.\n\n" +
+      "The purple sun gets worse, very slowly, across the campaign. As the Stain Clock advances, the purple grows a hair more wrong each chapter. By Chapter 8 it is hard to look at even peripherally. A perceptive PC may notice this. They will not be confirmed.",
+    tags: ["faith", "heavenly-body", "sun", "purple", "high-cosmology", "act-of-dreaming", "stain", "session-zero-discussion"],
+  },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Folk and Margin Figures parser — produces records from bold-lead paragraphs
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Names within the Folk and Margin Figures section that are NOT individual
+ * entities — typically meta-paragraphs about a topic covered elsewhere.
+ * "The Three Suns directly" is a paragraph about serving a sun rather than a
+ * lesser deity; the actual sun entities are produced by `parsePreambleSuns`.
+ */
+const FOLK_META_SKIPS = new Set(["The Three Suns directly"]);
+
+/**
+ * Parse the body of `## Folk and Margin Figures` into one record per
+ * `**Name.** ...` bold-lead paragraph. Strips the bold-lead from the
+ * description body so it doesn't appear duplicated in the rendered prose.
+ */
+export function parseFolkAndMargin(body: string): FaithRecord[] {
+  const out: FaithRecord[] = [];
+  // Each entry starts with `**Name.**` at paragraph-start. Find them.
+  const pattern = /(?:^|\n\n)\*\*([^*]+?)\.\*\*\s+([\s\S]*?)(?=\n\n\*\*[^*]+?\.\*\*|\n\n---|\n\n## |$)/g;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(body)) !== null) {
+    const name = m[1]!.trim();
+    if (FOLK_META_SKIPS.has(name)) continue;
+    const description = m[2]!.trim().replace(/\n*-{3,}\s*$/, "").trim();
+    const tags = ["faith", "folk-figure", "margin-figure", "session-zero-discussion", slug(name)];
+    out.push({
+      name,
+      raw_heading: name,
+      pantheon: PANTHEON_FOLK,
+      titles: null,
+      symbol: null,
+      alignment: null,
+      domains: [],
+      portfolio: null,
+      description,
+      dm_notes: null,
+      tags,
+    });
+  }
+  return out;
+}

--- a/scripts/lib/tiptap.test.ts
+++ b/scripts/lib/tiptap.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEITY_RICHTEXT_FIELDS,
+  NPC_RICHTEXT_FIELDS,
+  TIPTAP_DOC_ATTRS,
+  markdownToTiptap,
+  tiptapifyFields,
+} from "./tiptap";
+
+type TiptapNode = { type: string; content?: unknown[]; marks?: { type: string }[]; text?: string; attrs?: Record<string, unknown> };
+type TiptapDoc = { type: "doc"; attrs: typeof TIPTAP_DOC_ATTRS; content: TiptapNode[] };
+
+function parse(s: string | null): TiptapDoc {
+  expect(s).not.toBeNull();
+  return JSON.parse(s!) as TiptapDoc;
+}
+
+describe("markdownToTiptap — root doc shape", () => {
+  it("emits canonical doc node with twoColumn=false attrs (matches editor default)", () => {
+    const doc = parse(markdownToTiptap("hello"));
+    expect(doc.type).toBe("doc");
+    expect(doc.attrs).toEqual({ twoColumn: false });
+    expect(Array.isArray(doc.content)).toBe(true);
+  });
+
+  it("returns null for null/empty/whitespace input (safe for nullable fields)", () => {
+    expect(markdownToTiptap(null)).toBeNull();
+    expect(markdownToTiptap(undefined)).toBeNull();
+    expect(markdownToTiptap("")).toBeNull();
+    expect(markdownToTiptap("   \n  \n  ")).toBeNull();
+  });
+});
+
+describe("markdownToTiptap — paragraph content", () => {
+  it("wraps a single line in one paragraph", () => {
+    const doc = parse(markdownToTiptap("Just a simple sentence."));
+    expect(doc.content.length).toBe(1);
+    expect(doc.content[0]!.type).toBe("paragraph");
+    expect((doc.content[0]!.content![0] as TiptapNode).text).toBe("Just a simple sentence.");
+  });
+
+  it("preserves multi-paragraph structure across blank lines", () => {
+    const md = `First paragraph.
+
+Second paragraph.
+
+Third paragraph.`;
+    const doc = parse(markdownToTiptap(md));
+    expect(doc.content.length).toBe(3);
+    expect(doc.content.every((n) => n.type === "paragraph")).toBe(true);
+  });
+});
+
+describe("markdownToTiptap — inline marks", () => {
+  it("converts **bold** to a bold-marked text node", () => {
+    const doc = parse(markdownToTiptap("She is **the heaviest deity**."));
+    const para = doc.content[0]!.content as TiptapNode[];
+    const bold = para.find((n) => n.marks?.[0]?.type === "bold")!;
+    expect(bold.text).toBe("the heaviest deity");
+  });
+
+  it("converts _italic_ AND *italic* to italic-marked text nodes", () => {
+    const docUnderscore = parse(markdownToTiptap("Whispered: _that is the saying_."));
+    const docStar = parse(markdownToTiptap("Whispered: *that is the saying*."));
+    const findItalic = (d: TiptapDoc) =>
+      (d.content[0]!.content as TiptapNode[]).find((n) => n.marks?.[0]?.type === "italic")!;
+    expect(findItalic(docUnderscore).text).toBe("that is the saying");
+    expect(findItalic(docStar).text).toBe("that is the saying");
+  });
+});
+
+describe("markdownToTiptap — block-level shapes", () => {
+  it("recognises bullet lists", () => {
+    const doc = parse(markdownToTiptap("- one\n- two\n- three"));
+    expect(doc.content[0]!.type).toBe("bulletList");
+    expect((doc.content[0]!.content as TiptapNode[]).length).toBe(3);
+  });
+
+  it("recognises headings", () => {
+    const doc = parse(markdownToTiptap("# Big\n\n## Medium\n\n### Small"));
+    const types = doc.content.map((n) => n.type);
+    expect(types).toEqual(["heading", "heading", "heading"]);
+    const levels = doc.content.map((n) => (n.attrs as { level: number })?.level);
+    expect(levels).toEqual([1, 2, 3]);
+  });
+});
+
+describe("markdownToTiptap — synth'd **Label**\\n{content} preprocessing", () => {
+  // The NPC importer's `notes` field synthesizes blocks of the form:
+  //   **Emotional Core**
+  //   the patron's emotional core text here.
+  //
+  //   **Stage**
+  //   the stage info here.
+  // With no blank line between label and content, the raw markdown parser
+  // would join "**Emotional Core**" and the content into one paragraph. The
+  // preprocessor inserts a blank line so each label becomes its own paragraph.
+
+  it("splits **Label**\\n{content} into TWO paragraphs (label paragraph + content paragraph)", () => {
+    const md = `**Emotional Core**\nShe has loved her husband.\n\n**Stage**\nLate.`;
+    const doc = parse(markdownToTiptap(md));
+    // Expected: 4 paragraphs (label, content, label, content)
+    expect(doc.content.length).toBe(4);
+    expect(doc.content[0]!.type).toBe("paragraph");
+    // Label paragraph: first text node is bold "Emotional Core"
+    const label0 = (doc.content[0]!.content as TiptapNode[])[0]!;
+    expect(label0.marks?.[0]?.type).toBe("bold");
+    expect(label0.text).toBe("Emotional Core");
+    // Content paragraph: plain text
+    const content0 = (doc.content[1]!.content as TiptapNode[])[0]!;
+    expect(content0.text).toBe("She has loved her husband.");
+  });
+
+  it("does NOT double-blank when content already has blank-line separator (idempotent)", () => {
+    const mdAlreadyBlank = `**Stage**\n\nLate.`;
+    const doc = parse(markdownToTiptap(mdAlreadyBlank));
+    expect(doc.content.length).toBe(2);
+  });
+
+  it("doesn't touch inline **bold** mid-paragraph (only standalone-line labels)", () => {
+    const md = `This sentence has an inline **bold** word in the middle of it.`;
+    const doc = parse(markdownToTiptap(md));
+    expect(doc.content.length).toBe(1);
+    // The bold word is a marked text node inside the single paragraph
+    const para = doc.content[0]!.content as TiptapNode[];
+    const bold = para.find((n) => n.marks?.[0]?.type === "bold")!;
+    expect(bold.text).toBe("bold");
+  });
+});
+
+describe("tiptapifyFields", () => {
+  it("converts only the named fields, passes others through unchanged", () => {
+    const payload = {
+      name: "Master Cantor",
+      tags: ["faith", "sugarwell"],
+      appearance: "A warm-looking Sugarspun.",
+      personality: "Hospitable, gossipy.",
+      relevance: 3,
+      portrait_url: null,
+    };
+    const out = tiptapifyFields(payload, NPC_RICHTEXT_FIELDS);
+    // Untouched non-rich fields
+    expect(out.name).toBe("Master Cantor");
+    expect(out.tags).toEqual(["faith", "sugarwell"]);
+    expect(out.relevance).toBe(3);
+    expect(out.portrait_url).toBeNull();
+    // Converted prose fields parse as Tiptap docs
+    expect(parse(out.appearance as string).type).toBe("doc");
+    expect(parse(out.personality as string).type).toBe("doc");
+  });
+
+  it("skips fields not present in payload (so updates-map use is safe)", () => {
+    const updates = { pantheon_id: "abc-123", tags: ["a"] };
+    const out = tiptapifyFields(updates, DEITY_RICHTEXT_FIELDS);
+    expect(out).toEqual(updates);
+    expect("description" in out).toBe(false);
+    expect("dm_notes" in out).toBe(false);
+  });
+
+  it("leaves null values as null (no spurious empty docs)", () => {
+    const out = tiptapifyFields(
+      { appearance: null, personality: "text here" },
+      NPC_RICHTEXT_FIELDS,
+    );
+    expect(out.appearance).toBeNull();
+    expect(out.personality).not.toBeNull();
+  });
+
+  it("leaves non-string values untouched (defensive)", () => {
+    const out = tiptapifyFields(
+      { appearance: { already: "an object" } as unknown as string },
+      NPC_RICHTEXT_FIELDS,
+    );
+    expect(out.appearance).toEqual({ already: "an object" });
+  });
+});

--- a/scripts/lib/tiptap.ts
+++ b/scripts/lib/tiptap.ts
@@ -1,0 +1,107 @@
+/**
+ * Markdown → Tiptap JSON conversion at the importer's DB-write boundary.
+ *
+ * The chapter NPC + faiths importers' parsers produce plain markdown for
+ * rich-text fields (`appearance`, `personality`, `backstory`, `notes` on NPCs;
+ * `description`, `dm_notes` on deities; `description` on pantheons). The Vue
+ * `RichTextEditor` component binds those fields as Tiptap documents, so plain
+ * markdown round-trips through the editor without formatting — the user has
+ * to manually reformat every imported row.
+ *
+ * This module converts plain markdown into the canonical Tiptap JSON shape
+ * the editor expects:
+ *
+ *   { "type": "doc",
+ *     "attrs": { "twoColumn": false },
+ *     "content": [ ... ProseMirror nodes ... ] }
+ *
+ * The conversion happens at the DB-write layer (insert/update payload build).
+ * The merge engine still compares plain text on both sides — see the
+ * `import-chapter-npcs.ts` design note for why that's the right call.
+ *
+ * Reuses the app's existing `parseMarkdown` from `src/lib/markdownToTiptap.ts`
+ * (same converter the paste-handling pipeline uses).
+ */
+
+// Relative path — `@/` alias isn't resolved at runtime for value imports.
+import { parseMarkdown } from "../../src/lib/markdownToTiptap";
+
+/**
+ * The doc node attrs the existing UI saves. `twoColumn: false` is the editor's
+ * default; including it explicitly so importer output is byte-aligned with
+ * what `RichTextEditor` writes when the user saves a fresh document.
+ */
+export const TIPTAP_DOC_ATTRS = { twoColumn: false } as const;
+
+/**
+ * Synth'd `**Label**\n{content}` blocks (used in NPC `notes` for Emotional
+ * Core / Stage / Lens Variations / etc.) render as a single paragraph in the
+ * raw converter because there's no blank line between the label and content.
+ * Insert one before passing to the converter so each label is its own
+ * paragraph — preserves the visual separation a reader expects.
+ *
+ * Only inserted when the bold-label is on its own line AND the following line
+ * has content (not already blank). Idempotent — re-running yields the same
+ * input if the blank already exists.
+ */
+function separateBoldLabelLines(md: string): string {
+  return md.replace(/(^|\n)(\*\*[^*\n]+\*\*)\n(?!\n)/g, "$1$2\n\n");
+}
+
+/**
+ * Convert a plain-markdown string to a Tiptap JSON document string.
+ * Returns `null` for null/empty input (so it's safe to pipe through nullable
+ * fields without producing `"{type:'doc',content:[]}"` rows).
+ */
+export function markdownToTiptap(md: string | null | undefined): string | null {
+  if (md === null || md === undefined || md === "") return null;
+  const trimmed = md.trim();
+  if (trimmed === "") return null;
+  const preprocessed = separateBoldLabelLines(md);
+  return JSON.stringify({
+    type: "doc",
+    attrs: TIPTAP_DOC_ATTRS,
+    content: parseMarkdown(preprocessed),
+  });
+}
+
+/**
+ * Apply `markdownToTiptap` to a named subset of string-or-null fields in a
+ * payload object, returning a new object. Fields not present in the payload
+ * are skipped; fields whose value is not a string are passed through
+ * unchanged (so caller can safely point this at an `updates` map from the
+ * merge engine — non-prose fields like `tags` arrays stay intact).
+ */
+export function tiptapifyFields<T extends Record<string, unknown>>(
+  payload: T,
+  fieldNames: readonly string[],
+): T {
+  const out = { ...payload };
+  for (const f of fieldNames) {
+    if (!(f in out)) continue;
+    const v = out[f];
+    if (typeof v === "string") {
+      (out as Record<string, unknown>)[f] = markdownToTiptap(v);
+    } else if (v === null) {
+      // leave null as null (markdownToTiptap would too, but skip the call)
+    }
+  }
+  return out;
+}
+
+/** Field sets — kept here so both importers reference the same source of truth. */
+export const NPC_RICHTEXT_FIELDS = [
+  "appearance",
+  "personality",
+  "backstory",
+  "notes",
+] as const;
+
+export const DEITY_RICHTEXT_FIELDS = [
+  "description",
+  "dm_notes",
+] as const;
+
+export const PANTHEON_RICHTEXT_FIELDS = [
+  "description",
+] as const;

--- a/src/types/deity.types.ts
+++ b/src/types/deity.types.ts
@@ -6,6 +6,7 @@ export const CLERIC_DOMAINS = [
   "Knowledge",
   "Life",
   "Light",
+  "Mercy",
   "Nature",
   "Order",
   "Peace",

--- a/src/types/npc.types.ts
+++ b/src/types/npc.types.ts
@@ -2,68 +2,84 @@ export type NpcStatus = "alive" | "dead" | "missing" | "unknown";
 export type NpcRelationship = "ally" | "neutral" | "enemy" | "unknown";
 
 export type NpcRelationshipType =
-  | "family"
+  // ── Familial ─────────────────────────────────────────────────────────────
+  | "family"          // any blood-kinship not better described by `sibling`
+                      // (parent/child, aunt/uncle, cousin, grandparent, etc.)
+  | "sibling"         // blood sibling specifically — kept distinct from
+                      // `family` so the parent/child vs sibling-of distinction
+                      // survives in the data
+  | "chosen_family"   // non-blood deep bond carried with family-strength
+                      // (adopted, matched-pair foundlings, anchored-companion)
+  // ── Affinitive ───────────────────────────────────────────────────────────
   | "friend"
   | "ally"
   | "rival"
   | "enemy"
+  | "lover"
+  // ── Hierarchical ─────────────────────────────────────────────────────────
   | "mentor"
   | "apprentice"
-  | "lover"
   | "subordinate"
   | "superior"
+  // ── Acquaintance / former ────────────────────────────────────────────────
   | "contact"
   | "former_ally"
   | "former_enemy";
 
 export const NPC_RELATIONSHIP_TYPE_LABELS: Record<NpcRelationshipType, string> = {
-  family:       "Family",
-  friend:       "Friend",
-  ally:         "Ally",
-  rival:        "Rival",
-  enemy:        "Enemy",
-  mentor:       "Mentor",
-  apprentice:   "Apprentice",
-  lover:        "Lover",
-  subordinate:  "Subordinate",
-  superior:     "Superior",
-  contact:      "Contact",
-  former_ally:  "Former Ally",
-  former_enemy: "Former Enemy",
+  family:        "Family",
+  sibling:       "Sibling",
+  chosen_family: "Chosen family",
+  friend:        "Friend",
+  ally:          "Ally",
+  rival:         "Rival",
+  enemy:         "Enemy",
+  mentor:        "Mentor",
+  apprentice:    "Apprentice",
+  lover:         "Lover",
+  subordinate:   "Subordinate",
+  superior:      "Superior",
+  contact:       "Contact",
+  former_ally:   "Former Ally",
+  former_enemy:  "Former Enemy",
 };
 
 // When displaying a relationship from the *other* NPC's perspective, use the inverse type.
 // Symmetric types map to themselves.
 export const NPC_RELATIONSHIP_INVERSE: Record<NpcRelationshipType, NpcRelationshipType> = {
-  family:       "family",
-  friend:       "friend",
-  ally:         "ally",
-  rival:        "rival",
-  enemy:        "enemy",
-  mentor:       "apprentice",
-  apprentice:   "mentor",
-  lover:        "lover",
-  subordinate:  "superior",
-  superior:     "subordinate",
-  contact:      "contact",
-  former_ally:  "former_ally",
-  former_enemy: "former_enemy",
+  family:        "family",
+  sibling:       "sibling",          // symmetric
+  chosen_family: "chosen_family",    // symmetric
+  friend:        "friend",
+  ally:          "ally",
+  rival:         "rival",
+  enemy:         "enemy",
+  mentor:        "apprentice",
+  apprentice:    "mentor",
+  lover:         "lover",
+  subordinate:   "superior",
+  superior:      "subordinate",
+  contact:       "contact",
+  former_ally:   "former_ally",
+  former_enemy:  "former_enemy",
 };
 
 export const NPC_RELATIONSHIP_TYPE_COLORS: Record<NpcRelationshipType, string> = {
-  family:       "#7c3aed",
-  friend:       "#059669",
-  ally:         "#2563eb",
-  rival:        "#d97706",
-  enemy:        "#dc2626",
-  mentor:       "#0891b2",
-  apprentice:   "#6366f1",
-  lover:        "#db2777",
-  subordinate:  "#6b7280",
-  superior:     "#374151",
-  contact:      "#64748b",
-  former_ally:  "#92400e",
-  former_enemy: "#7f1d1d",
+  family:        "#7c3aed",  // violet
+  sibling:       "#a855f7",  // lighter violet — kin-cluster with family
+  chosen_family: "#c084fc",  // lavender — kin-cluster with family but airier
+  friend:        "#059669",
+  ally:          "#2563eb",
+  rival:         "#d97706",
+  enemy:         "#dc2626",
+  mentor:        "#0891b2",
+  apprentice:    "#6366f1",
+  lover:         "#db2777",
+  subordinate:   "#6b7280",
+  superior:      "#374151",
+  contact:       "#64748b",
+  former_ally:   "#92400e",
+  former_enemy:  "#7f1d1d",
 };
 
 export interface NpcRelation {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,7 +14,11 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "scripts/**/*.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     // happy-dom gives DOM globals when we mount components or touch canvas.
     // For pure-function tests it costs ~nothing.
     environment: "happy-dom",
-    include: ["src/**/*.{test,spec}.ts"],
+    include: ["src/**/*.{test,spec}.ts", "scripts/**/*.{test,spec}.ts"],
     exclude: ["node_modules", "dist", ".vercel"],
     // Explicit imports from "vitest" — no `globals: true` so TypeScript
     // doesn't need `"vitest/globals"` in tsconfig types.


### PR DESCRIPTION
## What this PR introduces

A reusable TypeScript script-side toolchain for ingesting campaign content from markdown into Supabase:

1. **Generic enrich-merge engine** that codifies a "fill empty, preserve user content" idempotency contract.
2. **Chapter NPC importer** (`scripts/import-chapter-npcs.ts`) — replaces the ad-hoc Python+SQL workflow used for Ch1–Ch5 to date.
3. **Faiths / deities importer** (`scripts/import-faiths.ts`) — full pantheon infrastructure: Heavenly Bodies (Saucer + Three Suns), Lesser Deities, Folk and Margin Figures.
4. **Markdown → Tiptap conversion** applied at the importer write boundary (`scripts/lib/tiptap.ts`) — rich-text fields land as proper Tiptap JSON, no more manual reformatting after import.
5. Supporting infra (tsx runner, scripts-tree typecheck + test globs, Mercy added to `CLERIC_DOMAINS`).
6. **103 vitest cases** covering parser, merge engine, Tiptap converter, dry-run-is-read-only contract.

Re-runnable as the source markdown evolves; idempotent on existing data modulo the enrich-merge contract (details below).

## Commits (5 scoped pieces)

| # | Title |
|---|---|
| `119cdef` | `chore(scripts): add tsx runner + scripts/** typecheck + test globs` |
| `9c65b92` | `feat(types): add Mercy to CLERIC_DOMAINS` |
| `46c6b7b` | `feat(scripts): generic enrich-merge engine for importers` |
| `5e3b03e` | `feat(scripts): reusable TS chapter-NPC importer with enrich-merge` |
| `2197572` | `feat(scripts): reusable TS faiths importer with pantheon infrastructure` |
| `22896cc` | `feat(scripts): markdown → Tiptap converter for importer write paths` |
| `cc3d845` | `feat(scripts): apply Tiptap conversion at importer write boundary` |
| `91bdaa4` | `chore(scripts): Ch5 sidecar — 5 new NPC entries + Quiverglass Townhouse` |

## Sections

### 1. Tooling (`119cdef`)

- `tsx ^4.22.1` as devDependency — lets `.ts` scripts run via `tsx --env-file=.env.local …` (parallels `node --env-file=.env.local …` for `.mjs` scripts).
- Two npm scripts: `import-chapter-npcs`, `import-faiths`.
- `tsconfig.node.json` includes `scripts/**/*.ts` so `vue-tsc -b` type-checks the script tree; adds `@/*` path alias + `"types": ["node"]`.
- `vitest.config.ts` include glob extended to `scripts/**/*.{test,spec}.ts`.

No app-build or behavior change — pure tooling setup.

### 2. Mercy → CLERIC_DOMAINS (`9c65b92`)

`faiths.md` uses "Mercy" on four deities + the dual-faced Doors. Previous enum filtered it out, so those domains landed truncated in the DB. `CLERIC_DOMAINS` is purely a TS const tuple (no Postgres enum, no Zod schema, no migration; the `deities.domains` column is unconstrained `text[]`); Vue components iterate via v-for and pick up the new value automatically.

Note: Mercy is not strictly a WotC-published cleric domain (Tasha's Way of Mercy is a monk subclass); the codebase comment flags this for future revisit.

### 3. Enrich-merge engine (`46c6b7b`)

New module `scripts/lib/merge-fields.ts`. Field-by-field merge contract:

- **Scalar** — existing empty → fill from source. Existing has user content → leave. Both non-empty + differ → **conflict** (no write; surface to user).
- **Array** — union (existing ∪ source). Never dedupe-down; user-added items survive a re-import even if source no longer has them.
- **Prose** — like scalar, plus a "stub-append" case: existing < 200 chars AND source ≥ 2× existing → append below `\n\n---\n\n*From source:*\n\n…` separator rather than overwrite.

Also includes `planForceOverwrite` for per-record overrides ("I made these fields up by looking at the image; please overwrite from canonical lore"). Image columns left outside the schema are protected by omission — the override never touches them.

**23 tests** covering all paths.

### 4. NPC importer (`5e3b03e`)

```bash
npm run import-chapter-npcs -- \
  path/to/late_in_the_kind_country_chapter_N_npcs.md \
  --chapter N \
  [--config scripts/chapter_npc_configs/chapter_N.json] \
  [--dry-run] [-v]
```

Three TS files for testability + readability:

- `scripts/lib/parse-chapter-npcs.ts` — pure parser. **Documents the presence-check invariant explicitly:** only `## NAME` top-level blocks become NPCs. `### NAME` sub-headings, inline `**Name**` bold within paragraphs, and bullet-point cross-references are NOT extracted. Pinned with regression tests after an audit found the original ad-hoc Python Ch4 import had extracted inline-bold names from the source (legitimately in source, but better routed through curation).
- `scripts/lib/import-chapter-npcs-db.ts` — Supabase service-client layer. `fetchDbState` pulls full row content for merge planning; `enrichNpc` issues partial UPDATEs.
- `scripts/import-chapter-npcs.ts` — CLI entry. Plans rows into five buckets: `npcsToInsert`, `npcsToEnrich`, `npcsToForceOverwrite`, `npcsAlreadyComplete`, `npcsWithConflicts`. Substring-name collisions ("Madame Petrichor" vs "Madame Petrichor & Cinder") route to a BLOCKED bucket, recoverable via `--allow-duplicate-of=<existing name>`.

Sidecar config (`scripts/chapter_npc_configs/chapter_5.json`) supplies per-NPC `display_name`, `location`, `status`/`relationship`/`relevance`, and curated tags so auto-generated defaults can be overridden where curation matters.

**29 tests** covering presence-check rule, sidecar application, substring-duplicate detection, multi-paragraph section capture.

### 5. Faiths importer + pantheon infrastructure (`2197572`)

```bash
npm run import-faiths -- path/to/<campaign>_faiths.md [--dry-run]
```

`scripts/lib/parse-faiths.ts`:

- **`PANTHEON_OVERRIDES` constant** — routes individual deities to non-default pantheons when the file's structural treatment doesn't match lore-tier categorization. Currently: `The Saucer → Heavenly Bodies`, `Old Tippet → Folk and Margin Figures`.
- **`parsePreambleSuns(text)`** — detects the canonical "the gold, the rose, and the purple" preamble phrasing and produces 3 fully-populated Heavenly Bodies records (Gold Sun, Rose Sun, Purple Sun). Content sourced from `campaign_book.md`: player-facing intro → `description`, GM reveal → `dm_notes`. Returns `[]` on files without the canonical phrasing so other campaigns' faiths files get no spurious rows.
- **`parseFolkAndMargin(body)`** — parses the `## Folk and Margin Figures` section's `**Name.**` bold-lead paragraphs into individual records (The Witch, The Stain). `FOLK_META_SKIPS` set skips meta-paragraphs like "The Three Suns directly".

`scripts/import-faiths.ts`:

- **`ensurePantheons(...dryRun)`** — idempotent by `(user_id, campaign_id, name)`. Always does a read-only SELECT to find existing pantheons; inserts missing ones only when not in dry-run. In dry-run mode, missing pantheons get deterministic placeholder UUIDs from `DRY_RUN_PANTHEON_UUIDS` (recognizable `00000000-dead-4eef-…` shape) so the planning step produces an accurate diff for existing assignments **without ever touching the DB**. This is the dry-run safety fix.
- Per-record `--force-from-source NAME` override (image columns stay protected via merge-schema omission).
- CLI-entry guard (`invokedAsCli` check via `import.meta.url`) so tests can `import { ensurePantheons }` from this file without triggering the CLI flow.

### 6. Tiptap conversion at the write boundary (`22896cc`, `cc3d845`, `91bdaa4`)

Rich-text fields on `npcs`, `deities`, and `pantheons` are stored as Tiptap JSON in the DB (the `RichTextEditor` component binds them as ProseMirror documents). Before this work the importers wrote plain markdown into those fields, forcing the user to manually reformat every imported row.

`scripts/lib/tiptap.ts`:

- `markdownToTiptap(md)` — wraps the existing `src/lib/markdownToTiptap.ts` (used by the paste-handling pipeline) and emits the canonical doc shape with `attrs: { twoColumn: false }`
- `tiptapifyFields(payload, fieldNames)` — applies conversion to a named subset of fields; safe to point at the merge engine's `updates` map (non-string values pass through)
- Field constants: `NPC_RICHTEXT_FIELDS`, `DEITY_RICHTEXT_FIELDS`, `PANTHEON_RICHTEXT_FIELDS`
- Preprocessing detail: synth'd `**Label**\n{content}` blocks in NPC `notes` get a blank line inserted so the label renders as its own paragraph rather than joining the content; pinned with a regression test

**Critical design call: conversion happens at the DB-write boundary, NOT at parser output.** The merge engine still compares plain text on both sides. This preserves idempotency for rows imported before this conversion landed (their plain text stays plain text under enrich-merge's preserve-non-empty rule) and avoids spurious conflicts when the source markdown is unchanged from a prior import.

Write sites updated: `enrichNpc`, `insertNpcs`, `ensurePantheons`, plus the deity enrich/force-overwrite/insert paths.

15 new tests in `scripts/lib/tiptap.test.ts`.

### 7. Ch5 sidecar additions (`91bdaa4`)

The Ch5 NPC markdown grew from 12 to 18 entries since the original import; the sidecar now has display-name + location + curated-tag overrides for the 5 new NPCs (Master Cantor, Master Cadenza, Toffee, Marzipan the Elder, Vellette Quiverglass) plus a `Quiverglass Townhouse` location under Marrow City for future Ch7-adjacent scenes.

### 8. Tests

**103 vitest cases pass** across five test files:

- `scripts/lib/merge-fields.test.ts` (23) — enrich-merge engine
- `scripts/lib/parse-chapter-npcs.test.ts` (29) — NPC parser
- `scripts/lib/parse-faiths.test.ts` (32) — faiths parser
- `scripts/import-faiths.test.ts` (4) — dry-run-is-read-only contract (the regression-pin for the safety fix)
- `scripts/lib/tiptap.test.ts` (15) — markdown → Tiptap converter

`tsc --noEmit -p tsconfig.node.json` clean.

## Idempotency

Re-running either importer against existing data is a **no-op modulo the enrich-merge contract**:

- Rows whose every parser-produced field is already populated → `already complete`, no UPDATEs issued
- Rows with one or more empty/array-extensible fields → `enrich`, UPDATE writes only the missing fields
- Rows whose existing non-empty content differs from source → `conflict`, **NOT written**, surfaced for user decision
- New rows (no name match in campaign) → `insert`
- Near-name matches → `BLOCKED`, surfaced for user decision, recoverable via `--allow-duplicate-of`

Manual edits in the UI are preserved by default. A re-import never silently overwrites user content.

## Out of scope

This PR does **not** ship the character sheet export work tracked in issues #418, #419, #420, #421, #423 (epic #422).

It also does **not** migrate the rows imported BEFORE this conversion landed (plain text sitting in Tiptap-typed fields). A separate one-shot migration script (`scripts/migrate-plaintext-to-tiptap.ts`) handles that as its own PR.

## Open questions handled by this PR

None directly close existing issues — this is groundwork tooling. The infrastructure is what enables the campaign-content ingestion workflow the user has been doing manually.

## Note on commit chain

This branch was carved from `origin/main` so the PR's diff is clean. An unrelated branch (`claude/dazzling-burnell-decdee`) in the same worktree carries earlier UI-refactor commits from prior sessions; those are separate concerns and stay on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

