### PR TITLE
feat: cast soundboard music to Google Home

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,5 +25,10 @@
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
+    <!-- Google Cast Sender SDK — must be loaded before the app bundle so the
+         __onGCastApiAvailable callback fires reliably. Only active in Chrome/Edge;
+         other browsers silently ignore it (no API surface exposed). -->
+    <script>window['__onGCastApiAvailable'] = function(a) { window.__castApiAvailable = a; window.dispatchEvent(new Event('cast-api-available')); };</script>
+    <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
   </body>
 </html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,7 @@ import { useTheme } from "@/composables/useTheme";
 import { useAuthStore } from "@/stores/auth";
 import { updateAvailable, reloadApp } from "@/composables/useAppUpdate";
 import { useMediaSession } from "@/composables/useMediaSession";
+import { useCast } from "@/composables/useCast";
 import { useCampaignStore } from "@/stores/campaign";
 import { useCampaignById } from "@/composables/useCampaigns";
 import { usePullToRefresh } from "@/composables/usePullToRefresh";
@@ -109,6 +110,7 @@ const { pullPx, readyToReload } = usePullToRefresh();
 
 if (!import.meta.env.SSR) useTheme().initTheme();
 if (!import.meta.env.SSR) useMediaSession();
+if (!import.meta.env.SSR) useCast();
 
 // When the Supabase session expires mid-session (refresh token exhausted or
 // network failure), onAuthStateChange emits SIGNED_OUT and sets user to null.

--- a/src/components/soundboard/CastButton.vue
+++ b/src/components/soundboard/CastButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <button
+    v-if="isCastAvailable"
+    class="shrink-0 transition-colors p-0.5"
+    :class="isCasting
+      ? 'text-gold-400 hover:text-gold-300'
+      : 'text-muted-foreground hover:text-foreground'"
+    :title="isCasting
+      ? `Casting to ${castDeviceName ?? 'Google Home'} — click to stop`
+      : 'Cast audio to Google Home'"
+    @click="openDevicePicker()"
+  >
+    <IconCast class="h-3.5 w-3.5" />
+  </button>
+</template>
+
+<script setup lang="ts">
+import { IconCast } from "@/lib/icons";
+import { useCast } from "@/composables/useCast";
+
+const { isCastAvailable, isCasting, castDeviceName, openDevicePicker } = useCast();
+</script>

--- a/src/components/soundboard/SoundboardWidget.vue
+++ b/src/components/soundboard/SoundboardWidget.vue
@@ -20,6 +20,7 @@
         >
           <IconMusicNote class="h-3.5 w-3.5 text-gold-400 shrink-0" />
           <span class="font-cinzel text-xs font-semibold text-foreground flex-1 tracking-wide">Soundboard</span>
+          <CastButton />
           <button
             v-if="store.playingCount > 0 || spotifyStore.isPlaying"
             class="font-fell text-[10px] text-muted-foreground hover:text-destructive transition-colors px-1.5 py-0.5 rounded border border-border hover:border-destructive/40"
@@ -283,6 +284,7 @@ import { useSoundboardStore } from "@/stores/soundboard";
 import { useSpotifyStore } from "@/stores/spotify";
 import { useSounds } from "@/composables/useSounds";
 import SoundEffectPicker from "./SoundEffectPicker.vue";
+import CastButton from "./CastButton.vue";
 
 const store = useSoundboardStore();
 const spotifyStore = useSpotifyStore();

--- a/src/composables/useCast.ts
+++ b/src/composables/useCast.ts
@@ -1,0 +1,353 @@
+/**
+ * Google Cast Sender SDK integration for the soundboard.
+ *
+ * Watches the active music playlist in the soundboard store and mirrors it to a
+ * connected Google Home / Chromecast Audio device using the Default Media Receiver
+ * (no custom receiver app required). Only one audio stream is cast at a time —
+ * music playlists are fully supported; ambient layering is browser-only.
+ *
+ * Call once from App.vue. All state is module-level (singleton) so subsequent
+ * calls to useCast() return the same reactive refs.
+ *
+ * Cast is only available in Chrome/Edge on desktop and Android. Other browsers
+ * silently receive isCastAvailable = false and all methods are no-ops.
+ */
+
+import { ref, computed, watch } from "vue";
+import { useSoundboardStore } from "@/stores/soundboard";
+
+// ── Minimal Cast SDK type declarations ────────────────────────────────────────
+//
+// The Cast Sender SDK has no npm type package. We declare only the subset we use.
+// SDK globals are accessed via window.cast and window.chrome.cast at runtime.
+
+interface CastContextAPI {
+  setOptions(opts: { receiverApplicationId: string; autoJoinPolicy: string }): void;
+  requestSession(): Promise<string | null>;
+  endCurrentSession(stopCasting: boolean): void;
+  getCurrentSession(): CastSessionAPI | null;
+  getCastState(): string;
+  addEventListener(type: string, handler: (e: CastStateEvent | SessionStateEvent) => void): void;
+}
+
+interface CastSessionAPI {
+  getSessionObj(): { receiver?: { friendlyName?: string } } | null;
+  getMediaSession(): { idleReason: string | null } | null;
+  loadMedia(request: CastLoadRequest): Promise<string | null>;
+}
+
+interface CastStateEvent {
+  castState: string;
+}
+
+interface SessionStateEvent {
+  sessionState: string;
+  session?: CastSessionAPI;
+}
+
+interface PlayerStateEvent {
+  value: string;
+}
+
+interface RemotePlayerAPI {
+  isPaused: boolean;
+  playerState: string;
+}
+
+interface RemotePlayerControllerAPI {
+  addEventListener(type: string, handler: (e: PlayerStateEvent) => void): void;
+  playOrPause(): void;
+  stop(): void;
+}
+
+// Cast SDK constructor functions (used with `new`)
+interface CastMediaInfo { metadata: CastMusicMetadata | null; streamType: string }
+interface CastMusicMetadata { title: string; artistName: string; albumName: string; images: CastImage[] }
+interface CastImage { url: string }
+interface CastLoadRequest { autoplay: boolean; currentTime: number }
+
+interface ChromeCastMedia {
+  MediaInfo: new (url: string, contentType: string) => CastMediaInfo;
+  MusicTrackMediaMetadata: new () => CastMusicMetadata;
+  LoadRequest: new (info: CastMediaInfo) => CastLoadRequest;
+  StreamType: { BUFFERED: string };
+  DEFAULT_MEDIA_RECEIVER_APP_ID: string;
+}
+
+interface ChromeCastAPI {
+  media: ChromeCastMedia;
+  Image: new (url: string) => CastImage;
+  AutoJoinPolicy: { ORIGIN_SCOPED: string };
+}
+
+interface CastFramework {
+  CastContext: { getInstance(): CastContextAPI };
+  RemotePlayer: new () => RemotePlayerAPI;
+  RemotePlayerController: new (player: RemotePlayerAPI) => RemotePlayerControllerAPI;
+  CastContextEventType: { SESSION_STATE_CHANGED: string; CAST_STATE_CHANGED: string };
+  RemotePlayerEventType: { PLAYER_STATE_CHANGED: string };
+  CastState: { NO_DEVICES_AVAILABLE: string };
+  SessionState: {
+    SESSION_STARTED: string;
+    SESSION_RESUMED: string;
+    SESSION_ENDED: string;
+    SESSION_START_FAILED: string;
+  };
+}
+
+interface CastWindow {
+  cast?: { framework?: CastFramework };
+  chrome?: { cast?: ChromeCastAPI };
+  __castApiAvailable?: boolean;
+}
+
+// ── Singleton module-level state ──────────────────────────────────────────────
+
+const isCastAvailable = ref(false);
+const castDeviceName = ref<string | null>(null);
+
+// Non-reactive SDK object references (same pattern as audioInstances in soundboard.ts)
+let remotePlayer: RemotePlayerAPI | null = null;
+let playerController: RemotePlayerControllerAPI | null = null;
+let initialized = false;
+
+// ── SDK access helpers ────────────────────────────────────────────────────────
+
+function castFramework(): CastFramework | undefined {
+  return (window as CastWindow).cast?.framework;
+}
+
+function castCtx(): CastContextAPI | null {
+  return castFramework()?.CastContext.getInstance() ?? null;
+}
+
+function chromeCast(): ChromeCastAPI | undefined {
+  return (window as CastWindow).chrome?.cast;
+}
+
+function mimeFromUrl(url: string): string {
+  try {
+    const ext = new URL(url).pathname.split(".").pop()?.toLowerCase();
+    const map: Record<string, string> = {
+      mp3:  "audio/mpeg",
+      ogg:  "audio/ogg",
+      opus: "audio/ogg; codecs=opus",
+      webm: "audio/webm",
+      wav:  "audio/wav",
+      flac: "audio/flac",
+      m4a:  "audio/mp4",
+      aac:  "audio/mp4",
+    };
+    return map[ext ?? ""] ?? "audio/mpeg";
+  } catch {
+    return "audio/mpeg";
+  }
+}
+
+// ── Media loading ─────────────────────────────────────────────────────────────
+
+function loadMedia(
+  url: string,
+  meta: { title: string; artist: string; album: string; thumbnail: string | null },
+): void {
+  const session = castCtx()?.getCurrentSession();
+  if (!session) return;
+
+  const cc = chromeCast();
+  if (!cc) return;
+
+  const mediaInfo = new cc.media.MediaInfo(url, mimeFromUrl(url));
+  mediaInfo.streamType = cc.media.StreamType.BUFFERED;
+
+  const metadata = new cc.media.MusicTrackMediaMetadata();
+  metadata.title = meta.title;
+  metadata.artistName = meta.artist;
+  metadata.albumName = meta.album;
+  if (meta.thumbnail) {
+    metadata.images = [new cc.Image(meta.thumbnail)];
+  }
+  mediaInfo.metadata = metadata;
+
+  const request = new cc.media.LoadRequest(mediaInfo);
+  request.autoplay = true;
+  request.currentTime = 0;
+
+  session.loadMedia(request).catch((err: unknown) => {
+    console.warn("[Cast] loadMedia failed:", err);
+  });
+}
+
+// ── Public interface ──────────────────────────────────────────────────────────
+
+export function useCast() {
+  if (!import.meta.env.SSR && !initialized) {
+    initialized = true;
+    _init();
+  }
+
+  const store = useSoundboardStore();
+
+  return {
+    isCastAvailable,
+    isCasting: computed(() => store.isCasting),
+    castDeviceName,
+    openDevicePicker,
+  };
+}
+
+function openDevicePicker(): void {
+  const store = useSoundboardStore();
+  if (store.isCasting) {
+    castCtx()?.endCurrentSession(true);
+  } else {
+    castCtx()?.requestSession().catch(() => {
+      // User cancelled the device picker or no devices available — ignore
+    });
+  }
+}
+
+// Convenience alias — called from module-scope event handlers that run after
+// Pinia is installed, so the store is always accessible.
+function useCastStore() {
+  return useSoundboardStore();
+}
+
+// ── Initialization (runs once after Cast SDK fires __onGCastApiAvailable) ─────
+
+function _init(): void {
+  window.addEventListener("cast-api-available", onSdkReady, { once: true });
+  if ((window as CastWindow).__castApiAvailable) onSdkReady();
+}
+
+function onSdkReady(): void {
+  const fw = castFramework();
+  if (!fw) return;
+
+  const ctx = fw.CastContext.getInstance();
+  const cc  = chromeCast();
+
+  ctx.setOptions({
+    receiverApplicationId: cc?.media.DEFAULT_MEDIA_RECEIVER_APP_ID ?? "CC1AD845",
+    autoJoinPolicy:        cc?.AutoJoinPolicy.ORIGIN_SCOPED ?? "origin_scoped",
+  });
+
+  remotePlayer     = new fw.RemotePlayer();
+  playerController = new fw.RemotePlayerController(remotePlayer);
+
+  const initialState = ctx.getCastState();
+  isCastAvailable.value = initialState !== fw.CastState.NO_DEVICES_AVAILABLE;
+
+  ctx.addEventListener(fw.CastContextEventType.CAST_STATE_CHANGED, (e) => {
+    isCastAvailable.value = (e as CastStateEvent).castState !== fw.CastState.NO_DEVICES_AVAILABLE;
+  });
+
+  ctx.addEventListener(fw.CastContextEventType.SESSION_STATE_CHANGED, (e) => {
+    onSessionStateChanged(e as SessionStateEvent);
+  });
+
+  playerController.addEventListener(fw.RemotePlayerEventType.PLAYER_STATE_CHANGED, (e) => {
+    onPlayerStateChanged(e);
+  });
+
+  setupStoreWatchers();
+}
+
+function onSessionStateChanged(e: SessionStateEvent): void {
+  const store = useCastStore();
+  const fw    = castFramework();
+  if (!fw) return;
+
+  switch (e.sessionState) {
+    case fw.SessionState.SESSION_STARTED:
+    case fw.SessionState.SESSION_RESUMED: {
+      store.isCasting = true;
+      castDeviceName.value =
+        e.session?.getSessionObj()?.receiver?.friendlyName ?? null;
+
+      const mpl = store.activeMusicPlaylist;
+      if (mpl) {
+        const soundId = mpl.trackSoundIds[mpl.currentIndex];
+        store.pauseForCast(soundId);
+        loadMedia(mpl.fileUrls[soundId], {
+          title:     mpl.soundNames[soundId]    ?? "Unknown Track",
+          artist:    mpl.artists[soundId]       ?? "Dungeon Grimoire",
+          album:     mpl.playlistName,
+          thumbnail: mpl.thumbnailUrls[soundId] ?? null,
+        });
+      }
+      break;
+    }
+
+    case fw.SessionState.SESSION_ENDED:
+    case fw.SessionState.SESSION_START_FAILED: {
+      const wasCasting = store.isCasting;
+      store.isCasting      = false;
+      castDeviceName.value = null;
+
+      if (wasCasting) {
+        const mpl = store.activeMusicPlaylist;
+        if (mpl && !mpl.paused) {
+          const soundId = mpl.trackSoundIds[mpl.currentIndex];
+          store.play(soundId, mpl.fileUrls[soundId]);
+        }
+      }
+      break;
+    }
+  }
+}
+
+function onPlayerStateChanged(e: PlayerStateEvent): void {
+  if (e.value !== "IDLE") return;
+
+  const store = useCastStore();
+  if (!store.isCasting) return;
+
+  const idleReason = castCtx()?.getCurrentSession()?.getMediaSession()?.idleReason;
+  if (idleReason === "FINISHED") {
+    store.musicPlaylistNext();
+  }
+}
+
+// ── Reactive store → Cast sync ────────────────────────────────────────────────
+
+function setupStoreWatchers(): void {
+  const store = useCastStore();
+
+  // New track started (playlist changed or index advanced)
+  watch(
+    () => [store.activeMusicPlaylist?.playlistId, store.activeMusicPlaylist?.currentIndex] as const,
+    ([playlistId, index], prev) => {
+      if (!store.isCasting) return;
+      const mpl = store.activeMusicPlaylist;
+      if (!mpl) return;
+      if (prev?.[0] === playlistId && prev?.[1] === index) return;
+
+      const soundId = mpl.trackSoundIds[mpl.currentIndex];
+      loadMedia(mpl.fileUrls[soundId], {
+        title:     mpl.soundNames[soundId]    ?? "Unknown Track",
+        artist:    mpl.artists[soundId]       ?? "Dungeon Grimoire",
+        album:     mpl.playlistName,
+        thumbnail: mpl.thumbnailUrls[soundId] ?? null,
+      });
+    },
+  );
+
+  // Playlist stopped entirely — stop Cast media but keep the session alive
+  watch(
+    () => store.activeMusicPlaylist,
+    (mpl) => {
+      if (!store.isCasting || mpl !== null) return;
+      playerController?.stop();
+    },
+  );
+
+  // Pause / resume sync
+  watch(
+    () => store.activeMusicPlaylist?.paused,
+    (paused) => {
+      if (!store.isCasting || paused === undefined || !remotePlayer) return;
+      if (paused && !remotePlayer.isPaused) playerController?.playOrPause();
+      if (!paused &&  remotePlayer.isPaused) playerController?.playOrPause();
+    },
+  );
+}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -5,7 +5,7 @@ export type { LucideIcon as AppIcon } from 'lucide-vue-next'
 import {
   AlertCircle, AlertTriangle, AlignCenter, AlignLeft, AlignRight,
   Archive, ArrowUpFromLine, Award, Axe,
-  Backpack, BarChart2, BetweenHorizontalEnd, BetweenVerticalEnd,
+  Backpack, BarChart2, BetweenHorizontalEnd, BetweenVerticalEnd, Cast,
   BookMarked, BookOpen, BookPlus, BookText, BookUser, Bookmark, Box, Brain, BrickWall, Brush, Bug,
   Calendar, CalendarCheck, CalendarDays, CalendarPlus, CalendarX,
   Check, CheckCheck, CheckCircle, ChevronDown, ChevronLeft, ChevronRight, ChevronUp,
@@ -216,6 +216,7 @@ export { Shuffle as IconShuffle }
 export { VolumeX as IconMute }
 export { Music as IconMusic }
 export { Music2 as IconMusicNote }
+export { Cast as IconCast }
 
 // ── Content / Rich Text ───────────────────────────────────────────────────────
 export { AlignLeft as IconAlignLeft }

--- a/src/stores/soundboard.ts
+++ b/src/stores/soundboard.ts
@@ -168,6 +168,10 @@ export const useSoundboardStore = defineStore("soundboard", () => {
   // Floating widget visibility
   const widgetOpen = ref(false);
 
+  // True while a Google Cast session is active — local audio.play() is skipped
+  // so the Cast device plays instead. Set externally by useCast composable.
+  const isCasting = ref(false);
+
   // Active playlist run states
   const activeMusicPlaylist = ref<MusicPlaylistRunState | null>(null);
   const activeAmbientPlaylist = ref<AmbientPlaylistRunState | null>(null);
@@ -216,10 +220,12 @@ export const useSoundboardStore = defineStore("soundboard", () => {
     const state = getState(soundId);
     audio.volume = state.volume;
     audio.loop = state.isLooping;
-    audio.play().catch(() => {
-      // Browser may block autoplay; silently ignore — the button stays in
-      // "stopped" state so the user can retry.
-    });
+    if (!isCasting.value) {
+      audio.play().catch(() => {
+        // Browser may block autoplay; silently ignore — the button stays in
+        // "stopped" state so the user can retry.
+      });
+    }
     state.isPlaying = true;
     audio.ontimeupdate = () => {
       const s = playbackStates.value[soundId];
@@ -517,6 +523,16 @@ export const useSoundboardStore = defineStore("soundboard", () => {
     soundEffects.value[soundId] = preset;
   }
 
+  /**
+   * Pause the local audio element for a sound without touching Pinia state.
+   * Used by the Cast integration to silence local playback when Cast takes over,
+   * while keeping isPlaying = true so the UI reflects that audio is playing (via Cast).
+   */
+  function pauseForCast(soundId: string): void {
+    const audio = audioInstances.get(soundId);
+    if (audio) audio.pause();
+  }
+
   /** Call when a sound is deleted from the library to clean up the engine. */
   function releaseSound(soundId: string): void {
     destroyEffectChain(soundId); // disconnect AudioContext nodes before destroying element
@@ -545,6 +561,7 @@ export const useSoundboardStore = defineStore("soundboard", () => {
     activeMusicPlaylist,
     activeAmbientPlaylist,
     soundEffects,
+    isCasting,
     getState,
     play,
     pause,
@@ -554,6 +571,7 @@ export const useSoundboardStore = defineStore("soundboard", () => {
     toggleLoop,
     stopAll,
     releaseSound,
+    pauseForCast,
     toggleWidget,
     warmup,
     playMusicPlaylist,


### PR DESCRIPTION
## Summary

- Adds a Cast button to the soundboard widget that sends the active music playlist to any Google Home / Chromecast Audio device on the local network, using the Default Media Receiver (no custom receiver app registration required)
- The Cast button appears automatically in Chrome/Edge when Cast devices are on the network, and is hidden in Firefox/Safari where the API is unavailable
- When casting: local `audio.play()` is suppressed, the Google Home fetches and plays the audio URL directly, and the browser acts as a remote control (play/pause/next/prev all sync to the device)
- When the Cast session ends (user disconnects or device powers off), local playback resumes automatically from where it was

## How it works

- `index.html`: loads the Google Cast Sender SDK with the `__onGCastApiAvailable` bootstrap callback
- `src/composables/useCast.ts`: singleton composable that initializes `CastContext`, sets up reactive watchers to sync `activeMusicPlaylist` state to the Cast session, handles track-end events from the device to auto-advance the playlist, and manages session lifecycle
- `src/stores/soundboard.ts`: adds `isCasting` ref (guards `audio.play()` when Cast is active) and `pauseForCast()` to silence the local audio element without touching playback state
- `src/components/soundboard/CastButton.vue`: Cast icon button with gold highlight and device-name tooltip when connected
- `src/components/soundboard/SoundboardWidget.vue`: wires in `CastButton` to the widget header

## Limitations (by design)

- Only the music playlist is cast — ambient layering requires simultaneous streams which need a custom Cast receiver app
- Audio effects (lowpass filter, etc.) are browser-side Web Audio and do not apply on the Cast device
- AirPlay (HomePod) is not handled here — Safari exposes a native AirPlay button on `<audio>` elements automatically, no code needed

https://claude.ai/code/session_01HFdYYeEYy1CnMhsE9DxFzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFdYYeEYy1CnMhsE9DxFzD)_