### PR TITLE
fix: remove audioSession and racy audio re-play regressions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,15 +45,6 @@ export const createApp = ViteSSG(
     setupRouterGuard(router);
 
     if (!import.meta.env.SSR) {
-      // Declare background playback intent for iOS PWA (standalone) mode.
-      // Safari browser manages the audio session automatically for any page that
-      // plays audio. A standalone PWA gets no such treatment — without this hint
-      // iOS assigns a restrictive default session that throttles background audio
-      // and breaks CarPlay routing. 'playback' grants the same priority as music apps.
-      if ("audioSession" in navigator) {
-        (navigator as Navigator & { audioSession: { type: string } }).audioSession.type = "playback";
-      }
-
       // Browser-only imports and setup.
       Promise.all([
         import("./composables/useWakeLock"),

--- a/src/stores/soundboard.ts
+++ b/src/stores/soundboard.ts
@@ -543,25 +543,18 @@ export const useSoundboardStore = defineStore("soundboard", () => {
   }
 
   /**
-   * Resume audio after an OS interruption (screen-lock, phone call, PWA backgrounding).
-   * Resumes the Web Audio graph if iOS suspended it, and re-plays any element that
-   * should be audible but got paused without updating our state.
+   * Resume the Web Audio graph after an OS suspension (screen-lock, PWA backgrounding).
    * Called from useMediaSession on visibilitychange → "visible".
+   *
+   * Only the AudioContext is resumed here. Re-playing HTMLAudioElements that
+   * were paused by an interruption is intentionally omitted: doing so races with
+   * the play() → onended → musicPlaylistNext() chain and can cause an AbortError
+   * that silently kills auto-advance.
    */
   function resumeAudioEngine(): void {
     if (sharedAudioCtx?.state === "suspended") {
       void sharedAudioCtx.resume();
     }
-    if (isCasting.value) return;
-    audioInstances.forEach((audio, id) => {
-      if (playbackStates.value[id]?.isPlaying && audio.paused) {
-        void audio.play().catch(() => {
-          // Play() still requires a user gesture in some contexts; if it fails,
-          // reflect reality rather than lying about the playing state.
-          if (playbackStates.value[id]) playbackStates.value[id].isPlaying = false;
-        });
-      }
-    });
   }
 
   function toggleWidget(): void {


### PR DESCRIPTION
## Regressions fixed from PR #449

### Music stops when webapp loses focus

`navigator.audioSession.type = 'playback'` was intended to tell iOS to keep background audio alive. In practice, Safari treats `'playback'` as requesting **exclusive** audio focus — switching away from the app causes it to pause, which is the opposite of what we wanted. The browser's default automatic audio session management was already working correctly; explicitly setting this made things worse. Removed.

### Auto-advance stops working (requires manual pause/play to recover)

`resumeAudioEngine()` iterated all audio elements and called `audio.play()` on any that were paused but marked as playing. This raced with the `play() → onended → musicPlaylistNext()` chain: when a track ended and the new track's `play()` Promise was still pending, `resumeAudioEngine()` would call `play()` a second time on the same element. The browser rejected this with an `AbortError`, whose catch block set `isPlaying = false` — silently killing auto-advance until the user manually toggled playback.

The audio-element re-play loop is removed. Only the `AudioContext.resume()` call is kept, which is safe and beneficial for effects-based audio after the PWA is backgrounded.

https://claude.ai/code/session_01HFdYYeEYy1CnMhsE9DxFzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFdYYeEYy1CnMhsE9DxFzD)_