### PR TITLE
Character sheet export: core scaffolding (#418)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,6 +157,7 @@
 - [x] Card Forge — MTG (63×88mm) and Tarot (70×120mm) print-ready cards with duplex alignment
 - [x] Card Forge — 5mm gap between printed cards (3mm visible after 1mm bleed each side); padding recalculated to keep sheets perfectly centered on A4; duplex alignment unaffected
 - [x] Card Library — localStorage save/load named collections across all card types
+- [x] **Character Sheet Export — core scaffolding** (irongollem/grimoire#418) — `/character-sheet/:partyMemberId` DM route renders a full printable 5e sheet (identity header, ability scores + modifiers + saves + skills, combat stats, attacks & spellcasting with auto-computed spell attack bonus / save DC, spell slots, currency, personality, proficiencies); `useCharacterSheetPdf` composable mounts the renderer off-screen and exports a multi-page jsPDF; A4 and Letter support; `.cs-*` semantic class taxonomy forward-compatible with future user-uploaded CSS themes (#423); "Export Sheet" button on DM party member view; "Character Sheet" entry in Publish nav
 
 ### Collaboration & Multi-Player
 

--- a/src/assets/character-sheet.css
+++ b/src/assets/character-sheet.css
@@ -1,0 +1,699 @@
+/* ============================================================
+   Character Sheet — .cs-* taxonomy
+   Stable, semantic, prefixed API — forward-compat with
+   user-uploaded CSS themes (#423/E).
+   All rules are scoped via .cs-page ancestor.
+   ============================================================ */
+
+/* ── Design tokens (override per theme) ────────────────────── */
+
+.cs-page {
+  /* Backgrounds */
+  --cs-bg:          #ede1c8;
+  --cs-bg-card:     #faf5e9;
+  --cs-bg-section:  rgba(250, 245, 233, 0.7);
+
+  /* Ink */
+  --cs-ink:         #1c1208;
+  --cs-ink-mid:     #4a3020;
+  --cs-ink-label:   #7a5c40;
+  --cs-ink-muted:   #a08060;
+
+  /* Accent — deep burgundy */
+  --cs-accent:      #6b1e2e;
+  --cs-accent-text: #f5e6cc;
+  --cs-accent-soft: rgba(107, 30, 46, 0.08);
+
+  /* Borders */
+  --cs-border:      #8b4a2a;
+  --cs-border-gold: #b08840;
+  --cs-border-light:#d4b888;
+
+  /* Typography */
+  --cs-font-body:   'Crimson Pro', Georgia, serif;
+  --cs-font-head:   'Cinzel', 'Palatino Linotype', serif;
+}
+
+/* ── Page shell ─────────────────────────────────────────────── */
+
+.cs-page {
+  width: 794px;
+  min-height: 1123px;
+  background:
+    /* Subtle vertical texture stripes */
+    repeating-linear-gradient(
+      to right,
+      transparent 0px,
+      transparent 3px,
+      rgba(0,0,0,0.007) 3px,
+      rgba(0,0,0,0.007) 4px
+    ),
+    /* Warm gradient base */
+    linear-gradient(170deg, #f2e4c0 0%, #ede1c8 45%, #e4d4b8 100%);
+  font-family: var(--cs-font-body);
+  color: var(--cs-ink);
+  padding: 18px 22px 22px;
+  box-sizing: border-box;
+  line-height: 1.35;
+  font-size: 11px;
+  /* Outer frame: thin double border to suggest a bound tome */
+  outline: 2px solid var(--cs-border);
+  outline-offset: -4px;
+  border: 1.5px solid var(--cs-border-gold);
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+
+.cs-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--cs-border);
+  margin-bottom: 11px;
+  position: relative;
+}
+
+/* Ornamental rule inside header bottom border */
+.cs-header::after {
+  content: "";
+  position: absolute;
+  bottom: -5px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--cs-border-light);
+}
+
+.cs-header-name-block {
+  flex: 1;
+  min-width: 0;
+}
+
+.cs-character-name {
+  font-family: var(--cs-font-head);
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  color: var(--cs-accent);
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cs-header-meta {
+  font-size: 9.5px;
+  color: var(--cs-ink-mid);
+  margin-top: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 4px;
+  align-items: baseline;
+  line-height: 1.4;
+}
+
+.cs-meta-item {
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cs-meta-label {
+  font-family: var(--cs-font-head);
+  font-size: 7px;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cs-ink-label);
+  margin-right: 2px;
+}
+
+.cs-meta-sep {
+  color: var(--cs-border-light);
+  font-size: 11px;
+}
+
+.cs-portrait-wrap {
+  width: 72px;
+  height: 90px;
+  flex-shrink: 0;
+  border: 2px solid var(--cs-border);
+  border-radius: 2px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.25), inset 0 0 0 1px var(--cs-border-light);
+}
+
+.cs-portrait {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+}
+
+/* ── Body layout ─────────────────────────────────────────────── */
+
+.cs-body {
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+}
+
+.cs-left-col {
+  width: 218px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.cs-right-col {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+/* ── Section wrapper ─────────────────────────────────────────── */
+
+.cs-section {
+  border: 1.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  background: var(--cs-bg-section);
+  overflow: hidden; /* so header spans full width */
+}
+
+/* Section header — dark band with cream text */
+.cs-section-title {
+  font-family: var(--cs-font-head);
+  font-size: 7px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--cs-accent-text);
+  background: var(--cs-accent);
+  padding: 3px 8px;
+  margin: 0; /* flush to section edge */
+}
+
+.cs-section-body {
+  padding: 6px 8px;
+}
+
+.cs-subsection-title {
+  font-family: var(--cs-font-head);
+  font-size: 6.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--cs-ink-label);
+  border-bottom: 0.5px solid var(--cs-border-light);
+  padding-bottom: 2px;
+  margin-bottom: 3px;
+}
+
+/* ── Ability scores ──────────────────────────────────────────── */
+
+.cs-ability-scores {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+}
+
+.cs-ability-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1.5px solid var(--cs-border);
+  border-radius: 3px;
+  padding: 5px 3px 4px;
+  background: var(--cs-bg-card);
+  position: relative;
+}
+
+/* Tiny burgundy top notch on each ability box */
+.cs-ability-score::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 50%; transform: translateX(-50%);
+  width: 18px; height: 3px;
+  background: var(--cs-accent);
+  border-radius: 0 0 2px 2px;
+}
+
+.cs-ability-modifier {
+  font-family: var(--cs-font-head);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--cs-accent);
+  margin-top: 4px;
+}
+
+.cs-ability-value {
+  font-size: 9px;
+  border: 0.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  padding: 1px 5px;
+  margin: 2px 0;
+  min-width: 22px;
+  text-align: center;
+  background: white;
+  color: var(--cs-ink-mid);
+}
+
+.cs-ability-label {
+  font-size: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--cs-ink-label);
+  text-align: center;
+  line-height: 1.2;
+}
+
+/* ── Inspiration + proficiency ───────────────────────────────── */
+
+.cs-insp-prof-row .cs-section-body {
+  display: flex;
+  gap: 7px;
+}
+
+.cs-stat-box {
+  flex: 1;
+  border: 1.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  padding: 4px;
+  background: var(--cs-bg-card);
+  text-align: center;
+}
+
+.cs-stat-box-value {
+  font-family: var(--cs-font-head);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--cs-accent);
+  line-height: 1;
+}
+
+.cs-stat-box-label {
+  font-size: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--cs-ink-label);
+  margin-top: 1px;
+}
+
+/* ── Check rows (saves + skills) ─────────────────────────────── */
+
+.cs-check-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1.5px 0;
+  border-bottom: 0.5px solid rgba(212, 184, 136, 0.4);
+}
+
+.cs-check-row:last-child {
+  border-bottom: none;
+}
+
+.cs-prof-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.5px solid var(--cs-border);
+  flex-shrink: 0;
+  display: inline-block;
+  background: white;
+}
+
+.cs-prof-dot--filled {
+  background: var(--cs-accent);
+  border-color: var(--cs-accent);
+}
+
+.cs-prof-dot--expertise {
+  box-shadow: 0 0 0 2px var(--cs-accent);
+}
+
+.cs-check-bonus {
+  font-family: var(--cs-font-head);
+  font-size: 9px;
+  font-weight: 600;
+  min-width: 22px;
+  text-align: right;
+  color: var(--cs-ink);
+}
+
+.cs-check-label {
+  font-size: 9px;
+  color: var(--cs-ink-mid);
+  flex: 1;
+}
+
+.cs-check-ability {
+  font-size: 7px;
+  color: var(--cs-ink-label);
+}
+
+/* ── Passive perception ──────────────────────────────────────── */
+
+.cs-passive-row .cs-section-body {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cs-passive-label {
+  font-size: 8.5px;
+  color: var(--cs-ink-mid);
+  font-style: italic;
+}
+
+.cs-passive-value {
+  font-family: var(--cs-font-head);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--cs-accent);
+}
+
+/* ── Combat stats ────────────────────────────────────────────── */
+
+.cs-combat-row .cs-section-body {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+
+.cs-combat-stat {
+  border: 1.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  padding: 4px 6px;
+  background: var(--cs-bg-card);
+  text-align: center;
+  flex-shrink: 0;
+  min-width: 36px;
+}
+
+.cs-combat-stat--wide {
+  flex: 1;
+}
+
+.cs-combat-value {
+  font-family: var(--cs-font-head);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--cs-accent);
+  line-height: 1;
+}
+
+.cs-combat-label {
+  font-size: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--cs-ink-label);
+  margin-top: 2px;
+  white-space: nowrap;
+}
+
+.cs-hp-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.cs-hp-block {
+  text-align: center;
+}
+
+/* ── Hit Dice + Death saves ──────────────────────────────────── */
+
+.cs-dice-saves-row .cs-section-body {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.cs-hit-dice {
+  flex-shrink: 0;
+  text-align: center;
+  min-width: 60px;
+}
+
+.cs-hit-dice-value {
+  font-family: var(--cs-font-head);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--cs-accent);
+  margin-top: 3px;
+}
+
+.cs-death-saves {
+  flex: 1;
+}
+
+.cs-death-save-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 3px;
+}
+
+.cs-death-label {
+  font-size: 8px;
+  color: var(--cs-ink-mid);
+  min-width: 50px;
+}
+
+.cs-save-pip {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 1.5px solid var(--cs-border);
+  display: inline-block;
+  background: white;
+}
+
+.cs-save-pip--filled { background: #2d5a1f; border-color: #2d5a1f; }
+.cs-save-pip--fail   { background: #8b1a1a; border-color: #8b1a1a; }
+
+/* ── Attacks ─────────────────────────────────────────────────── */
+
+.cs-attacks .cs-section-body {
+  padding: 5px 8px;
+}
+
+.cs-attack-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 9px;
+  margin-bottom: 4px;
+}
+
+.cs-attack-th {
+  font-family: var(--cs-font-head);
+  font-size: 7px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--cs-ink-label);
+  border-bottom: 1px solid var(--cs-border-light);
+  padding: 2px 4px;
+  text-align: left;
+}
+
+.cs-attack-name-col {
+  width: 45%;
+}
+
+.cs-attack-row td {
+  padding: 3px 4px;
+  border-bottom: 0.5px solid rgba(212, 184, 136, 0.5);
+  color: var(--cs-ink-mid);
+}
+
+.cs-attack-row:last-child td {
+  border-bottom: none;
+}
+
+.cs-attack-row--blank td {
+  height: 16px;
+  border-bottom: 0.5px dashed var(--cs-border-light);
+  opacity: 0.5;
+}
+
+.cs-attack-row--blank:last-child td {
+  border-bottom: none;
+}
+
+.cs-spellcasting-stats {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+  padding-top: 5px;
+  border-top: 0.5px solid var(--cs-border-light);
+}
+
+.cs-spell-stat {
+  flex: 1;
+  border: 1.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  padding: 4px 5px;
+  background: var(--cs-bg-card);
+  text-align: center;
+}
+
+.cs-spell-stat-value {
+  font-family: var(--cs-font-head);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--cs-accent);
+}
+
+.cs-spell-stat-label {
+  font-size: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--cs-ink-label);
+  margin-top: 1px;
+}
+
+/* ── Spell slots ─────────────────────────────────────────────── */
+
+.cs-spell-slots .cs-section-body {
+  padding: 5px 8px 6px;
+}
+
+.cs-slot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  align-items: flex-start;
+}
+
+.cs-slot-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.cs-slot-level {
+  font-family: var(--cs-font-head);
+  font-size: 6.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--cs-ink-label);
+}
+
+.cs-slot-pips {
+  display: flex;
+  gap: 2px;
+}
+
+.cs-slot-pip {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1.5px solid var(--cs-border);
+  display: inline-block;
+  background: var(--cs-bg-card);
+}
+
+.cs-slot-pip--used {
+  background: white;
+  border-color: var(--cs-border-light);
+  opacity: 0.5;
+}
+
+/* ── Currency ────────────────────────────────────────────────── */
+
+.cs-currency .cs-section-body {
+  padding: 5px 8px 6px;
+}
+
+.cs-currency-row {
+  display: flex;
+  gap: 5px;
+}
+
+.cs-coin {
+  flex: 1;
+  border: 1.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  padding: 3px 4px;
+  background: var(--cs-bg-card);
+  text-align: center;
+}
+
+.cs-coin-amount {
+  font-family: var(--cs-font-head);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--cs-accent);
+}
+
+.cs-coin-label {
+  font-size: 6.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--cs-ink-label);
+}
+
+/* ── Personality ─────────────────────────────────────────────── */
+
+.cs-personality .cs-section-body {
+  padding: 5px 8px;
+}
+
+.cs-personality-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+}
+
+.cs-trait-box {
+  border: 1.5px solid var(--cs-border-light);
+  border-radius: 2px;
+  padding: 4px 5px;
+  background: var(--cs-bg-card);
+  min-height: 46px;
+}
+
+.cs-trait-title {
+  font-family: var(--cs-font-head);
+  font-size: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--cs-ink-label);
+  border-bottom: 0.5px solid var(--cs-border-light);
+  padding-bottom: 2px;
+  margin-bottom: 2px;
+}
+
+.cs-trait-text {
+  font-size: 8.5px;
+  color: var(--cs-ink-mid);
+  line-height: 1.4;
+}
+
+/* ── Other proficiencies ─────────────────────────────────────── */
+
+.cs-proficiencies .cs-section-body {
+  padding: 5px 8px;
+}
+
+.cs-proficiencies-text {
+  font-size: 9px;
+  color: var(--cs-ink-mid);
+  line-height: 1.55;
+}
+
+.cs-proficiencies-text strong {
+  font-family: var(--cs-font-head);
+  font-size: 7px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--cs-ink-label);
+}

--- a/src/components/character-sheet/CharacterSheetRenderer.vue
+++ b/src/components/character-sheet/CharacterSheetRenderer.vue
@@ -1,21 +1,33 @@
 <template>
   <!-- Page 1: Core stats -->
   <div class="cs-page">
-    <!-- ── Header ──────────────────────────────────────────────── -->
+
+    <!-- ── Header ─────────────────────────────────────────────────── -->
     <header class="cs-header">
       <div class="cs-header-name-block">
         <div class="cs-character-name">{{ member.name }}</div>
         <div class="cs-header-meta">
-          <span class="cs-meta-item"><span class="cs-meta-label">Class &amp; Level</span> {{ member.class ?? "—" }}{{ member.subclass ? ` (${member.subclass})` : "" }} {{ member.level }}</span>
+          <span class="cs-meta-item">
+            <span class="cs-meta-label">Class &amp; Level</span>
+            {{ member.class ?? "—" }}{{ member.subclass ? ` (${member.subclass})` : "" }} {{ member.level }}
+          </span>
           <span class="cs-meta-sep">·</span>
-          <span class="cs-meta-item"><span class="cs-meta-label">Background</span> {{ background }}</span>
+          <span class="cs-meta-item">
+            <span class="cs-meta-label">Background</span>{{ background }}
+          </span>
           <span class="cs-meta-sep">·</span>
-          <span class="cs-meta-item"><span class="cs-meta-label">Species</span> {{ species }}</span>
+          <span class="cs-meta-item">
+            <span class="cs-meta-label">Species</span>{{ species }}
+          </span>
           <span class="cs-meta-sep">·</span>
-          <span class="cs-meta-item"><span class="cs-meta-label">Alignment</span> {{ member.alignment ?? "—" }}</span>
+          <span class="cs-meta-item">
+            <span class="cs-meta-label">Alignment</span>{{ member.alignment ?? "—" }}
+          </span>
           <template v-if="(member.experience_points ?? 0) > 0">
             <span class="cs-meta-sep">·</span>
-            <span class="cs-meta-item"><span class="cs-meta-label">XP</span> {{ member.experience_points?.toLocaleString() }}</span>
+            <span class="cs-meta-item">
+              <span class="cs-meta-label">XP</span>{{ member.experience_points?.toLocaleString() }}
+            </span>
           </template>
         </div>
       </div>
@@ -26,213 +38,258 @@
 
     <!-- ── Body (two columns) ──────────────────────────────────── -->
     <div class="cs-body">
-      <!-- Left column: abilities, saves, skills -->
+
+      <!-- Left column: abilities · saves · skills -->
       <aside class="cs-left-col">
 
         <!-- Ability scores -->
-        <section class="cs-section cs-ability-scores">
-          <div v-for="ab in ABILITIES" :key="ab.key" class="cs-ability-score">
-            <div class="cs-ability-modifier">{{ signedMod(member[ab.key]) }}</div>
-            <div class="cs-ability-value">{{ member[ab.key] }}</div>
-            <div class="cs-ability-label">{{ ab.label }}</div>
+        <div class="cs-section cs-ability-scores-section">
+          <div class="cs-ability-scores">
+            <div v-for="ab in ABILITIES" :key="ab.key" class="cs-ability-score">
+              <div class="cs-ability-modifier">{{ signedMod(member[ab.key]) }}</div>
+              <div class="cs-ability-value">{{ member[ab.key] }}</div>
+              <div class="cs-ability-label">{{ ab.label }}</div>
+            </div>
           </div>
-        </section>
+        </div>
 
         <!-- Inspiration + Proficiency Bonus -->
-        <section class="cs-section cs-insp-prof-row">
-          <div class="cs-stat-box">
-            <div class="cs-stat-box-value">{{ member.inspiration ? "✦" : "○" }}</div>
-            <div class="cs-stat-box-label">Inspiration</div>
+        <div class="cs-section cs-insp-prof-row">
+          <div class="cs-section-body">
+            <div class="cs-stat-box">
+              <div class="cs-stat-box-value">{{ member.inspiration ? "✦" : "○" }}</div>
+              <div class="cs-stat-box-label">Inspiration</div>
+            </div>
+            <div class="cs-stat-box">
+              <div class="cs-stat-box-value">+{{ member.proficiency_bonus }}</div>
+              <div class="cs-stat-box-label">Proficiency Bonus</div>
+            </div>
           </div>
-          <div class="cs-stat-box">
-            <div class="cs-stat-box-value">+{{ member.proficiency_bonus }}</div>
-            <div class="cs-stat-box-label">Proficiency Bonus</div>
-          </div>
-        </section>
+        </div>
 
         <!-- Saving Throws -->
-        <section class="cs-section cs-saving-throws">
+        <div class="cs-section cs-saving-throws">
           <div class="cs-section-title">Saving Throws</div>
-          <div v-for="ab in ABILITIES" :key="ab.key" class="cs-check-row">
-            <span :class="['cs-prof-dot', member.saving_throw_proficiencies.includes(ab.key) ? 'cs-prof-dot--filled' : '']" />
-            <span class="cs-check-bonus">{{ signedBonus(saveBonus(ab.key)) }}</span>
-            <span class="cs-check-label">{{ ab.label }}</span>
+          <div class="cs-section-body">
+            <div v-for="ab in ABILITIES" :key="ab.key" class="cs-check-row">
+              <span :class="['cs-prof-dot', member.saving_throw_proficiencies.includes(ab.key) ? 'cs-prof-dot--filled' : '']" />
+              <span class="cs-check-bonus">{{ signedBonus(saveBonus(ab.key)) }}</span>
+              <span class="cs-check-label">{{ ab.label }}</span>
+            </div>
           </div>
-        </section>
+        </div>
 
         <!-- Passive Perception -->
-        <section class="cs-section cs-passive-row">
-          <span class="cs-passive-label">Passive Wisdom (Perception)</span>
-          <span class="cs-passive-value">{{ passivePerception }}</span>
-        </section>
+        <div class="cs-section cs-passive-row">
+          <div class="cs-section-body">
+            <span class="cs-passive-label">Passive Wisdom (Perception)</span>
+            <span class="cs-passive-value">{{ passivePerception }}</span>
+          </div>
+        </div>
 
         <!-- Skills -->
-        <section class="cs-section cs-skills">
+        <div class="cs-section cs-skills">
           <div class="cs-section-title">Skills</div>
-          <div v-for="sk in SKILLS" :key="sk.key" class="cs-check-row">
-            <span :class="['cs-prof-dot', skillLevel(sk.key) !== 'none' ? 'cs-prof-dot--filled' : '', skillLevel(sk.key) === 'expertise' ? 'cs-prof-dot--expertise' : '']" />
-            <span class="cs-check-bonus">{{ signedBonus(computedSkillBonus(sk)) }}</span>
-            <span class="cs-check-label">{{ sk.label }} <span class="cs-check-ability">({{ sk.ability.toUpperCase() }})</span></span>
+          <div class="cs-section-body">
+            <div v-for="sk in SKILLS" :key="sk.key" class="cs-check-row">
+              <span :class="[
+                'cs-prof-dot',
+                skillLevel(sk.key) !== 'none' ? 'cs-prof-dot--filled' : '',
+                skillLevel(sk.key) === 'expertise' ? 'cs-prof-dot--expertise' : '',
+              ]" />
+              <span class="cs-check-bonus">{{ signedBonus(computedSkillBonus(sk)) }}</span>
+              <span class="cs-check-label">
+                {{ sk.label }} <span class="cs-check-ability">({{ sk.ability.toUpperCase() }})</span>
+              </span>
+            </div>
           </div>
-        </section>
+        </div>
 
       </aside>
 
-      <!-- Right column: combat + attacks + currency + personality -->
+      <!-- Right column: combat · attacks · spells · currency · personality -->
       <main class="cs-right-col">
 
         <!-- Combat stats bar -->
-        <section class="cs-section cs-combat-row">
-          <div class="cs-combat-stat">
-            <div class="cs-combat-value">{{ member.ac }}</div>
-            <div class="cs-combat-label">Armor Class</div>
-          </div>
-          <div class="cs-combat-stat">
-            <div class="cs-combat-value">{{ signedBonus(member.initiative_bonus + abilityMod(member.dex)) }}</div>
-            <div class="cs-combat-label">Initiative</div>
-          </div>
-          <div class="cs-combat-stat">
-            <div class="cs-combat-value">{{ member.speed }}</div>
-            <div class="cs-combat-label">Speed</div>
-          </div>
-          <div class="cs-combat-stat cs-combat-stat--wide">
-            <div class="cs-hp-row">
-              <div class="cs-hp-block">
-                <div class="cs-combat-value">{{ member.max_hp }}</div>
-                <div class="cs-combat-label">HP Maximum</div>
-              </div>
-              <div class="cs-hp-block">
-                <div class="cs-combat-value">{{ member.current_hp }}</div>
-                <div class="cs-combat-label">Current HP</div>
-              </div>
-              <div class="cs-hp-block">
-                <div class="cs-combat-value">{{ member.temp_hp || "—" }}</div>
-                <div class="cs-combat-label">Temporary HP</div>
+        <div class="cs-section cs-combat-row">
+          <div class="cs-section-title">Combat</div>
+          <div class="cs-section-body">
+            <div class="cs-combat-stat">
+              <div class="cs-combat-value">{{ member.ac }}</div>
+              <div class="cs-combat-label">Armor Class</div>
+            </div>
+            <div class="cs-combat-stat">
+              <div class="cs-combat-value">{{ signedBonus(member.initiative_bonus + abilityMod(member.dex)) }}</div>
+              <div class="cs-combat-label">Initiative</div>
+            </div>
+            <div class="cs-combat-stat">
+              <div class="cs-combat-value">{{ member.speed }}</div>
+              <div class="cs-combat-label">Speed</div>
+            </div>
+            <div class="cs-combat-stat cs-combat-stat--wide">
+              <div class="cs-hp-row">
+                <div class="cs-hp-block">
+                  <div class="cs-combat-value">{{ member.max_hp }}</div>
+                  <div class="cs-combat-label">HP Maximum</div>
+                </div>
+                <div class="cs-hp-block">
+                  <div class="cs-combat-value">{{ member.current_hp }}</div>
+                  <div class="cs-combat-label">Current HP</div>
+                </div>
+                <div class="cs-hp-block">
+                  <div class="cs-combat-value">{{ member.temp_hp || "—" }}</div>
+                  <div class="cs-combat-label">Temporary HP</div>
+                </div>
               </div>
             </div>
           </div>
-        </section>
+        </div>
 
         <!-- Hit Dice + Death Saves -->
-        <section class="cs-section cs-dice-saves-row">
-          <div class="cs-hit-dice">
-            <div class="cs-subsection-title">Hit Dice</div>
-            <div class="cs-hit-dice-value">{{ hitDiceStr }}</div>
-          </div>
-          <div class="cs-death-saves">
-            <div class="cs-subsection-title">Death Saves</div>
-            <div class="cs-death-save-row">
-              <span class="cs-death-label">Successes</span>
-              <span v-for="i in 3" :key="i" :class="['cs-save-pip', i <= member.death_save_successes ? 'cs-save-pip--filled' : '']" />
+        <div class="cs-section cs-dice-saves-row">
+          <div class="cs-section-body">
+            <div class="cs-hit-dice">
+              <div class="cs-subsection-title">Hit Dice</div>
+              <div class="cs-hit-dice-value">{{ hitDiceStr }}</div>
             </div>
-            <div class="cs-death-save-row">
-              <span class="cs-death-label">Failures</span>
-              <span v-for="i in 3" :key="i" :class="['cs-save-pip', i <= member.death_save_failures ? 'cs-save-pip--filled cs-save-pip--fail' : '']" />
-            </div>
-          </div>
-        </section>
-
-        <!-- Attacks & Spellcasting -->
-        <section class="cs-section cs-attacks">
-          <div class="cs-section-title">Attacks &amp; Spellcasting</div>
-          <table class="cs-attack-table">
-            <thead>
-              <tr>
-                <th class="cs-attack-th cs-attack-name">Name</th>
-                <th class="cs-attack-th">Atk Bonus</th>
-                <th class="cs-attack-th">Damage / Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="item in equippedWeapons" :key="item.id" class="cs-attack-row">
-                <td class="cs-attack-name">{{ item.name }}</td>
-                <td>—</td>
-                <td>—</td>
-              </tr>
-              <tr v-for="i in Math.max(0, 3 - equippedWeapons.length)" :key="`blank-${i}`" class="cs-attack-row cs-attack-row--blank">
-                <td></td><td></td><td></td>
-              </tr>
-            </tbody>
-          </table>
-          <!-- Spellcasting stats -->
-          <div v-if="spellAttack !== null" class="cs-spellcasting-stats">
-            <div class="cs-spell-stat">
-              <div class="cs-spell-stat-value">{{ castingAbility?.toUpperCase() }}</div>
-              <div class="cs-spell-stat-label">Spellcasting Ability</div>
-            </div>
-            <div class="cs-spell-stat">
-              <div class="cs-spell-stat-value">{{ spellSaveDC }}</div>
-              <div class="cs-spell-stat-label">Spell Save DC</div>
-            </div>
-            <div class="cs-spell-stat">
-              <div class="cs-spell-stat-value">{{ signedBonus(spellAttack) }}</div>
-              <div class="cs-spell-stat-label">Spell Attack</div>
-            </div>
-          </div>
-        </section>
-
-        <!-- Spell Slots -->
-        <section v-if="member.spell_slots.length" class="cs-section cs-spell-slots">
-          <div class="cs-section-title">Spell Slots</div>
-          <div class="cs-slot-grid">
-            <div v-for="slot in member.spell_slots" :key="slot.level" class="cs-slot-entry">
-              <div class="cs-slot-level">{{ ORDINALS[slot.level - 1] }}</div>
-              <div class="cs-slot-pips">
+            <div class="cs-death-saves">
+              <div class="cs-subsection-title">Death Saves</div>
+              <div class="cs-death-save-row">
+                <span class="cs-death-label">Successes</span>
                 <span
-                  v-for="i in slot.max"
+                  v-for="i in 3"
                   :key="i"
-                  :class="['cs-slot-pip', i > (slot.max - slot.used) ? 'cs-slot-pip--used' : '']"
+                  :class="['cs-save-pip', i <= member.death_save_successes ? 'cs-save-pip--filled' : '']"
+                />
+              </div>
+              <div class="cs-death-save-row">
+                <span class="cs-death-label">Failures</span>
+                <span
+                  v-for="i in 3"
+                  :key="i"
+                  :class="['cs-save-pip', i <= member.death_save_failures ? 'cs-save-pip--filled cs-save-pip--fail' : '']"
                 />
               </div>
             </div>
           </div>
-        </section>
+        </div>
+
+        <!-- Attacks & Spellcasting -->
+        <div class="cs-section cs-attacks">
+          <div class="cs-section-title">Attacks &amp; Spellcasting</div>
+          <div class="cs-section-body">
+            <table class="cs-attack-table">
+              <thead>
+                <tr>
+                  <th class="cs-attack-th cs-attack-name-col">Name</th>
+                  <th class="cs-attack-th">Atk Bonus</th>
+                  <th class="cs-attack-th">Damage / Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in equippedWeapons" :key="item.id" class="cs-attack-row">
+                  <td>{{ item.name }}</td>
+                  <td>—</td>
+                  <td>—</td>
+                </tr>
+                <tr
+                  v-for="i in Math.max(0, 3 - equippedWeapons.length)"
+                  :key="`blank-${i}`"
+                  class="cs-attack-row cs-attack-row--blank"
+                >
+                  <td></td><td></td><td></td>
+                </tr>
+              </tbody>
+            </table>
+            <!-- Spellcasting stats -->
+            <div v-if="spellAttack !== null" class="cs-spellcasting-stats">
+              <div class="cs-spell-stat">
+                <div class="cs-spell-stat-value">{{ castingAbility?.toUpperCase() }}</div>
+                <div class="cs-spell-stat-label">Spellcasting Ability</div>
+              </div>
+              <div class="cs-spell-stat">
+                <div class="cs-spell-stat-value">{{ spellSaveDC }}</div>
+                <div class="cs-spell-stat-label">Spell Save DC</div>
+              </div>
+              <div class="cs-spell-stat">
+                <div class="cs-spell-stat-value">{{ signedBonus(spellAttack) }}</div>
+                <div class="cs-spell-stat-label">Spell Attack</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Spell Slots -->
+        <div v-if="member.spell_slots.length" class="cs-section cs-spell-slots">
+          <div class="cs-section-title">Spell Slots</div>
+          <div class="cs-section-body">
+            <div class="cs-slot-grid">
+              <div v-for="slot in member.spell_slots" :key="slot.level" class="cs-slot-entry">
+                <div class="cs-slot-level">{{ ORDINALS[slot.level - 1] }}</div>
+                <div class="cs-slot-pips">
+                  <span
+                    v-for="i in slot.max"
+                    :key="i"
+                    :class="['cs-slot-pip', i > (slot.max - slot.used) ? 'cs-slot-pip--used' : '']"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
 
         <!-- Currency -->
-        <section class="cs-section cs-currency">
+        <div class="cs-section cs-currency">
           <div class="cs-section-title">Currency</div>
-          <div class="cs-currency-row">
-            <div v-for="coin in COINS" :key="coin.key" class="cs-coin">
-              <div class="cs-coin-amount">{{ member[coin.key] }}</div>
-              <div class="cs-coin-label">{{ coin.label }}</div>
+          <div class="cs-section-body">
+            <div class="cs-currency-row">
+              <div v-for="coin in COINS" :key="coin.key" class="cs-coin">
+                <div class="cs-coin-amount">{{ member[coin.key] }}</div>
+                <div class="cs-coin-label">{{ coin.label }}</div>
+              </div>
             </div>
           </div>
-        </section>
+        </div>
 
         <!-- Personality -->
-        <section class="cs-section cs-personality">
-          <div class="cs-personality-grid">
-            <div class="cs-trait-box">
-              <div class="cs-subsection-title">Personality Traits</div>
-              <div class="cs-trait-text">{{ member.personality_traits || "" }}</div>
-            </div>
-            <div class="cs-trait-box">
-              <div class="cs-subsection-title">Ideals</div>
-              <div class="cs-trait-text">{{ member.ideals || "" }}</div>
-            </div>
-            <div class="cs-trait-box">
-              <div class="cs-subsection-title">Bonds</div>
-              <div class="cs-trait-text">{{ member.bonds || "" }}</div>
-            </div>
-            <div class="cs-trait-box">
-              <div class="cs-subsection-title">Flaws</div>
-              <div class="cs-trait-text">{{ member.flaws || "" }}</div>
+        <div class="cs-section cs-personality">
+          <div class="cs-section-title">Personality</div>
+          <div class="cs-section-body">
+            <div class="cs-personality-grid">
+              <div class="cs-trait-box">
+                <div class="cs-trait-title">Personality Traits</div>
+                <div class="cs-trait-text">{{ member.personality_traits || "" }}</div>
+              </div>
+              <div class="cs-trait-box">
+                <div class="cs-trait-title">Ideals</div>
+                <div class="cs-trait-text">{{ member.ideals || "" }}</div>
+              </div>
+              <div class="cs-trait-box">
+                <div class="cs-trait-title">Bonds</div>
+                <div class="cs-trait-text">{{ member.bonds || "" }}</div>
+              </div>
+              <div class="cs-trait-box">
+                <div class="cs-trait-title">Flaws</div>
+                <div class="cs-trait-text">{{ member.flaws || "" }}</div>
+              </div>
             </div>
           </div>
-        </section>
+        </div>
 
-        <!-- Features & Other proficiencies -->
-        <section class="cs-section cs-features">
+        <!-- Other Proficiencies & Languages -->
+        <div class="cs-section cs-proficiencies">
           <div class="cs-section-title">Other Proficiencies &amp; Languages</div>
-          <div class="cs-features-text">
-            <template v-if="member.tool_proficiencies.length">
-              <strong>Tools:</strong> {{ member.tool_proficiencies.join(", ") }}<br />
-            </template>
-            <template v-if="member.languages.length">
-              <strong>Languages:</strong> {{ member.languages.join(", ") }}
-            </template>
+          <div class="cs-section-body">
+            <div class="cs-proficiencies-text">
+              <template v-if="member.tool_proficiencies.length">
+                <strong>Tools:</strong> {{ member.tool_proficiencies.join(", ") }}<br />
+              </template>
+              <template v-if="member.languages.length">
+                <strong>Languages:</strong> {{ member.languages.join(", ") }}
+              </template>
+            </div>
           </div>
-        </section>
+        </div>
 
       </main>
     </div>
@@ -246,10 +303,12 @@ import type { PartyInventoryItem } from "@/types/inventory.types";
 import { getCastingAbility } from "@/types/spell.types";
 import type { SheetPageSize } from "@/composables/useCharacterSheetPdf";
 
-const props = defineProps<{
+const { member, inventory, speciesName = null, backgroundName = null } = defineProps<{
   member: PartyMember;
   inventory: PartyInventoryItem[];
   pageSize?: SheetPageSize;
+  speciesName?: string | null;
+  backgroundName?: string | null;
 }>();
 
 const ABILITIES = [
@@ -259,7 +318,7 @@ const ABILITIES = [
   { key: "int" as const, label: "Intelligence" },
   { key: "wis" as const, label: "Wisdom" },
   { key: "cha" as const, label: "Charisma" },
-];
+] as const;
 
 const COINS = [
   { key: "pp" as keyof PartyMember, label: "PP" },
@@ -267,16 +326,19 @@ const COINS = [
   { key: "ep" as keyof PartyMember, label: "EP" },
   { key: "sp" as keyof PartyMember, label: "SP" },
   { key: "cp" as keyof PartyMember, label: "CP" },
-];
+] as const;
 
-const ORDINALS = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th"];
+const ORDINALS = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th"] as const;
+
+// ── Data resolution ────────────────────────────────────────────────────────────
+
+/** Resolved display name: subrace takes priority, then speciesName prop, else em dash */
+const species = computed(() => member.subrace ?? speciesName ?? "—");
+
+/** Resolved display name: backgroundName prop else em dash */
+const background = computed(() => backgroundName ?? "—");
 
 // ── Computed helpers ──────────────────────────────────────────────────────────
-
-const background = computed(() => props.member.background_id ?? "—");
-const species = computed(() => props.member.subrace
-  ? `${props.member.subrace}`
-  : (props.member.species_id ?? "—"));
 
 function abilityMod(score: number): number {
   return Math.floor((score - 10) / 2);
@@ -292,19 +354,19 @@ function signedBonus(n: number): string {
 }
 
 function saveBonus(key: keyof Pick<PartyMember, "str" | "dex" | "con" | "int" | "wis" | "cha">): number {
-  const mod = abilityMod(props.member[key]);
-  const prof = props.member.saving_throw_proficiencies.includes(key) ? props.member.proficiency_bonus : 0;
+  const mod = abilityMod(member[key]);
+  const prof = member.saving_throw_proficiencies.includes(key) ? member.proficiency_bonus : 0;
   return mod + prof;
 }
 
 function skillLevel(key: keyof SkillProficiencies): string {
-  return props.member.skill_proficiencies?.[key] ?? "none";
+  return member.skill_proficiencies?.[key] ?? "none";
 }
 
 function computedSkillBonus(sk: typeof SKILLS[number]): number {
-  const mod = abilityMod(props.member[sk.ability]);
+  const mod = abilityMod(member[sk.ability]);
   const level = skillLevel(sk.key);
-  const pb = props.member.proficiency_bonus;
+  const pb = member.proficiency_bonus;
   return mod + (level === "none" ? 0 : level === "proficient" ? pb : pb * 2);
 }
 
@@ -313,577 +375,44 @@ const passivePerception = computed(() => {
   return 10 + computedSkillBonus(sk);
 });
 
-const castingAbility = computed(() => getCastingAbility(props.member.class));
+const castingAbility = computed(() => getCastingAbility(member.class));
 const castingMod = computed(() =>
-  castingAbility.value ? abilityMod(props.member[castingAbility.value]) : null,
+  castingAbility.value ? abilityMod(member[castingAbility.value]) : null,
 );
 const spellAttack = computed(() =>
-  castingMod.value !== null ? props.member.proficiency_bonus + castingMod.value : null,
+  castingMod.value !== null ? member.proficiency_bonus + castingMod.value : null,
 );
 const spellSaveDC = computed(() =>
   spellAttack.value !== null ? 8 + spellAttack.value : null,
 );
 
 const hitDiceStr = computed(() => {
-  if (!props.member.class) return `${props.member.level}d8`;
+  if (!member.class) return `${member.level}d8`;
   const dieMap: Record<string, number> = {
     Barbarian: 12, Fighter: 10, Paladin: 10, Ranger: 10,
     Bard: 8, Cleric: 8, Druid: 8, Monk: 8, Rogue: 8, Warlock: 8,
     Artificer: 8, Sorcerer: 6, Wizard: 6,
   };
-  const die = dieMap[props.member.class] ?? 8;
-  const rem = props.member.hit_dice_remaining ?? props.member.level;
+  const die = dieMap[member.class] ?? 8;
+  const rem = member.hit_dice_remaining ?? member.level;
   return `${rem}d${die}`;
 });
 
 const equippedWeapons = computed(() =>
-  props.inventory.filter(
-    (i) => i.carried_by === props.member.id && i.location === "equipped" &&
+  inventory.filter(
+    (i) => i.carried_by === member.id && i.location === "equipped" &&
     (i.slot === "main_hand" || i.slot === "off_hand"),
   ),
 );
 </script>
 
 <style>
-/* Character Sheet — .cs-* taxonomy (stable, semantic, prefixed) */
-/* All rules scoped via .cs-page ancestor to avoid app bleed. */
-
-.cs-page {
-  width: 794px;
-  min-height: 1123px;
-  background: #f8f4ec;
-  font-family: 'Crimson Pro', Georgia, 'Times New Roman', serif;
-  color: #1a1208;
-  padding: 20px 22px;
-  box-sizing: border-box;
-  line-height: 1.3;
-  font-size: 12px;
-}
-
-/* ── Header ──────────────────────────────────────────────────────────── */
-
-.cs-header {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding-bottom: 10px;
-  border-bottom: 2px solid #2d1f0e;
-  margin-bottom: 10px;
-}
-
-.cs-header-name-block {
-  flex: 1;
-  min-width: 0;
-}
-
-.cs-character-name {
-  font-family: 'Cinzel', 'Palatino Linotype', serif;
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  color: #1a0e04;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.cs-header-meta {
-  font-size: 10px;
-  color: #5a4a32;
-  margin-top: 3px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 3px;
-  align-items: center;
-}
-
-.cs-meta-label {
-  font-family: 'Cinzel', serif;
-  font-size: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #8a7055;
-  margin-right: 3px;
-}
-
-.cs-meta-sep {
-  color: #c8b896;
-  margin: 0 1px;
-}
-
-.cs-portrait-wrap {
-  width: 60px;
-  height: 75px;
-  flex-shrink: 0;
-  border: 1.5px solid #6b4c2a;
-  border-radius: 3px;
-  overflow: hidden;
-}
-
-.cs-portrait {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-/* ── Body layout ────────────────────────────────────────────────────── */
-
-.cs-body {
-  display: flex;
-  gap: 12px;
-  align-items: flex-start;
-}
-
-.cs-left-col {
-  width: 220px;
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.cs-right-col {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-/* ── Sections ────────────────────────────────────────────────────────── */
-
-.cs-section {
-  border: 1px solid #b09870;
-  border-radius: 3px;
-  padding: 6px 8px;
-  background: rgba(255,252,245,0.6);
-}
-
-.cs-section-title {
-  font-family: 'Cinzel', serif;
-  font-size: 7.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #6b4c2a;
-  border-bottom: 0.5px solid #c8b896;
-  padding-bottom: 2px;
-  margin-bottom: 4px;
-}
-
-.cs-subsection-title {
-  font-family: 'Cinzel', serif;
-  font-size: 7px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #8a7055;
-  margin-bottom: 2px;
-}
-
-/* ── Ability scores ──────────────────────────────────────────────────── */
-
-.cs-ability-scores {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-  padding: 6px;
-}
-
-.cs-ability-score {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  border: 1px solid #b09870;
-  border-radius: 3px;
-  padding: 4px 2px;
-  background: white;
-  min-width: 0;
-}
-
-.cs-ability-modifier {
-  font-family: 'Cinzel', serif;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 1;
-  color: #1a0e04;
-}
-
-.cs-ability-value {
-  font-size: 10px;
-  border: 0.5px solid #c8b896;
-  border-radius: 2px;
-  padding: 0 4px;
-  margin: 2px 0;
-  min-width: 22px;
-  text-align: center;
-  background: #f8f4ec;
-}
-
-.cs-ability-label {
-  font-size: 6.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a7055;
-  text-align: center;
-}
-
-/* ── Insp + prof ────────────────────────────────────────────────────── */
-
-.cs-insp-prof-row {
-  display: flex;
-  gap: 6px;
-}
-
-.cs-stat-box {
-  flex: 1;
-  border: 1px solid #b09870;
-  border-radius: 3px;
-  padding: 4px;
-  background: white;
-  text-align: center;
-}
-
-.cs-stat-box-value {
-  font-family: 'Cinzel', serif;
-  font-size: 13px;
-  font-weight: 700;
-  color: #1a0e04;
-  line-height: 1;
-}
-
-.cs-stat-box-label {
-  font-size: 6.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a7055;
-  margin-top: 1px;
-}
-
-/* ── Check rows (saves + skills) ─────────────────────────────────────── */
-
-.cs-check-row {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 1px 0;
-}
-
-.cs-prof-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  border: 1px solid #6b4c2a;
-  flex-shrink: 0;
-  display: inline-block;
-}
-
-.cs-prof-dot--filled {
-  background: #2d1f0e;
-}
-
-.cs-prof-dot--expertise {
-  box-shadow: 0 0 0 1.5px #2d1f0e;
-}
-
-.cs-check-bonus {
-  font-family: 'Cinzel', serif;
-  font-size: 9px;
-  font-weight: 600;
-  min-width: 22px;
-  text-align: right;
-  color: #1a0e04;
-}
-
-.cs-check-label {
-  font-size: 9px;
-  color: #1a0e04;
-  flex: 1;
-}
-
-.cs-check-ability {
-  font-size: 7.5px;
-  color: #8a7055;
-}
-
-/* ── Passive perception ──────────────────────────────────────────────── */
-
-.cs-passive-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.cs-passive-label {
-  font-size: 8.5px;
-  color: #5a4a32;
-}
-
-.cs-passive-value {
-  font-family: 'Cinzel', serif;
-  font-size: 13px;
-  font-weight: 700;
-  color: #1a0e04;
-}
-
-/* ── Combat stats ────────────────────────────────────────────────────── */
-
-.cs-combat-row {
-  display: flex;
-  gap: 6px;
-  align-items: stretch;
-}
-
-.cs-combat-stat {
-  border: 1px solid #b09870;
-  border-radius: 3px;
-  padding: 4px 6px;
-  background: white;
-  text-align: center;
-  flex-shrink: 0;
-}
-
-.cs-combat-stat--wide {
-  flex: 1;
-}
-
-.cs-combat-value {
-  font-family: 'Cinzel', serif;
-  font-size: 15px;
-  font-weight: 700;
-  color: #1a0e04;
-  line-height: 1;
-}
-
-.cs-combat-label {
-  font-size: 6.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a7055;
-  margin-top: 1px;
-  white-space: nowrap;
-}
-
-.cs-hp-row {
-  display: flex;
-  gap: 6px;
-  justify-content: center;
-}
-
-.cs-hp-block {
-  text-align: center;
-}
-
-/* ── Hit Dice + Death saves ──────────────────────────────────────────── */
-
-.cs-dice-saves-row {
-  display: flex;
-  gap: 12px;
-  align-items: flex-start;
-}
-
-.cs-hit-dice {
-  flex-shrink: 0;
-}
-
-.cs-hit-dice-value {
-  font-family: 'Cinzel', serif;
-  font-size: 13px;
-  font-weight: 700;
-  margin-top: 2px;
-}
-
-.cs-death-saves {
-  flex: 1;
-}
-
-.cs-death-save-row {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-top: 2px;
-}
-
-.cs-death-label {
-  font-size: 8px;
-  color: #5a4a32;
-  min-width: 50px;
-}
-
-.cs-save-pip {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 1px solid #6b4c2a;
-  display: inline-block;
-}
-
-.cs-save-pip--filled { background: #2d5a1f; }
-.cs-save-pip--fail   { background: #8b1a1a; }
-
-/* ── Attacks ─────────────────────────────────────────────────────────── */
-
-.cs-attack-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 9px;
-  margin-bottom: 4px;
-}
-
-.cs-attack-th {
-  font-family: 'Cinzel', serif;
-  font-size: 7.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #6b4c2a;
-  border-bottom: 0.5px solid #b09870;
-  padding: 1px 3px;
-  text-align: left;
-}
-
-.cs-attack-name {
-  flex: 1;
-}
-
-.cs-attack-row td {
-  padding: 3px;
-  border-bottom: 0.5px solid #e4d8c0;
-  min-height: 16px;
-}
-
-.cs-attack-row--blank td {
-  height: 14px;
-}
-
-.cs-spellcasting-stats {
-  display: flex;
-  gap: 8px;
-  margin-top: 4px;
-}
-
-.cs-spell-stat {
-  flex: 1;
-  border: 1px solid #b09870;
-  border-radius: 3px;
-  padding: 3px 5px;
-  background: white;
-  text-align: center;
-}
-
-.cs-spell-stat-value {
-  font-family: 'Cinzel', serif;
-  font-size: 11px;
-  font-weight: 700;
-  color: #1a0e04;
-}
-
-.cs-spell-stat-label {
-  font-size: 6.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a7055;
-}
-
-/* ── Spell slots ─────────────────────────────────────────────────────── */
-
-.cs-slot-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.cs-slot-entry {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-}
-
-.cs-slot-level {
-  font-size: 7px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a7055;
-}
-
-.cs-slot-pips {
-  display: flex;
-  gap: 2px;
-}
-
-.cs-slot-pip {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  border: 1px solid #6b4c2a;
-  display: inline-block;
-  background: #f8f4ec;
-}
-
-.cs-slot-pip--used {
-  background: white;
-  border-color: #c8b896;
-}
-
-/* ── Currency ────────────────────────────────────────────────────────── */
-
-.cs-currency-row {
-  display: flex;
-  gap: 6px;
-}
-
-.cs-coin {
-  flex: 1;
-  border: 1px solid #b09870;
-  border-radius: 3px;
-  padding: 3px 4px;
-  background: white;
-  text-align: center;
-}
-
-.cs-coin-amount {
-  font-family: 'Cinzel', serif;
-  font-size: 11px;
-  font-weight: 700;
-  color: #1a0e04;
-}
-
-.cs-coin-label {
-  font-size: 7px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a7055;
-}
-
-/* ── Personality ─────────────────────────────────────────────────────── */
-
-.cs-personality-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 5px;
-}
-
-.cs-trait-box {
-  border: 1px solid #b09870;
-  border-radius: 2px;
-  padding: 4px;
-  background: white;
-  min-height: 44px;
-}
-
-.cs-trait-text {
-  font-size: 8.5px;
-  color: #1a0e04;
-  line-height: 1.4;
-  margin-top: 1px;
-}
-
-/* ── Features ────────────────────────────────────────────────────────── */
-
-.cs-features-text {
-  font-size: 9px;
-  color: #1a0e04;
-  line-height: 1.5;
+/* Import the shared .cs-* stylesheet.
+   Unscoped so the styles survive the off-screen createApp() rendering context. */
+@import "@/assets/character-sheet.css";
+
+/* Ability-scores section doesn't use cs-section-body padding — grid sits flush */
+.cs-ability-scores-section {
+  padding: 8px;
 }
 </style>

--- a/src/components/character-sheet/CharacterSheetRenderer.vue
+++ b/src/components/character-sheet/CharacterSheetRenderer.vue
@@ -1,0 +1,889 @@
+<template>
+  <!-- Page 1: Core stats -->
+  <div class="cs-page">
+    <!-- ── Header ──────────────────────────────────────────────── -->
+    <header class="cs-header">
+      <div class="cs-header-name-block">
+        <div class="cs-character-name">{{ member.name }}</div>
+        <div class="cs-header-meta">
+          <span class="cs-meta-item"><span class="cs-meta-label">Class &amp; Level</span> {{ member.class ?? "—" }}{{ member.subclass ? ` (${member.subclass})` : "" }} {{ member.level }}</span>
+          <span class="cs-meta-sep">·</span>
+          <span class="cs-meta-item"><span class="cs-meta-label">Background</span> {{ background }}</span>
+          <span class="cs-meta-sep">·</span>
+          <span class="cs-meta-item"><span class="cs-meta-label">Species</span> {{ species }}</span>
+          <span class="cs-meta-sep">·</span>
+          <span class="cs-meta-item"><span class="cs-meta-label">Alignment</span> {{ member.alignment ?? "—" }}</span>
+          <template v-if="(member.experience_points ?? 0) > 0">
+            <span class="cs-meta-sep">·</span>
+            <span class="cs-meta-item"><span class="cs-meta-label">XP</span> {{ member.experience_points?.toLocaleString() }}</span>
+          </template>
+        </div>
+      </div>
+      <div v-if="member.portrait_url" class="cs-portrait-wrap">
+        <img class="cs-portrait" :src="member.portrait_url" alt="" crossorigin="anonymous" />
+      </div>
+    </header>
+
+    <!-- ── Body (two columns) ──────────────────────────────────── -->
+    <div class="cs-body">
+      <!-- Left column: abilities, saves, skills -->
+      <aside class="cs-left-col">
+
+        <!-- Ability scores -->
+        <section class="cs-section cs-ability-scores">
+          <div v-for="ab in ABILITIES" :key="ab.key" class="cs-ability-score">
+            <div class="cs-ability-modifier">{{ signedMod(member[ab.key]) }}</div>
+            <div class="cs-ability-value">{{ member[ab.key] }}</div>
+            <div class="cs-ability-label">{{ ab.label }}</div>
+          </div>
+        </section>
+
+        <!-- Inspiration + Proficiency Bonus -->
+        <section class="cs-section cs-insp-prof-row">
+          <div class="cs-stat-box">
+            <div class="cs-stat-box-value">{{ member.inspiration ? "✦" : "○" }}</div>
+            <div class="cs-stat-box-label">Inspiration</div>
+          </div>
+          <div class="cs-stat-box">
+            <div class="cs-stat-box-value">+{{ member.proficiency_bonus }}</div>
+            <div class="cs-stat-box-label">Proficiency Bonus</div>
+          </div>
+        </section>
+
+        <!-- Saving Throws -->
+        <section class="cs-section cs-saving-throws">
+          <div class="cs-section-title">Saving Throws</div>
+          <div v-for="ab in ABILITIES" :key="ab.key" class="cs-check-row">
+            <span :class="['cs-prof-dot', member.saving_throw_proficiencies.includes(ab.key) ? 'cs-prof-dot--filled' : '']" />
+            <span class="cs-check-bonus">{{ signedBonus(saveBonus(ab.key)) }}</span>
+            <span class="cs-check-label">{{ ab.label }}</span>
+          </div>
+        </section>
+
+        <!-- Passive Perception -->
+        <section class="cs-section cs-passive-row">
+          <span class="cs-passive-label">Passive Wisdom (Perception)</span>
+          <span class="cs-passive-value">{{ passivePerception }}</span>
+        </section>
+
+        <!-- Skills -->
+        <section class="cs-section cs-skills">
+          <div class="cs-section-title">Skills</div>
+          <div v-for="sk in SKILLS" :key="sk.key" class="cs-check-row">
+            <span :class="['cs-prof-dot', skillLevel(sk.key) !== 'none' ? 'cs-prof-dot--filled' : '', skillLevel(sk.key) === 'expertise' ? 'cs-prof-dot--expertise' : '']" />
+            <span class="cs-check-bonus">{{ signedBonus(computedSkillBonus(sk)) }}</span>
+            <span class="cs-check-label">{{ sk.label }} <span class="cs-check-ability">({{ sk.ability.toUpperCase() }})</span></span>
+          </div>
+        </section>
+
+      </aside>
+
+      <!-- Right column: combat + attacks + currency + personality -->
+      <main class="cs-right-col">
+
+        <!-- Combat stats bar -->
+        <section class="cs-section cs-combat-row">
+          <div class="cs-combat-stat">
+            <div class="cs-combat-value">{{ member.ac }}</div>
+            <div class="cs-combat-label">Armor Class</div>
+          </div>
+          <div class="cs-combat-stat">
+            <div class="cs-combat-value">{{ signedBonus(member.initiative_bonus + abilityMod(member.dex)) }}</div>
+            <div class="cs-combat-label">Initiative</div>
+          </div>
+          <div class="cs-combat-stat">
+            <div class="cs-combat-value">{{ member.speed }}</div>
+            <div class="cs-combat-label">Speed</div>
+          </div>
+          <div class="cs-combat-stat cs-combat-stat--wide">
+            <div class="cs-hp-row">
+              <div class="cs-hp-block">
+                <div class="cs-combat-value">{{ member.max_hp }}</div>
+                <div class="cs-combat-label">HP Maximum</div>
+              </div>
+              <div class="cs-hp-block">
+                <div class="cs-combat-value">{{ member.current_hp }}</div>
+                <div class="cs-combat-label">Current HP</div>
+              </div>
+              <div class="cs-hp-block">
+                <div class="cs-combat-value">{{ member.temp_hp || "—" }}</div>
+                <div class="cs-combat-label">Temporary HP</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Hit Dice + Death Saves -->
+        <section class="cs-section cs-dice-saves-row">
+          <div class="cs-hit-dice">
+            <div class="cs-subsection-title">Hit Dice</div>
+            <div class="cs-hit-dice-value">{{ hitDiceStr }}</div>
+          </div>
+          <div class="cs-death-saves">
+            <div class="cs-subsection-title">Death Saves</div>
+            <div class="cs-death-save-row">
+              <span class="cs-death-label">Successes</span>
+              <span v-for="i in 3" :key="i" :class="['cs-save-pip', i <= member.death_save_successes ? 'cs-save-pip--filled' : '']" />
+            </div>
+            <div class="cs-death-save-row">
+              <span class="cs-death-label">Failures</span>
+              <span v-for="i in 3" :key="i" :class="['cs-save-pip', i <= member.death_save_failures ? 'cs-save-pip--filled cs-save-pip--fail' : '']" />
+            </div>
+          </div>
+        </section>
+
+        <!-- Attacks & Spellcasting -->
+        <section class="cs-section cs-attacks">
+          <div class="cs-section-title">Attacks &amp; Spellcasting</div>
+          <table class="cs-attack-table">
+            <thead>
+              <tr>
+                <th class="cs-attack-th cs-attack-name">Name</th>
+                <th class="cs-attack-th">Atk Bonus</th>
+                <th class="cs-attack-th">Damage / Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in equippedWeapons" :key="item.id" class="cs-attack-row">
+                <td class="cs-attack-name">{{ item.name }}</td>
+                <td>—</td>
+                <td>—</td>
+              </tr>
+              <tr v-for="i in Math.max(0, 3 - equippedWeapons.length)" :key="`blank-${i}`" class="cs-attack-row cs-attack-row--blank">
+                <td></td><td></td><td></td>
+              </tr>
+            </tbody>
+          </table>
+          <!-- Spellcasting stats -->
+          <div v-if="spellAttack !== null" class="cs-spellcasting-stats">
+            <div class="cs-spell-stat">
+              <div class="cs-spell-stat-value">{{ castingAbility?.toUpperCase() }}</div>
+              <div class="cs-spell-stat-label">Spellcasting Ability</div>
+            </div>
+            <div class="cs-spell-stat">
+              <div class="cs-spell-stat-value">{{ spellSaveDC }}</div>
+              <div class="cs-spell-stat-label">Spell Save DC</div>
+            </div>
+            <div class="cs-spell-stat">
+              <div class="cs-spell-stat-value">{{ signedBonus(spellAttack) }}</div>
+              <div class="cs-spell-stat-label">Spell Attack</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Spell Slots -->
+        <section v-if="member.spell_slots.length" class="cs-section cs-spell-slots">
+          <div class="cs-section-title">Spell Slots</div>
+          <div class="cs-slot-grid">
+            <div v-for="slot in member.spell_slots" :key="slot.level" class="cs-slot-entry">
+              <div class="cs-slot-level">{{ ORDINALS[slot.level - 1] }}</div>
+              <div class="cs-slot-pips">
+                <span
+                  v-for="i in slot.max"
+                  :key="i"
+                  :class="['cs-slot-pip', i > (slot.max - slot.used) ? 'cs-slot-pip--used' : '']"
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Currency -->
+        <section class="cs-section cs-currency">
+          <div class="cs-section-title">Currency</div>
+          <div class="cs-currency-row">
+            <div v-for="coin in COINS" :key="coin.key" class="cs-coin">
+              <div class="cs-coin-amount">{{ member[coin.key] }}</div>
+              <div class="cs-coin-label">{{ coin.label }}</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Personality -->
+        <section class="cs-section cs-personality">
+          <div class="cs-personality-grid">
+            <div class="cs-trait-box">
+              <div class="cs-subsection-title">Personality Traits</div>
+              <div class="cs-trait-text">{{ member.personality_traits || "" }}</div>
+            </div>
+            <div class="cs-trait-box">
+              <div class="cs-subsection-title">Ideals</div>
+              <div class="cs-trait-text">{{ member.ideals || "" }}</div>
+            </div>
+            <div class="cs-trait-box">
+              <div class="cs-subsection-title">Bonds</div>
+              <div class="cs-trait-text">{{ member.bonds || "" }}</div>
+            </div>
+            <div class="cs-trait-box">
+              <div class="cs-subsection-title">Flaws</div>
+              <div class="cs-trait-text">{{ member.flaws || "" }}</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Features & Other proficiencies -->
+        <section class="cs-section cs-features">
+          <div class="cs-section-title">Other Proficiencies &amp; Languages</div>
+          <div class="cs-features-text">
+            <template v-if="member.tool_proficiencies.length">
+              <strong>Tools:</strong> {{ member.tool_proficiencies.join(", ") }}<br />
+            </template>
+            <template v-if="member.languages.length">
+              <strong>Languages:</strong> {{ member.languages.join(", ") }}
+            </template>
+          </div>
+        </section>
+
+      </main>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { SKILLS, type PartyMember, type SkillProficiencies } from "@/types/party.types";
+import type { PartyInventoryItem } from "@/types/inventory.types";
+import { getCastingAbility } from "@/types/spell.types";
+import type { SheetPageSize } from "@/composables/useCharacterSheetPdf";
+
+const props = defineProps<{
+  member: PartyMember;
+  inventory: PartyInventoryItem[];
+  pageSize?: SheetPageSize;
+}>();
+
+const ABILITIES = [
+  { key: "str" as const, label: "Strength" },
+  { key: "dex" as const, label: "Dexterity" },
+  { key: "con" as const, label: "Constitution" },
+  { key: "int" as const, label: "Intelligence" },
+  { key: "wis" as const, label: "Wisdom" },
+  { key: "cha" as const, label: "Charisma" },
+];
+
+const COINS = [
+  { key: "pp" as keyof PartyMember, label: "PP" },
+  { key: "gp" as keyof PartyMember, label: "GP" },
+  { key: "ep" as keyof PartyMember, label: "EP" },
+  { key: "sp" as keyof PartyMember, label: "SP" },
+  { key: "cp" as keyof PartyMember, label: "CP" },
+];
+
+const ORDINALS = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th"];
+
+// ── Computed helpers ──────────────────────────────────────────────────────────
+
+const background = computed(() => props.member.background_id ?? "—");
+const species = computed(() => props.member.subrace
+  ? `${props.member.subrace}`
+  : (props.member.species_id ?? "—"));
+
+function abilityMod(score: number): number {
+  return Math.floor((score - 10) / 2);
+}
+
+function signedMod(score: number): string {
+  const m = abilityMod(score);
+  return m >= 0 ? `+${m}` : `${m}`;
+}
+
+function signedBonus(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}
+
+function saveBonus(key: keyof Pick<PartyMember, "str" | "dex" | "con" | "int" | "wis" | "cha">): number {
+  const mod = abilityMod(props.member[key]);
+  const prof = props.member.saving_throw_proficiencies.includes(key) ? props.member.proficiency_bonus : 0;
+  return mod + prof;
+}
+
+function skillLevel(key: keyof SkillProficiencies): string {
+  return props.member.skill_proficiencies?.[key] ?? "none";
+}
+
+function computedSkillBonus(sk: typeof SKILLS[number]): number {
+  const mod = abilityMod(props.member[sk.ability]);
+  const level = skillLevel(sk.key);
+  const pb = props.member.proficiency_bonus;
+  return mod + (level === "none" ? 0 : level === "proficient" ? pb : pb * 2);
+}
+
+const passivePerception = computed(() => {
+  const sk = SKILLS.find((s) => s.key === "perception")!;
+  return 10 + computedSkillBonus(sk);
+});
+
+const castingAbility = computed(() => getCastingAbility(props.member.class));
+const castingMod = computed(() =>
+  castingAbility.value ? abilityMod(props.member[castingAbility.value]) : null,
+);
+const spellAttack = computed(() =>
+  castingMod.value !== null ? props.member.proficiency_bonus + castingMod.value : null,
+);
+const spellSaveDC = computed(() =>
+  spellAttack.value !== null ? 8 + spellAttack.value : null,
+);
+
+const hitDiceStr = computed(() => {
+  if (!props.member.class) return `${props.member.level}d8`;
+  const dieMap: Record<string, number> = {
+    Barbarian: 12, Fighter: 10, Paladin: 10, Ranger: 10,
+    Bard: 8, Cleric: 8, Druid: 8, Monk: 8, Rogue: 8, Warlock: 8,
+    Artificer: 8, Sorcerer: 6, Wizard: 6,
+  };
+  const die = dieMap[props.member.class] ?? 8;
+  const rem = props.member.hit_dice_remaining ?? props.member.level;
+  return `${rem}d${die}`;
+});
+
+const equippedWeapons = computed(() =>
+  props.inventory.filter(
+    (i) => i.carried_by === props.member.id && i.location === "equipped" &&
+    (i.slot === "main_hand" || i.slot === "off_hand"),
+  ),
+);
+</script>
+
+<style>
+/* Character Sheet — .cs-* taxonomy (stable, semantic, prefixed) */
+/* All rules scoped via .cs-page ancestor to avoid app bleed. */
+
+.cs-page {
+  width: 794px;
+  min-height: 1123px;
+  background: #f8f4ec;
+  font-family: 'Crimson Pro', Georgia, 'Times New Roman', serif;
+  color: #1a1208;
+  padding: 20px 22px;
+  box-sizing: border-box;
+  line-height: 1.3;
+  font-size: 12px;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+
+.cs-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid #2d1f0e;
+  margin-bottom: 10px;
+}
+
+.cs-header-name-block {
+  flex: 1;
+  min-width: 0;
+}
+
+.cs-character-name {
+  font-family: 'Cinzel', 'Palatino Linotype', serif;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #1a0e04;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cs-header-meta {
+  font-size: 10px;
+  color: #5a4a32;
+  margin-top: 3px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  align-items: center;
+}
+
+.cs-meta-label {
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8a7055;
+  margin-right: 3px;
+}
+
+.cs-meta-sep {
+  color: #c8b896;
+  margin: 0 1px;
+}
+
+.cs-portrait-wrap {
+  width: 60px;
+  height: 75px;
+  flex-shrink: 0;
+  border: 1.5px solid #6b4c2a;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.cs-portrait {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ── Body layout ────────────────────────────────────────────────────── */
+
+.cs-body {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.cs-left-col {
+  width: 220px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cs-right-col {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* ── Sections ────────────────────────────────────────────────────────── */
+
+.cs-section {
+  border: 1px solid #b09870;
+  border-radius: 3px;
+  padding: 6px 8px;
+  background: rgba(255,252,245,0.6);
+}
+
+.cs-section-title {
+  font-family: 'Cinzel', serif;
+  font-size: 7.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b4c2a;
+  border-bottom: 0.5px solid #c8b896;
+  padding-bottom: 2px;
+  margin-bottom: 4px;
+}
+
+.cs-subsection-title {
+  font-family: 'Cinzel', serif;
+  font-size: 7px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8a7055;
+  margin-bottom: 2px;
+}
+
+/* ── Ability scores ──────────────────────────────────────────────────── */
+
+.cs-ability-scores {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  padding: 6px;
+}
+
+.cs-ability-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid #b09870;
+  border-radius: 3px;
+  padding: 4px 2px;
+  background: white;
+  min-width: 0;
+}
+
+.cs-ability-modifier {
+  font-family: 'Cinzel', serif;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  color: #1a0e04;
+}
+
+.cs-ability-value {
+  font-size: 10px;
+  border: 0.5px solid #c8b896;
+  border-radius: 2px;
+  padding: 0 4px;
+  margin: 2px 0;
+  min-width: 22px;
+  text-align: center;
+  background: #f8f4ec;
+}
+
+.cs-ability-label {
+  font-size: 6.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a7055;
+  text-align: center;
+}
+
+/* ── Insp + prof ────────────────────────────────────────────────────── */
+
+.cs-insp-prof-row {
+  display: flex;
+  gap: 6px;
+}
+
+.cs-stat-box {
+  flex: 1;
+  border: 1px solid #b09870;
+  border-radius: 3px;
+  padding: 4px;
+  background: white;
+  text-align: center;
+}
+
+.cs-stat-box-value {
+  font-family: 'Cinzel', serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #1a0e04;
+  line-height: 1;
+}
+
+.cs-stat-box-label {
+  font-size: 6.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a7055;
+  margin-top: 1px;
+}
+
+/* ── Check rows (saves + skills) ─────────────────────────────────────── */
+
+.cs-check-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 0;
+}
+
+.cs-prof-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1px solid #6b4c2a;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.cs-prof-dot--filled {
+  background: #2d1f0e;
+}
+
+.cs-prof-dot--expertise {
+  box-shadow: 0 0 0 1.5px #2d1f0e;
+}
+
+.cs-check-bonus {
+  font-family: 'Cinzel', serif;
+  font-size: 9px;
+  font-weight: 600;
+  min-width: 22px;
+  text-align: right;
+  color: #1a0e04;
+}
+
+.cs-check-label {
+  font-size: 9px;
+  color: #1a0e04;
+  flex: 1;
+}
+
+.cs-check-ability {
+  font-size: 7.5px;
+  color: #8a7055;
+}
+
+/* ── Passive perception ──────────────────────────────────────────────── */
+
+.cs-passive-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cs-passive-label {
+  font-size: 8.5px;
+  color: #5a4a32;
+}
+
+.cs-passive-value {
+  font-family: 'Cinzel', serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #1a0e04;
+}
+
+/* ── Combat stats ────────────────────────────────────────────────────── */
+
+.cs-combat-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+
+.cs-combat-stat {
+  border: 1px solid #b09870;
+  border-radius: 3px;
+  padding: 4px 6px;
+  background: white;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.cs-combat-stat--wide {
+  flex: 1;
+}
+
+.cs-combat-value {
+  font-family: 'Cinzel', serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: #1a0e04;
+  line-height: 1;
+}
+
+.cs-combat-label {
+  font-size: 6.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a7055;
+  margin-top: 1px;
+  white-space: nowrap;
+}
+
+.cs-hp-row {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+}
+
+.cs-hp-block {
+  text-align: center;
+}
+
+/* ── Hit Dice + Death saves ──────────────────────────────────────────── */
+
+.cs-dice-saves-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.cs-hit-dice {
+  flex-shrink: 0;
+}
+
+.cs-hit-dice-value {
+  font-family: 'Cinzel', serif;
+  font-size: 13px;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.cs-death-saves {
+  flex: 1;
+}
+
+.cs-death-save-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.cs-death-label {
+  font-size: 8px;
+  color: #5a4a32;
+  min-width: 50px;
+}
+
+.cs-save-pip {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #6b4c2a;
+  display: inline-block;
+}
+
+.cs-save-pip--filled { background: #2d5a1f; }
+.cs-save-pip--fail   { background: #8b1a1a; }
+
+/* ── Attacks ─────────────────────────────────────────────────────────── */
+
+.cs-attack-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 9px;
+  margin-bottom: 4px;
+}
+
+.cs-attack-th {
+  font-family: 'Cinzel', serif;
+  font-size: 7.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b4c2a;
+  border-bottom: 0.5px solid #b09870;
+  padding: 1px 3px;
+  text-align: left;
+}
+
+.cs-attack-name {
+  flex: 1;
+}
+
+.cs-attack-row td {
+  padding: 3px;
+  border-bottom: 0.5px solid #e4d8c0;
+  min-height: 16px;
+}
+
+.cs-attack-row--blank td {
+  height: 14px;
+}
+
+.cs-spellcasting-stats {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.cs-spell-stat {
+  flex: 1;
+  border: 1px solid #b09870;
+  border-radius: 3px;
+  padding: 3px 5px;
+  background: white;
+  text-align: center;
+}
+
+.cs-spell-stat-value {
+  font-family: 'Cinzel', serif;
+  font-size: 11px;
+  font-weight: 700;
+  color: #1a0e04;
+}
+
+.cs-spell-stat-label {
+  font-size: 6.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a7055;
+}
+
+/* ── Spell slots ─────────────────────────────────────────────────────── */
+
+.cs-slot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.cs-slot-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.cs-slot-level {
+  font-size: 7px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a7055;
+}
+
+.cs-slot-pips {
+  display: flex;
+  gap: 2px;
+}
+
+.cs-slot-pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid #6b4c2a;
+  display: inline-block;
+  background: #f8f4ec;
+}
+
+.cs-slot-pip--used {
+  background: white;
+  border-color: #c8b896;
+}
+
+/* ── Currency ────────────────────────────────────────────────────────── */
+
+.cs-currency-row {
+  display: flex;
+  gap: 6px;
+}
+
+.cs-coin {
+  flex: 1;
+  border: 1px solid #b09870;
+  border-radius: 3px;
+  padding: 3px 4px;
+  background: white;
+  text-align: center;
+}
+
+.cs-coin-amount {
+  font-family: 'Cinzel', serif;
+  font-size: 11px;
+  font-weight: 700;
+  color: #1a0e04;
+}
+
+.cs-coin-label {
+  font-size: 7px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a7055;
+}
+
+/* ── Personality ─────────────────────────────────────────────────────── */
+
+.cs-personality-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+}
+
+.cs-trait-box {
+  border: 1px solid #b09870;
+  border-radius: 2px;
+  padding: 4px;
+  background: white;
+  min-height: 44px;
+}
+
+.cs-trait-text {
+  font-size: 8.5px;
+  color: #1a0e04;
+  line-height: 1.4;
+  margin-top: 1px;
+}
+
+/* ── Features ────────────────────────────────────────────────────────── */
+
+.cs-features-text {
+  font-size: 9px;
+  color: #1a0e04;
+  line-height: 1.5;
+}
+</style>

--- a/src/composables/useBackgrounds.ts
+++ b/src/composables/useBackgrounds.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
-import { type Ref } from "vue";
+import { computed, type Ref } from "vue";
 import { supabase, getCurrentUser } from "@/lib/supabase";
 import type { Background, BackgroundInsert, BackgroundUpdate } from "@/types/background.types";
 import { removeStorageImages } from "@/composables/useImageUpload";
@@ -53,6 +53,16 @@ async function deleteBackground(bg: Background): Promise<void> {
 
 export function useBackgrounds() {
   return useQuery({ queryKey: [QUERY_KEY], queryFn: fetchBackgrounds, staleTime: Infinity });
+}
+
+/** Returns a Map<background_id, background_name> for fast inline lookups. */
+export function useBackgroundNameMap() {
+  const { data } = useBackgrounds();
+  return computed(() => {
+    const m = new Map<string, string>();
+    for (const bg of data.value ?? []) m.set(bg.id, bg.name);
+    return m;
+  });
 }
 
 export function useBackground(id: Ref<string>) {

--- a/src/composables/useCharacterSheetPdf.ts
+++ b/src/composables/useCharacterSheetPdf.ts
@@ -7,6 +7,12 @@ import CharacterSheetRenderer from "@/components/character-sheet/CharacterSheetR
 
 export type SheetPageSize = "A4" | "Letter";
 
+export interface SheetExportOptions {
+  pageSize?: SheetPageSize;
+  speciesName?: string | null;
+  backgroundName?: string | null;
+}
+
 const PAGE_DIMS_PX: Record<SheetPageSize, { w: number; h: number }> = {
   A4:     { w: 794, h: 1123 },
   Letter: { w: 816, h: 1056 },
@@ -23,7 +29,7 @@ export function useCharacterSheetPdf() {
   async function exportPdf(
     member: PartyMember,
     inventory: PartyInventoryItem[],
-    pageSize: SheetPageSize = "A4",
+    { pageSize = "A4", speciesName = null, backgroundName = null }: SheetExportOptions = {},
   ): Promise<void> {
     isGenerating.value = true;
 
@@ -32,10 +38,17 @@ export function useCharacterSheetPdf() {
 
     // Create an off-screen container at exact page dimensions
     const container = document.createElement("div");
-    container.style.cssText = `position:fixed;top:-9999px;left:-9999px;width:${pxW}px;overflow:hidden;z-index:-1;`;
+    container.style.cssText =
+      `position:fixed;top:-9999px;left:-9999px;width:${pxW}px;overflow:hidden;z-index:-1;`;
     document.body.appendChild(container);
 
-    const app = createApp(CharacterSheetRenderer, { member, inventory, pageSize });
+    const app = createApp(CharacterSheetRenderer, {
+      member,
+      inventory,
+      pageSize,
+      speciesName,
+      backgroundName,
+    });
     app.mount(container);
 
     try {

--- a/src/composables/useCharacterSheetPdf.ts
+++ b/src/composables/useCharacterSheetPdf.ts
@@ -1,0 +1,73 @@
+import { ref, createApp, nextTick } from "vue";
+import jsPDF from "jspdf";
+import html2canvas from "html2canvas";
+import type { PartyMember } from "@/types/party.types";
+import type { PartyInventoryItem } from "@/types/inventory.types";
+import CharacterSheetRenderer from "@/components/character-sheet/CharacterSheetRenderer.vue";
+
+export type SheetPageSize = "A4" | "Letter";
+
+const PAGE_DIMS_PX: Record<SheetPageSize, { w: number; h: number }> = {
+  A4:     { w: 794, h: 1123 },
+  Letter: { w: 816, h: 1056 },
+};
+
+const PAGE_DIMS_MM: Record<SheetPageSize, { w: number; h: number; format: string }> = {
+  A4:     { w: 210, h: 297, format: "a4" },
+  Letter: { w: 216, h: 279, format: "letter" },
+};
+
+export function useCharacterSheetPdf() {
+  const isGenerating = ref(false);
+
+  async function exportPdf(
+    member: PartyMember,
+    inventory: PartyInventoryItem[],
+    pageSize: SheetPageSize = "A4",
+  ): Promise<void> {
+    isGenerating.value = true;
+
+    const { w: pxW, h: pxH } = PAGE_DIMS_PX[pageSize];
+    const { w: mmW, h: mmH, format } = PAGE_DIMS_MM[pageSize];
+
+    // Create an off-screen container at exact page dimensions
+    const container = document.createElement("div");
+    container.style.cssText = `position:fixed;top:-9999px;left:-9999px;width:${pxW}px;overflow:hidden;z-index:-1;`;
+    document.body.appendChild(container);
+
+    const app = createApp(CharacterSheetRenderer, { member, inventory, pageSize });
+    app.mount(container);
+
+    try {
+      await nextTick();
+      await document.fonts.ready;
+
+      const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format });
+      const pages = container.querySelectorAll<HTMLElement>(".cs-page");
+
+      for (let i = 0; i < pages.length; i++) {
+        const canvas = await html2canvas(pages[i] as HTMLElement, {
+          scale: 2,
+          useCORS: true,
+          allowTaint: false,
+          width: pxW,
+          height: pxH,
+          windowWidth: pxW,
+          windowHeight: pxH,
+        });
+        const imgData = canvas.toDataURL("image/jpeg", 0.92);
+        if (i > 0) pdf.addPage(format as string);
+        pdf.addImage(imgData, "JPEG", 0, 0, mmW, mmH);
+      }
+
+      const filename = `${member.name.replace(/\s+/g, "_")}_character_sheet.pdf`;
+      pdf.save(filename);
+    } finally {
+      app.unmount();
+      document.body.removeChild(container);
+      isGenerating.value = false;
+    }
+  }
+
+  return { isGenerating, exportPdf };
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -214,7 +214,7 @@ export const NAV_GROUPS: NavGroup[] = [
         label: "Character Sheet",
         to: "/party",
         icon: IconBookUser,
-        description: "Export printable character sheets",
+        description: "Export printable character sheets (select a party member)",
       },
       {
         label: "Card Forge",

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -19,6 +19,7 @@ import {
   IconPopulate,
   IconQuest,
   IconScrollText,
+  IconBookUser,
   IconSettingsAlt,
   IconShield,
   IconSpecies,
@@ -208,6 +209,12 @@ export const NAV_GROUPS: NavGroup[] = [
         to: "/scriptorium",
         icon: IconQuest,
         description: "Craft & export documents",
+      },
+      {
+        label: "Character Sheet",
+        to: "/party",
+        icon: IconBookUser,
+        description: "Export printable character sheets",
       },
       {
         label: "Card Forge",

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -764,6 +764,13 @@ export const routes: RouteRecordRaw[] = [
     component: () => import("@/views/cardforge/CardForgeView.vue"),
     meta: { requiresAuth: true, title: "Card Forge" },
   },
+  // Character Sheet Export
+  {
+    path: "/character-sheet/:partyMemberId",
+    name: "character-sheet",
+    component: () => import("@/views/publishing/CharacterSheetView.vue"),
+    meta: { requiresAuth: true, title: "Character Sheet" },
+  },
   // The Mint
   {
     path: "/tokens",

--- a/src/views/party/PartyMemberView.vue
+++ b/src/views/party/PartyMemberView.vue
@@ -12,15 +12,22 @@
         to="/party"
         class="font-cinzel text-xs text-muted-foreground hover:text-foreground transition-colors tracking-wider"
       >← Party</RouterLink>
-      <button
-        v-if="member"
-        type="button"
-        class="ml-auto inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
-        @click="editOpen = true"
-      >
-        <IconEdit class="h-3.5 w-3.5" />
-        Edit
-      </button>
+      <template v-if="member">
+        <RouterLink
+          :to="`/character-sheet/${member.id}`"
+          class="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-muted-foreground/50 transition-colors"
+        >
+          Export Sheet
+        </RouterLink>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity"
+          @click="editOpen = true"
+        >
+          <IconEdit class="h-3.5 w-3.5" />
+          Edit
+        </button>
+      </template>
     </div>
 
     <PlayerCharacterView
@@ -39,7 +46,7 @@
 
 <script setup lang="ts">
 import { computed, ref, defineAsyncComponent } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, RouterLink } from "vue-router";
 import { IconEdit } from '@/lib/icons';
 import { useParty } from "@/composables/useParty";
 import PlayerCharacterView from "@/views/play/PlayerCharacterView.vue";

--- a/src/views/play/PlayerCharacterView.vue
+++ b/src/views/play/PlayerCharacterView.vue
@@ -70,15 +70,24 @@
         :member="member"
       />
 
-      <!-- ── Tabs ───────────────────────────────────────────── -->
-      <div class="flex flex-wrap rounded-md border border-border overflow-hidden w-fit text-xs font-cinzel font-semibold tracking-wider">
-        <button
-          v-for="tab in visibleTabs"
-          :key="tab.id"
-          class="cursor-pointer px-4 py-1.5 transition-colors"
-          :class="activeTab === tab.id ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground hover:text-foreground'"
-          @click="activeTab = tab.id"
-        >{{ tab.label }}</button>
+      <!-- ── Tabs + Export Sheet ──────────────────────────── -->
+      <div class="flex items-center gap-3 flex-wrap">
+        <div class="flex flex-wrap rounded-md border border-border overflow-hidden w-fit text-xs font-cinzel font-semibold tracking-wider">
+          <button
+            v-for="tab in visibleTabs"
+            :key="tab.id"
+            class="cursor-pointer px-4 py-1.5 transition-colors"
+            :class="activeTab === tab.id ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground hover:text-foreground'"
+            @click="activeTab = tab.id"
+          >{{ tab.label }}</button>
+        </div>
+        <RouterLink
+          v-if="!hidePlayerActions && member"
+          :to="`/character-sheet/${member.id}`"
+          class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 font-cinzel text-xs font-semibold text-muted-foreground hover:text-foreground hover:border-muted-foreground/50 transition-colors"
+        >
+          Export Sheet
+        </RouterLink>
       </div>
 
       <!-- Skills -->

--- a/src/views/publishing/CharacterSheetView.vue
+++ b/src/views/publishing/CharacterSheetView.vue
@@ -1,0 +1,106 @@
+<template>
+  <PageHeader title="Character Sheet" description="Export a printable PDF character sheet">
+
+    <div v-if="isLoading" class="flex justify-center py-16">
+      <LoadingSpinner />
+    </div>
+
+    <div v-else-if="!member" class="flex flex-col items-center gap-4 py-16 text-center">
+      <p class="font-fell text-base text-muted-foreground italic">Character not found.</p>
+      <RouterLink to="/party" class="font-cinzel text-xs text-primary hover:underline">← Party list</RouterLink>
+    </div>
+
+    <template v-else>
+      <!-- Toolbar -->
+      <div class="flex items-center gap-3 mb-6">
+        <select
+          v-model="pageSize"
+          class="bg-card border border-border rounded px-2.5 py-1.5 font-cinzel text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <option value="A4">A4</option>
+          <option value="Letter">Letter</option>
+        </select>
+
+        <button
+          type="button"
+          :disabled="isGenerating"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 font-cinzel text-xs font-semibold text-primary-foreground tracking-wider hover:opacity-90 transition-opacity disabled:opacity-50"
+          @click="doExport"
+        >
+          {{ isGenerating ? "Generating PDF…" : "Export PDF" }}
+        </button>
+
+        <RouterLink
+          :to="`/party`"
+          class="font-fell text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← Back to party
+        </RouterLink>
+      </div>
+
+      <!-- Preview (scaled-down rendition of the sheet) -->
+      <div class="cs-preview-wrapper">
+        <div class="cs-preview-scaler">
+          <CharacterSheetRenderer
+            :member="member"
+            :inventory="inventory"
+            :page-size="pageSize"
+          />
+        </div>
+      </div>
+    </template>
+  </PageHeader>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useRoute } from "vue-router";
+import PageHeader from "@/components/common/PageHeader.vue";
+import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
+import CharacterSheetRenderer from "@/components/character-sheet/CharacterSheetRenderer.vue";
+import { useParty } from "@/composables/useParty";
+import { usePartyInventory } from "@/composables/usePartyInventory";
+import { useCharacterSheetPdf, type SheetPageSize } from "@/composables/useCharacterSheetPdf";
+
+const route = useRoute();
+const memberId = computed(() => route.params.partyMemberId as string);
+
+const { data: partyMembers, isLoading: partyLoading } = useParty();
+const { data: inventoryItems, isLoading: inventoryLoading } = usePartyInventory();
+
+const isLoading = computed(() => partyLoading.value || inventoryLoading.value);
+
+const member = computed(() =>
+  partyMembers.value?.find((m) => m.id === memberId.value) ?? null,
+);
+
+const inventory = computed(() =>
+  (inventoryItems.value ?? []).filter((i) => i.carried_by === memberId.value),
+);
+
+const pageSize = ref<SheetPageSize>("A4");
+
+const { isGenerating, exportPdf } = useCharacterSheetPdf();
+
+async function doExport() {
+  if (!member.value) return;
+  await exportPdf(member.value, inventory.value, pageSize.value);
+}
+</script>
+
+<style scoped>
+/* Preview: zoom collapses the rendered element's layout size (unlike transform:scale).
+   The sheet is 794px wide; at 0.85 zoom it displays at ~675px. */
+.cs-preview-wrapper {
+  display: inline-block;
+  border: 1px solid hsl(var(--border));
+  border-radius: 6px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.12);
+  overflow: hidden;
+}
+
+.cs-preview-scaler {
+  zoom: 0.75;
+  pointer-events: none;
+}
+</style>

--- a/src/views/publishing/CharacterSheetView.vue
+++ b/src/views/publishing/CharacterSheetView.vue
@@ -7,12 +7,14 @@
 
     <div v-else-if="!member" class="flex flex-col items-center gap-4 py-16 text-center">
       <p class="font-fell text-base text-muted-foreground italic">Character not found.</p>
-      <RouterLink to="/party" class="font-cinzel text-xs text-primary hover:underline">← Party list</RouterLink>
+      <RouterLink :to="backRoute" class="font-cinzel text-xs text-primary hover:underline">
+        ← Back
+      </RouterLink>
     </div>
 
     <template v-else>
       <!-- Toolbar -->
-      <div class="flex items-center gap-3 mb-6">
+      <div class="flex flex-wrap items-center gap-3 mb-6">
         <select
           v-model="pageSize"
           class="bg-card border border-border rounded px-2.5 py-1.5 font-cinzel text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
@@ -31,10 +33,10 @@
         </button>
 
         <RouterLink
-          :to="`/party`"
+          :to="backRoute"
           class="font-fell text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
-          ← Back to party
+          ← Back
         </RouterLink>
       </div>
 
@@ -45,6 +47,8 @@
             :member="member"
             :inventory="inventory"
             :page-size="pageSize"
+            :species-name="speciesName"
+            :background-name="backgroundName"
           />
         </div>
       </div>
@@ -54,19 +58,26 @@
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, RouterLink } from "vue-router";
 import PageHeader from "@/components/common/PageHeader.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import CharacterSheetRenderer from "@/components/character-sheet/CharacterSheetRenderer.vue";
 import { useParty } from "@/composables/useParty";
 import { usePartyInventory } from "@/composables/usePartyInventory";
 import { useCharacterSheetPdf, type SheetPageSize } from "@/composables/useCharacterSheetPdf";
+import { useSpeciesNameMap } from "@/composables/useSpecies";
+import { useBackgroundNameMap } from "@/composables/useBackgrounds";
+import { useAuthStore } from "@/stores/auth";
 
 const route = useRoute();
+const auth = useAuthStore();
+
 const memberId = computed(() => route.params.partyMemberId as string);
 
 const { data: partyMembers, isLoading: partyLoading } = useParty();
 const { data: inventoryItems, isLoading: inventoryLoading } = usePartyInventory();
+const speciesMap = useSpeciesNameMap();
+const backgroundMap = useBackgroundNameMap();
 
 const isLoading = computed(() => partyLoading.value || inventoryLoading.value);
 
@@ -78,25 +89,41 @@ const inventory = computed(() =>
   (inventoryItems.value ?? []).filter((i) => i.carried_by === memberId.value),
 );
 
+/** Resolved names — fall back to null if the lookup maps aren't loaded yet */
+const speciesName = computed(() =>
+  member.value?.species_id ? (speciesMap.value.get(member.value.species_id) ?? null) : null,
+);
+const backgroundName = computed(() =>
+  member.value?.background_id ? (backgroundMap.value.get(member.value.background_id) ?? null) : null,
+);
+
+/** Players go back to /play, the DM goes back to /party */
+const backRoute = computed(() => auth.isDM ? "/party" : "/play");
+
 const pageSize = ref<SheetPageSize>("A4");
 
 const { isGenerating, exportPdf } = useCharacterSheetPdf();
 
 async function doExport() {
   if (!member.value) return;
-  await exportPdf(member.value, inventory.value, pageSize.value);
+  await exportPdf(member.value, inventory.value, {
+    pageSize: pageSize.value,
+    speciesName: speciesName.value,
+    backgroundName: backgroundName.value,
+  });
 }
 </script>
 
 <style scoped>
-/* Preview: zoom collapses the rendered element's layout size (unlike transform:scale).
-   The sheet is 794px wide; at 0.85 zoom it displays at ~675px. */
+/* Preview: zoom collapses the rendered element's layout size.
+   The sheet is 794px wide; at 0.75 zoom it displays at ~595px. */
 .cs-preview-wrapper {
   display: inline-block;
   border: 1px solid hsl(var(--border));
   border-radius: 6px;
   box-shadow: 0 2px 12px rgba(0,0,0,0.12);
   overflow: hidden;
+  max-width: 100%;
 }
 
 .cs-preview-scaler {


### PR DESCRIPTION
## Summary

Implements the foundational character sheet PDF exporter (#418). Establishes the pattern that the player route (#419), theme variants (#420, #421), and user CSS skinning (#423) will build on.

- **Route** `/character-sheet/:partyMemberId` (`requiresAuth: true`) — DM-only for now; player access is #419
- **`CharacterSheetRenderer.vue`** — all standard 5e sections in a single A4/Letter-sized page:
  - Identity header (name, class/level, background, species, alignment, XP, portrait)
  - Ability score boxes with large modifier + raw score
  - Saving throws with proficiency dots
  - Passive Perception
  - Skills with proficiency/expertise dots
  - Combat stats bar (AC, initiative, speed, max/current/temp HP)
  - Hit dice + death saves pips
  - Attacks & Spellcasting table (equipped main/off-hand weapons auto-populated; spell attack bonus + save DC auto-computed for casters)
  - Spell slots grid with used/available pips
  - Currency (PP/GP/EP/SP/CP)
  - Personality traits, ideals, bonds, flaws (2-col grid)
  - Other proficiencies & languages
- **`useCharacterSheetPdf.ts`** — mounts `CharacterSheetRenderer` off-screen in a standalone app, captures each `.cs-page` with html2canvas at 2× scale, assembles a jsPDF multi-page PDF, downloads it
- **A4 and Letter** page sizes selectable in the UI
- **"Export Sheet" button** on DM `PartyMemberView` action bar
- **"Character Sheet" entry** in the Publish nav group
- **`.cs-*` class taxonomy** on every rendered element — designed as a stable, semantic, prefixed API for forward-compat with future user-uploaded CSS themes (#423/E)

## Test plan

- [ ] Navigate to a party member and click "Export Sheet" — lands on `/character-sheet/:id` with a preview
- [ ] Preview renders the character's name, class, ability scores, saves, skills correctly
- [ ] Click "Export PDF" → PDF downloads with correct name (`CharacterName_character_sheet.pdf`)
- [ ] PDF renders correctly (no missing fonts, no CORS errors on portrait image)
- [ ] Spellcasting stats (Ability / Save DC / Attack bonus) appear only for caster classes
- [ ] Equipped main/off-hand weapons appear in the Attacks table
- [ ] Switching page size A4 ↔ Letter works
- [ ] Works for a character with no portrait, no spells, no equipped weapons (all sections degrade gracefully)

https://claude.ai/code/session_01RWTkqkC9u3HXGgtTKYopwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWTkqkC9u3HXGgtTKYopwh)_