### PR TITLE
fix: playlist track removal broken on mobile + race condition

### DIFF
--- a/src/components/soundboard/PlaylistEditorDialog.vue
+++ b/src/components/soundboard/PlaylistEditorDialog.vue
@@ -189,6 +189,7 @@ const localType = ref<PlaylistType>("music");
 const localShuffle = ref(false);
 const localRepeat = ref(true);
 const trackList = ref<TrackListItem[]>([]);
+const trackListSeeded = ref(false);
 const addSoundId = ref("");
 const saving = ref(false);
 
@@ -198,6 +199,7 @@ const dialogTitleId = computed(() => playlist ? `edit-playlist-${playlist.id}` :
 watch(
   () => playlist,
   (pl) => {
+    trackListSeeded.value = false;
     if (pl) {
       localName.value = pl.name;
       localType.value = pl.playlist_type;
@@ -214,9 +216,12 @@ watch(
   { immediate: true },
 );
 
-// Populate track list when existing tracks load (edit mode)
+// Populate track list when existing tracks first load (edit mode).
+// Guard with trackListSeeded so background re-fetches don't overwrite
+// changes the user has made since opening the dialog.
 watch(existingTracks, (tracks) => {
-  if (tracks && playlist) {
+  if (tracks && playlist && !trackListSeeded.value) {
+    trackListSeeded.value = true;
     trackList.value = tracks.map((t) => ({
       sound: t.sound,
       localId: t.id,

--- a/src/components/soundboard/PlaylistTrackRow.vue
+++ b/src/components/soundboard/PlaylistTrackRow.vue
@@ -22,7 +22,7 @@
     <!-- Remove button -->
     <button
       type="button"
-      class="shrink-0 text-muted-foreground/40 hover:text-destructive transition-colors opacity-0 group-hover/row:opacity-100"
+      class="shrink-0 text-muted-foreground/40 hover:text-destructive transition-colors opacity-60 group-hover/row:opacity-100"
       title="Remove from playlist"
       @click="$emit('remove')"
     >


### PR DESCRIPTION
## Bug 1: Remove button invisible on mobile

`PlaylistTrackRow.vue` had the remove button styled as `opacity-0 group-hover/row:opacity-100`. On touch devices there is no persistent hover state, so the button was always fully transparent — impossible to see or tap.

**Fix:** Changed to `opacity-60 group-hover/row:opacity-100`. The button is now always visible at reduced opacity and becomes fully opaque on hover/focus.

## Bug 2: Background re-fetch overwrites local track removals

`PlaylistEditorDialog.vue` watched `existingTracks` with no guard:

```typescript
watch(existingTracks, (tracks) => {
  if (tracks && playlist) {
    trackList.value = tracks.map(...) // always overwrites
  }
})
```

After saving, `useReplacePlaylistTracks.onSuccess` calls `invalidateQueries`, which triggers a background re-fetch of `existingTracks`. If the fetch completed while the dialog was still mounted (during the close transition, or if the user re-opened quickly), the watch would fire and overwrite any further local edits the user had made — silently restoring removed tracks.

**Fix:** Added a `trackListSeeded` boolean ref. The watch only populates `trackList` on the first data arrival per playlist (seeded = false → set to true). The flag is reset whenever the target playlist changes, so re-opening the dialog with any playlist always loads fresh data.

https://claude.ai/code/session_01WmWq3cCLBKkkRkkaPB9sBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmWq3cCLBKkkRkkaPB9sBa)_