### PR TITLE
feat(backgrounds): 2024 PHB feat grant (#346)

### DIFF
--- a/src/components/backgrounds/BackgroundDetail.vue
+++ b/src/components/backgrounds/BackgroundDetail.vue
@@ -90,6 +90,21 @@
       />
     </div>
 
+    <!-- Feat grant (2024 PHB) -->
+    <div class="flex flex-col gap-2 rounded-lg border border-border bg-card/50 px-4 py-3">
+      <span class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">Feat grant <span class="font-normal text-muted-foreground/60">(2024 PHB — optional)</span></span>
+      <input
+        v-model="form.feat_grant_name"
+        placeholder="Feat name, e.g. Magic Initiate (Wizard)"
+        class="w-full bg-background border border-border rounded-md px-3 py-2 font-cinzel text-sm font-bold text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      <RichTextEditor
+        v-model="form.feat_grant_description"
+        placeholder="Brief summary of what the feat grants — passive bonuses, spells, proficiencies…"
+        min-height="80px"
+      />
+    </div>
+
     <!-- Suggested characteristics -->
     <div class="flex flex-col gap-1">
       <span class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">Suggested characteristics</span>
@@ -135,6 +150,8 @@ function blankForm(): BackgroundInsert {
     equipment: null,
     feature_name: null,
     feature_description: null,
+    feat_grant_name: null,
+    feat_grant_description: null,
     suggested_characteristics: null,
     tags: [],
     source: null,

--- a/src/components/backgrounds/BackgroundSheet.vue
+++ b/src/components/backgrounds/BackgroundSheet.vue
@@ -92,6 +92,18 @@
       </div>
     </div>
 
+    <!-- Feat grant card (2024 PHB) -->
+    <div v-if="background.feat_grant_name" class="rounded-lg border border-primary/30 bg-primary/5 overflow-hidden">
+      <div class="px-3 py-2 border-b border-primary/20 bg-primary/10 flex items-center gap-2">
+        <span class="font-cinzel text-xs font-semibold text-primary tracking-wider">Feat Grant</span>
+        <span class="font-cinzel text-[10px] text-primary/60 tracking-wider">2024 PHB</span>
+      </div>
+      <div class="p-4 flex flex-col gap-2">
+        <p class="font-cinzel text-sm font-bold text-foreground">{{ background.feat_grant_name }}</p>
+        <RichTextViewer v-if="background.feat_grant_description" :content="background.feat_grant_description" />
+      </div>
+    </div>
+
     <!-- Tags card -->
     <div v-if="background.tags.length" class="rounded-lg border border-border bg-card overflow-hidden">
       <div class="px-3 py-2 border-b border-border bg-muted/20">

--- a/src/components/play/CharacterCreateBackgroundStep.vue
+++ b/src/components/play/CharacterCreateBackgroundStep.vue
@@ -9,21 +9,73 @@
       </div>
       <div v-else class="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <button v-for="bg in allBackgrounds" :key="bg.id" type="button"
-          class="rounded-lg border overflow-hidden text-left transition-all p-3"
+          class="group rounded-lg border overflow-hidden text-left transition-all"
           :class="f.background_id === bg.id
-            ? 'border-primary ring-1 ring-primary bg-primary/5'
+            ? 'border-primary ring-1 ring-primary'
             : 'border-border bg-card hover:border-primary/40'"
           @click="onBackgroundSelect(bg.id)">
-          <p class="font-cinzel text-sm font-bold text-foreground">{{ bg.name }}</p>
-          <div v-if="bg.skill_proficiencies?.length" class="mt-1.5 flex flex-wrap gap-1">
-            <span v-for="sk in bg.skill_proficiencies" :key="sk"
-              class="px-1.5 py-0.5 rounded bg-primary/10 border border-primary/20 font-cinzel text-[9px] text-primary">
-              {{ sk }}
-            </span>
+
+          <!-- Portrait thumbnail -->
+          <div class="relative h-24 bg-muted overflow-hidden shrink-0">
+            <FocalImage
+              :src="bg.image_url"
+              :alt="bg.name"
+              format="landscape"
+              :focal-point="bg.focal_point ?? null"
+              placeholder="/assets/placeholders/background.webp"
+              class="group-hover:scale-105 transition-transform duration-300"
+            />
+            <!-- Selected badge -->
+            <div v-if="f.background_id === bg.id"
+              class="absolute top-1.5 right-1.5 size-5 rounded-full bg-primary flex items-center justify-center">
+              <IconCheck class="size-3 text-primary-foreground" />
+            </div>
+            <!-- Feat badge -->
+            <div v-if="bg.feat_grant_name"
+              class="absolute bottom-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/60 font-cinzel text-[9px] text-amber-300 tracking-wider leading-none">
+              ✦ {{ bg.feat_grant_name }}
+            </div>
           </div>
-          <p v-if="bg.feature_name" class="font-fell text-xs text-muted-foreground mt-1.5 italic">{{ bg.feature_name }}</p>
-          <p v-if="bg.source_title" class="font-cinzel text-[9px] text-muted-foreground/50 mt-1">{{ bg.source_title }}</p>
+
+          <div class="p-2.5">
+            <p class="font-cinzel text-sm font-bold text-foreground leading-tight">{{ bg.name }}</p>
+            <!-- Proficiencies summary -->
+            <div class="mt-1.5 flex flex-wrap gap-1">
+              <span v-for="sk in bg.skill_proficiencies" :key="sk"
+                class="px-1.5 py-0.5 rounded bg-primary/10 border border-primary/20 font-cinzel text-[9px] text-primary">
+                {{ sk }}
+              </span>
+              <span v-for="t in bg.tool_proficiencies" :key="t"
+                class="px-1.5 py-0.5 rounded bg-muted font-cinzel text-[9px] text-muted-foreground">
+                {{ t }}
+              </span>
+              <span v-if="bg.languages?.length"
+                class="px-1.5 py-0.5 rounded bg-muted font-cinzel text-[9px] text-muted-foreground">
+                {{ bg.languages.length === 1 ? bg.languages[0] : `${bg.languages.length} languages` }}
+              </span>
+            </div>
+            <p v-if="bg.feature_name" class="font-fell text-xs text-muted-foreground mt-1.5 italic line-clamp-1">
+              {{ bg.feature_name }}
+            </p>
+            <p v-if="bg.source_title" class="font-cinzel text-[9px] text-muted-foreground/50 mt-1">
+              {{ bg.source_title }}
+            </p>
+          </div>
         </button>
+      </div>
+
+      <!-- Feat grant preview -->
+      <div v-if="selectedBg?.feat_grant_name"
+        class="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 space-y-1">
+        <div class="flex items-center gap-2">
+          <p class="font-cinzel text-xs font-semibold text-amber-600 dark:text-amber-400 tracking-wider">FEAT GRANT</p>
+          <span class="font-cinzel text-[10px] text-amber-600/60 dark:text-amber-400/60 tracking-wider">2024 PHB</span>
+        </div>
+        <p class="font-cinzel text-sm font-bold text-foreground">{{ selectedBg.feat_grant_name }}</p>
+        <p v-if="selectedBg.feat_grant_description && typeof selectedBg.feat_grant_description === 'string' && !selectedBg.feat_grant_description.startsWith('{')"
+          class="font-fell text-sm text-foreground/80">
+          {{ selectedBg.feat_grant_description }}
+        </p>
       </div>
 
       <!-- Starting equipment preview -->
@@ -146,6 +198,8 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import RichTextEditor from "@/components/common/RichTextEditor.vue";
+import FocalImage from "@/components/common/FocalImage.vue";
+import { IconCheck } from "@/lib/icons";
 import { useAllDeities } from "@/composables/useDeities";
 import type { CharacterCreationForm } from "@/composables/useCharacterCreationForm";
 

--- a/src/components/player/PlayerFeaturesTab.vue
+++ b/src/components/player/PlayerFeaturesTab.vue
@@ -101,6 +101,17 @@
     </div>
 
     <!-- ── Class choices ───────────────────────────────────────────────────── -->
+    <!-- ── Background feat (2024 PHB) ──────────────────────────────────────── -->
+    <div v-if="backgroundFeat" class="rounded-lg border border-amber-500/30 bg-amber-500/5 overflow-hidden">
+      <div class="px-4 py-2.5 border-b border-amber-500/20 bg-amber-500/10 flex items-center gap-2">
+        <p class="font-cinzel text-xs font-semibold text-amber-600 dark:text-amber-400 tracking-wider">Background Feat</p>
+        <span class="font-cinzel text-[10px] text-amber-600/60 dark:text-amber-400/60 tracking-wider">2024 PHB</span>
+      </div>
+      <div class="px-4 py-3">
+        <p class="font-cinzel text-sm font-bold text-foreground">{{ backgroundFeat }}</p>
+      </div>
+    </div>
+
     <div v-if="choiceEntries.length > 0" class="rounded-lg border border-border bg-card overflow-hidden">
       <div class="px-4 py-2.5 border-b border-border">
         <p class="font-cinzel text-xs font-semibold text-muted-foreground tracking-wider">Choices</p>
@@ -443,10 +454,21 @@ const CHOICE_LABELS: Record<string, string> = {
   barbarian_path:         "Primal Path",
 };
 
+/** Background feat name from class_choices (set when a 2024 PHB background is picked). */
+const backgroundFeat = computed(() => {
+  const raw = props.member.class_choices?.background_feat;
+  return raw && typeof raw === "string" ? raw : null;
+});
+
 const choiceEntries = computed(() => {
   const choices = props.member.class_choices ?? {};
   return Object.entries(choices)
-    .filter(([key, v]) => key !== "metamagic_options" && key !== "infusions_known" && key !== "eldritch_invocations" && key !== "battle_master_maneuvers" && v !== null && v !== undefined && v !== "")
+    .filter(([key, v]) =>
+      key !== "metamagic_options" && key !== "infusions_known" &&
+      key !== "eldritch_invocations" && key !== "battle_master_maneuvers" &&
+      key !== "background_feat" &&           // shown in its own dedicated card
+      v !== null && v !== undefined && v !== "",
+    )
     .map(([key, value]) => ({
       key,
       label: CHOICE_LABELS[key] ?? key.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()),

--- a/src/components/rules/CodexTab.vue
+++ b/src/components/rules/CodexTab.vue
@@ -195,6 +195,16 @@
                     <p v-else class="font-fell text-sm text-muted-foreground italic">No description.</p>
                   </div>
                   <div class="flex flex-col gap-4 p-5 border-t border-border md:border-t-0">
+                    <!-- Feat grant (2024 PHB) -->
+                    <div v-if="selectedBackground.feat_grant_name"
+                      class="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 space-y-1">
+                      <div class="flex items-center gap-2">
+                        <p class="font-cinzel text-[10px] font-semibold text-amber-600 dark:text-amber-400 tracking-wider">FEAT GRANT</p>
+                        <span class="font-cinzel text-[9px] text-amber-600/60 dark:text-amber-400/60 tracking-wider">2024 PHB</span>
+                      </div>
+                      <p class="font-cinzel text-sm font-bold text-foreground">{{ selectedBackground.feat_grant_name }}</p>
+                      <RichTextViewer v-if="selectedBackground.feat_grant_description" :content="selectedBackground.feat_grant_description" />
+                    </div>
                     <div v-if="selectedBackground.skill_proficiencies?.length">
                       <p class="font-cinzel text-[10px] font-semibold text-muted-foreground tracking-wider mb-1.5">SKILL PROFICIENCIES</p>
                       <div class="flex flex-wrap gap-1.5">

--- a/src/composables/useCharacterCreationForm.ts
+++ b/src/composables/useCharacterCreationForm.ts
@@ -412,6 +412,15 @@ export function useCharacterCreationForm() {
     for (const lang of bg.languages ?? []) {
       if (!f.languages.includes(lang)) f.languages.push(lang);
     }
+    // 2024 PHB: record background feat grant in class_choices so it surfaces
+    // in the character's features tab.
+    if (bg.feat_grant_name) {
+      f.class_choices = { ...f.class_choices, background_feat: bg.feat_grant_name };
+    } else {
+      const { background_feat: _removed, ...rest } = f.class_choices as Record<string, unknown>;
+      void _removed;
+      f.class_choices = rest;
+    }
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/lib/open5eBackgroundImport.ts
+++ b/src/lib/open5eBackgroundImport.ts
@@ -84,6 +84,8 @@ function mapBackground(b: Open5eBackground): BackgroundInsert {
     equipment: b.equipment?.trim() || null,
     feature_name: b.feature?.trim() || null,
     feature_description: b.feature_desc?.trim() || null,
+    feat_grant_name: null,
+    feat_grant_description: null,
     suggested_characteristics: b.suggested_characteristics?.trim() || null,
     tags: [],
     source: b.document__slug ?? null,

--- a/src/types/background.types.ts
+++ b/src/types/background.types.ts
@@ -16,6 +16,13 @@ export interface Background {
   equipment: string | null;
   feature_name: string | null;
   feature_description: string | null;
+  /**
+   * 2024 PHB: every background grants a feat at 1st level.
+   * Stored as a free-text name so any ruleset / homebrew feat can be referenced.
+   */
+  feat_grant_name: string | null;
+  /** Optional description / summary of what the feat does, for in-app display. */
+  feat_grant_description: string | null;
   /** Block of personality traits / ideals / bonds / flaws suggestions. */
   suggested_characteristics: string | null;
   tags: string[];

--- a/src/views/play/PlayerBackgroundPickerView.vue
+++ b/src/views/play/PlayerBackgroundPickerView.vue
@@ -44,6 +44,18 @@
             </p>
           </div>
 
+          <!-- Feat grant (2024 PHB) -->
+          <div v-if="pendingBg.feat_grant_name"
+            class="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 space-y-1">
+            <div class="flex items-center gap-2">
+              <p class="font-cinzel text-2xs md:text-sm font-semibold text-amber-600 dark:text-amber-400 tracking-wider">
+                FEAT GRANT
+              </p>
+              <span class="font-cinzel text-[10px] text-amber-600/60 dark:text-amber-400/60 tracking-wider">2024 PHB</span>
+            </div>
+            <p class="font-cinzel text-sm font-bold text-foreground">{{ pendingBg.feat_grant_name }}</p>
+          </div>
+
           <!-- Proficiencies granted by the new background -->
           <div v-if="propsToApply.length > 0">
             <p class="font-cinzel text-2xs md:text-sm font-semibold text-muted-foreground tracking-wider mb-2">
@@ -225,6 +237,12 @@ async function confirm() {
     if (removeOld.value && pendingRemovals.value) {
       removeBackgroundProfs(form, pendingRemovals.value);
     }
+    // Update class_choices.background_feat to reflect the newly selected background's feat grant
+    const existingChoices = me.value.class_choices ?? {};
+    const updatedChoices = pendingBg.value.feat_grant_name
+      ? { ...existingChoices, background_feat: pendingBg.value.feat_grant_name }
+      : (({ background_feat: _r, ...rest }) => (void _r, rest))(existingChoices as Record<string, unknown>);
+
     await update({
       id: me.value.id,
       update: {
@@ -232,6 +250,7 @@ async function confirm() {
         skill_proficiencies: form.skill_proficiencies,
         tool_proficiencies: form.tool_proficiencies,
         languages: form.languages,
+        class_choices: updatedChoices,
       },
     });
     router.push("/play");

--- a/supabase/migrations/20260525000001_backgrounds_feat_grant.sql
+++ b/supabase/migrations/20260525000001_backgrounds_feat_grant.sql
@@ -1,0 +1,6 @@
+-- Migration: backgrounds_feat_grant
+-- Add feat_grant_name and feat_grant_description columns to backgrounds (2024 PHB feat-at-1st-level)
+
+alter table backgrounds
+  add column if not exists feat_grant_name        text,
+  add column if not exists feat_grant_description text;


### PR DESCRIPTION
## Summary

Implements the background feat-grant mechanic from issue #346 — 2024 PHB backgrounds grant a feat at 1st level.

## What changed

### DB — migration `20260525000001`
- `feat_grant_name text` and `feat_grant_description text` added to `backgrounds` (nullable; existing rows stay null)
- Run `supabase db push` to apply

### Type & importer
- `Background` type gains `feat_grant_name` and `feat_grant_description`
- `open5eBackgroundImport.ts` seeds both as `null` (Open5e doesn't carry 2024 PHB data)

### Background editor (`BackgroundDetail.vue`)
New **"Feat grant (2024 PHB)"** section — name input + rich-text description. DMs fill this in for any background that grants a feat.

### Background viewer (`BackgroundSheet.vue`)
Amber **"Feat Grant"** card appears whenever `feat_grant_name` is set.

### Character creation (`CharacterCreateBackgroundStep.vue`)
- Background cards now show a **landscape FocalImage thumbnail** (matches the DM codex view and `BackgroundList.vue` — previously just plain text buttons)
- Tool proficiencies and languages added to cards alongside skill pills
- Feat grant name shown as an **amber badge** overlaid on the card thumbnail
- Selection panel shows a dedicated amber "FEAT GRANT" preview before the equipment preview

`useCharacterCreationForm.ts` — `onBackgroundSelect()` now stores the feat name in `class_choices.background_feat` (cleared when switching to a background with no feat grant).

### Mid-game background picker (`PlayerBackgroundPickerView.vue`)
- Confirmation sheet shows the feat grant before the proficiency list
- `confirm()` updates `class_choices.background_feat` in the same DB write as `background_id`

### Player codex (`CodexTab.vue`)
Background detail modal shows the amber feat grant box before the proficiency lists.

### Player features tab (`PlayerFeaturesTab.vue`)
- `background_feat` filtered out of the generic "Choices" card
- New amber **"Background Feat"** card shown above Choices when a feat is recorded

## Test plan

- [ ] Open a background in the editor — "Feat grant" section appears below the feature section
- [ ] Set a feat name (e.g. "Magic Initiate (Wizard)") and save — amber card appears in the view
- [ ] Player codex → Backgrounds → click a background with a feat → amber box in the right column
- [ ] Character creation → Background step — background cards show portrait thumbnails; hovering over a background with a feat shows the amber badge
- [ ] Select a background with a feat → amber "FEAT GRANT" panel appears above equipment preview
- [ ] Finish character creation → Features tab shows amber "Background Feat" card
- [ ] Player codex background picker → select a background with a feat → feat shown in confirmation sheet
- [ ] Backgrounds with no `feat_grant_name` show no amber elements anywhere

Closes #346

https://claude.ai/code/session_01B3HQN2UyoXy2c7gN41sc6L

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3HQN2UyoXy2c7gN41sc6L)_