### PR TITLE
fix: campaign settings mobile layout + scroll restoration on list views

### DIFF
--- a/src/components/backgrounds/BackgroundList.vue
+++ b/src/components/backgrounds/BackgroundList.vue
@@ -158,6 +158,7 @@ import { IconCheck, IconEdit } from '@/lib/icons';
 import { useUiStore } from "@/stores/ui";
 import { useBackgrounds } from "@/composables/useBackgrounds";
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
 import FocalImage from "@/components/common/FocalImage.vue";
@@ -203,5 +204,7 @@ const filtered = computed(() => {
   return list;
 });
 
-const { visibleItems, sentinelRef } = useInfiniteScroll(filtered);
+const { savedCount, linkCount } = useScrollRestore("backgrounds");
+const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount);
+linkCount(visibleCount);
 </script>

--- a/src/components/items/ItemList.vue
+++ b/src/components/items/ItemList.vue
@@ -159,6 +159,7 @@ function itemTypeIcon(type: ItemType): VueComponent {
   return ITEM_TYPE_ICONS[type] ?? IconComponent;
 }
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import { useItems } from "@/composables/useItems";
 import { ITEM_RARITY_LABELS, RARITY_BADGE_COLORS } from "@/types/item.types";
 import type { ItemRarity } from "@/types/item.types";
@@ -192,7 +193,9 @@ const filtered = computed(() => {
   });
 });
 
-const { visibleItems, sentinelRef } = useInfiniteScroll(filtered);
+const { savedCount, linkCount } = useScrollRestore("items");
+const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount);
+linkCount(visibleCount);
 
 function rarityColor(rarity: ItemRarity): string {
   return RARITY_BADGE_COLORS[rarity] ?? "#9ca3af";

--- a/src/components/monsters/MonsterList.vue
+++ b/src/components/monsters/MonsterList.vue
@@ -242,6 +242,7 @@ import { formatHitPoints } from "@/lib/utils";
 import { IconChart, IconEdit, IconHide, IconLock, IconParty, IconReveal } from '@/lib/icons';
 import { useUiStore } from "@/stores/ui";
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import { useAllMonsters } from "@/composables/useMonsters";
 import { useMonsterVisibility } from "@/composables/useMonsterVisibility";
 import type { Monster, DiscoveredMonster } from "@/types/monster.types";
@@ -331,7 +332,9 @@ const filtered = computed(() => {
   return list;
 });
 
-const { visibleItems, sentinelRef } = useInfiniteScroll(filtered);
+const { savedCount, linkCount } = useScrollRestore("monsters");
+const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount);
+linkCount(visibleCount);
 
 const lockedMonsterIds = computed((): Set<string> => {
   const q = monsterQuota.value;

--- a/src/components/npcs/NpcList.vue
+++ b/src/components/npcs/NpcList.vue
@@ -231,6 +231,7 @@
 import { ref, computed, reactive } from "vue";
 import { useRouter } from "vue-router";
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import { IconEdit, IconHide, IconLock, IconParty, IconReveal } from '@/lib/icons';
 import { useNpcs, useUpdateNpc } from "@/composables/useNpcs";
 import { useParty } from "@/composables/useParty";
@@ -336,7 +337,9 @@ const filtered = computed(() => {
   return list;
 });
 
-const { visibleItems, sentinelRef } = useInfiniteScroll(filtered);
+const { savedCount, linkCount } = useScrollRestore("npcs");
+const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount);
+linkCount(visibleCount);
 
 const lockedNpcIds = computed((): Set<string> => {
   const q = npcQuota.value;

--- a/src/components/species/SpeciesList.vue
+++ b/src/components/species/SpeciesList.vue
@@ -138,6 +138,7 @@ import type { Species } from "@/types/species.types";
 import { useUiStore } from "@/stores/ui";
 import { useAllSpecies } from "@/composables/useSpecies";
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
 import FocalImage from "@/components/common/FocalImage.vue";
@@ -173,5 +174,7 @@ const filtered = computed(() => {
   return list;
 });
 
-const { visibleItems, sentinelRef } = useInfiniteScroll(filtered);
+const { savedCount, linkCount } = useScrollRestore("species");
+const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount);
+linkCount(visibleCount);
 </script>

--- a/src/components/spells/SpellList.vue
+++ b/src/components/spells/SpellList.vue
@@ -177,6 +177,7 @@ import { refDebounced } from "@vueuse/core";
 import { useAllSpells } from "@/composables/useSpells";
 import { useAddCharacterSpell, useRemoveCharacterSpell } from "@/composables/useCharacterSpells";
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import { SCHOOL_COLORS, spellLevelLabel } from "@/types/spell.types";
 import type { CasterType, Spell } from "@/types/spell.types";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
@@ -240,5 +241,7 @@ const filtered = computed<Spell[]>(() => {
   return list;
 });
 
-const { visibleItems, sentinelRef } = useInfiniteScroll(filtered);
+const { savedCount, linkCount } = useScrollRestore("spells");
+const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount);
+linkCount(visibleCount);
 </script>

--- a/src/composables/useInfiniteScroll.ts
+++ b/src/composables/useInfiniteScroll.ts
@@ -4,15 +4,22 @@ import { ref, computed, watch, onUnmounted, type Ref } from "vue";
  * Client-side infinite scroll over an already-fetched filtered list.
  *
  * Usage:
- *   const { visibleItems, sentinelRef } = useInfiniteScroll(filtered)
+ *   const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered)
  *
  *   // template: v-for="x in visibleItems" ... <div ref="sentinelRef" />
  *
  * Resets to the first page whenever `filtered` changes (search / filter update).
  * Uses IntersectionObserver on the sentinel element to load the next page.
+ *
+ * Pass `initialCount` (from useScrollRestore) to restore the previously loaded
+ * page depth when navigating back from a detail view.
  */
-export function useInfiniteScroll<T>(filtered: Ref<T[]>, pageSize = 48) {
-  const visibleCount = ref(pageSize);
+export function useInfiniteScroll<T>(
+  filtered: Ref<T[]>,
+  pageSize = 48,
+  initialCount?: number,
+) {
+  const visibleCount = ref(initialCount ?? pageSize);
   const sentinelRef = ref<HTMLElement | null>(null);
 
   const visibleItems = computed(() => filtered.value.slice(0, visibleCount.value));
@@ -39,5 +46,5 @@ export function useInfiniteScroll<T>(filtered: Ref<T[]>, pageSize = 48) {
 
   onUnmounted(() => observer?.disconnect());
 
-  return { visibleItems, sentinelRef, hasMore };
+  return { visibleItems, sentinelRef, hasMore, visibleCount };
 }

--- a/src/composables/useScrollRestore.ts
+++ b/src/composables/useScrollRestore.ts
@@ -1,0 +1,85 @@
+import { getCurrentInstance, onMounted, onBeforeUnmount, nextTick, type Ref } from "vue";
+import { onBeforeRouteLeave } from "vue-router";
+
+/**
+ * Persists the scroll position (and infinite-scroll page count) for a list
+ * view so that navigating List → Detail → Back restores exactly where the
+ * user was.
+ *
+ * Usage — inside the list component (e.g. NpcList.vue):
+ *
+ *   const { savedCount, linkCount } = useScrollRestore('npcs')
+ *   const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount)
+ *   linkCount(visibleCount)
+ *
+ * The composable auto-detects the active scroll container at runtime by
+ * walking up the DOM — this correctly resolves to the inner
+ * `lg:overflow-y-auto` div inside ListPageLayout on desktop, and to the
+ * `<main>` element (DefaultLayout) on mobile, with no manual wiring needed.
+ *
+ * State is kept in a module-level Map (session memory only, never persisted
+ * to localStorage) so it survives in-session navigation but is reset on
+ * hard refresh.
+ */
+
+interface State {
+  scrollTop: number;
+  count: number;
+}
+
+const states = new Map<string, State>();
+
+function findScrollParent(el: Element): Element | null {
+  let node: Element | null = el.parentElement;
+  while (node && node !== document.documentElement) {
+    const { overflowY } = getComputedStyle(node);
+    if (overflowY === "auto" || overflowY === "scroll") return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+export function useScrollRestore(key: string) {
+  const instance = getCurrentInstance();
+  let scrollEl: Element | null = null;
+  let countRef: Ref<number> | null = null;
+
+  /**
+   * Link the `visibleCount` ref returned by useInfiniteScroll so that the
+   * current page depth is included in the saved state.
+   */
+  function linkCount(ref: Ref<number>) {
+    countRef = ref;
+  }
+
+  function save() {
+    if (!scrollEl) return;
+    states.set(key, {
+      scrollTop: scrollEl.scrollTop,
+      count: countRef?.value ?? states.get(key)?.count ?? 0,
+    });
+  }
+
+  onMounted(async () => {
+    const root = instance?.proxy?.$el as Element | null;
+    if (root) scrollEl = findScrollParent(root);
+
+    const saved = states.get(key);
+    if (saved?.scrollTop) {
+      await nextTick();
+      if (scrollEl) scrollEl.scrollTop = saved.scrollTop;
+    }
+  });
+
+  onBeforeRouteLeave(save);
+  onBeforeUnmount(save);
+
+  /**
+   * The visibleCount that was active when the user left the list.
+   * Pass this as `initialCount` to useInfiniteScroll so the same number of
+   * items are rendered before the scroll position is restored.
+   */
+  const savedCount = states.get(key)?.count;
+
+  return { savedCount, linkCount };
+}

--- a/src/composables/useScrollRestore.ts
+++ b/src/composables/useScrollRestore.ts
@@ -1,21 +1,29 @@
 import { getCurrentInstance, onMounted, onBeforeUnmount, nextTick, type Ref } from "vue";
 import { onBeforeRouteLeave } from "vue-router";
+import type { ComponentPublicInstance } from "vue";
 
 /**
  * Persists the scroll position (and infinite-scroll page count) for a list
  * view so that navigating List → Detail → Back restores exactly where the
  * user was.
  *
- * Usage — inside the list component (e.g. NpcList.vue):
+ * Usage A — inside a list component that uses useInfiniteScroll (e.g. NpcList.vue):
  *
  *   const { savedCount, linkCount } = useScrollRestore('npcs')
  *   const { visibleItems, sentinelRef, visibleCount } = useInfiniteScroll(filtered, 48, savedCount)
  *   linkCount(visibleCount)
  *
+ * Usage B — inside a view that renders its list content directly (no child list component):
+ *
+ *   const listRef = ref<HTMLElement | null>(null)
+ *   useScrollRestore('hall-of-heroes', listRef)
+ *   // In template: wrap the list body in <div ref="listRef">
+ *
  * The composable auto-detects the active scroll container at runtime by
- * walking up the DOM — this correctly resolves to the inner
+ * walking up the DOM from either the provided `startRef` element or the
+ * component's own root element. This correctly resolves to the inner
  * `lg:overflow-y-auto` div inside ListPageLayout on desktop, and to the
- * `<main>` element (DefaultLayout) on mobile, with no manual wiring needed.
+ * `<main>` element (DefaultLayout) on mobile.
  *
  * State is kept in a module-level Map (session memory only, never persisted
  * to localStorage) so it survives in-session navigation but is reset on
@@ -39,7 +47,13 @@ function findScrollParent(el: Element): Element | null {
   return null;
 }
 
-export function useScrollRestore(key: string) {
+export function useScrollRestore(
+  key: string,
+  /** Optional ref to an element inside the scroll container — use this when
+   *  calling from a view that renders list content directly rather than
+   *  delegating to a child list component. */
+  startRef?: Ref<HTMLElement | ComponentPublicInstance | null>,
+) {
   const instance = getCurrentInstance();
   let scrollEl: Element | null = null;
   let countRef: Ref<number> | null = null;
@@ -61,7 +75,14 @@ export function useScrollRestore(key: string) {
   }
 
   onMounted(async () => {
-    const root = instance?.proxy?.$el as Element | null;
+    // Prefer the explicitly provided startRef (handles views that render list
+    // content directly and need a reference point inside the scroll container).
+    // Fall back to the component's own root element.
+    const rawRef = startRef?.value;
+    const root: Element | null =
+      rawRef
+        ? ("$el" in rawRef ? (rawRef.$el as Element) : rawRef)
+        : (instance?.proxy?.$el as Element | null);
     if (root) scrollEl = findScrollParent(root);
 
     const saved = states.get(key);

--- a/src/views/HallOfHeroesView.vue
+++ b/src/views/HallOfHeroesView.vue
@@ -29,6 +29,7 @@
       </ListFilterBar>
     </template>
 
+    <div ref="listRef">
     <div v-if="isLoading" class="flex justify-center py-16">
       <LoadingSpinner />
     </div>
@@ -137,6 +138,7 @@
         </div>
       </div>
     </div>
+    </div><!-- /listRef -->
 
     <template v-if="filtered.length" #footer>
       <p class="text-center font-fell text-xs text-muted-foreground">
@@ -149,6 +151,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useRouter } from "vue-router";
+import { useScrollRestore } from "@/composables/useScrollRestore";
 import { IconAdd, IconDelete, IconEdit, IconGenerate } from '@/lib/icons';
 import { useHallOfHeroes, useDeleteHero, useImportHero, usePopulateAllSettingHeroes } from "@/composables/useHallOfHeroes";
 import { useAuthStore } from "@/stores/auth";
@@ -175,6 +178,9 @@ function settingLabel(val: string) {
 }
 
 const router = useRouter();
+const listRef = ref<HTMLElement | null>(null);
+useScrollRestore("hall-of-heroes", listRef);
+
 const auth = useAuthStore();
 const campaign = useCampaignStore();
 const ui = useUiStore();

--- a/src/views/campaign/CampaignSettingsView.vue
+++ b/src/views/campaign/CampaignSettingsView.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col h-full">
     <PageHeader title="Campaign Settings" :subtitle="campaignStore.activeCampaign?.name ?? ''" />
 
-    <div v-if="campaignStore.activeCampaign" class="flex flex-1 min-h-0">
+    <div v-if="campaignStore.activeCampaign" class="flex flex-col md:flex-row flex-1 min-h-0">
       <!-- Sidebar tabs -->
       <aside class="hidden md:flex flex-col w-48 shrink-0 border-r border-border px-3 py-4 gap-0.5">
         <button


### PR DESCRIPTION
## Changes

### 1. Campaign settings broken on mobile
The outer flex container in `CampaignSettingsView.vue` had no direction class, so on mobile the horizontal tab strip and the `<main>` content area ended up side-by-side instead of stacked.

**Fix:** One-line change — `flex flex-1 min-h-0` → `flex flex-col md:flex-row flex-1 min-h-0`

---

### 2. Scroll position lost when navigating back to list views

Navigating List → Detail → Back always snapped to the top of the list, losing both scroll position and any infinite-scroll pages that had been loaded.

**New composable: `useScrollRestore(key)`**

- Module-level `Map<string, { scrollTop, count }>` — session memory only, never persisted to localStorage
- `findScrollParent()` walks up the DOM at runtime to detect the active scroll container — resolves to the `lg:overflow-y-auto` inner div of `ListPageLayout` on desktop, and to `<main>` (DefaultLayout) on mobile, with no manual wiring needed in views or the layout shell
- `onBeforeRouteLeave` saves scroll position + current page depth; `onMounted` restores after `nextTick`
- `linkCount(visibleCount)` connects the infinite-scroll page ref so the correct number of items is rendered before the scroll offset is applied (avoids a blank-below-fold flash)

**`useInfiniteScroll` update**

- Accepts optional `initialCount` parameter (used by `useScrollRestore` to restore page depth)
- Now exposes `visibleCount` ref so the composable can read it on route leave

**Wired into all 6 list components that use infinite scroll:**
`NpcList`, `MonsterList`, `ItemList`, `SpellList`, `SpeciesList`, `BackgroundList`

https://claude.ai/code/session_01WmWq3cCLBKkkRkkaPB9sBa