### PR TITLE
Fix bottom nav invisible on Firefox Android; move update prompt into menus

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,14 +22,6 @@
     </div>
   </Transition>
 
-  <!-- App update banner — shown instead of a forced reload when a new service worker takes control -->
-  <Transition name="update-slide">
-    <div v-if="updateAvailable" class="update-banner">
-      <span class="update-label">✦ Update available</span>
-      <button class="update-btn" @click="reloadApp">Reload</button>
-      <button class="update-dismiss" aria-label="Dismiss" @click="updateAvailable = false">✕</button>
-    </div>
-  </Transition>
 </template>
 
 <script setup lang="ts">
@@ -47,7 +39,7 @@ import { pendingBundleFile } from "@/composables/usePendingBundle";
 import LoadingScreen from "@/components/auth/LoadingScreen.vue";
 import { useTheme } from "@/composables/useTheme";
 import { useAuthStore } from "@/stores/auth";
-import { updateAvailable, reloadApp } from "@/composables/useAppUpdate";
+
 import { useMediaSession } from "@/composables/useMediaSession";
 import { useCampaignStore } from "@/stores/campaign";
 import { useCampaignById } from "@/composables/useCampaigns";
@@ -207,72 +199,5 @@ const layout = computed(() => {
   opacity: 0;
 }
 
-/* ── App update banner ─────────────────────────────────────────────── */
-.update-banner {
-  position: fixed;
-  /* Float above the player bottom nav when it's present (--bottom-nav-h is set
-     by PlayerLayout on mount); fall back to 1.25rem on layouts without a nav. */
-  bottom: calc(var(--bottom-nav-h, 0px) + 1.25rem);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-  white-space: nowrap;
-  box-shadow: 0 4px 16px hsl(0 0% 0% / 0.25);
-}
 
-.update-label {
-  font-family: var(--font-cinzel, sans-serif);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.update-btn {
-  font-family: var(--font-cinzel, sans-serif);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 0.2rem 0.75rem;
-  border-radius: 999px;
-  background: hsl(var(--primary-foreground));
-  color: hsl(var(--primary));
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.update-btn:hover {
-  opacity: 0.9;
-}
-
-.update-dismiss {
-  background: transparent;
-  border: none;
-  color: hsl(var(--primary-foreground) / 0.7);
-  cursor: pointer;
-  font-size: 12px;
-  padding: 0;
-  line-height: 1;
-}
-
-.update-dismiss:hover {
-  color: hsl(var(--primary-foreground));
-}
-
-.update-slide-enter-active,
-.update-slide-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-.update-slide-enter-from,
-.update-slide-leave-to {
-  opacity: 0;
-  transform: translateX(-50%) translateY(0.75rem);
-}
 </style>

--- a/src/components/layout/DmBottomNav.vue
+++ b/src/components/layout/DmBottomNav.vue
@@ -3,7 +3,7 @@
        left sidebar. Only DMs see it; players have their own portal nav. -->
   <nav
     v-if="isDm"
-    class="fixed inset-x-0 bottom-0 z-40 grid grid-cols-5 items-end border-t border-border bg-card/95 px-1.5 backdrop-blur md:hidden"
+    class="fixed inset-x-0 bottom-0 z-40 grid grid-cols-5 items-end border-t border-border bg-card px-1.5 md:hidden"
     :style="barStyle"
   >
     <template v-for="slot in barSlots" :key="slot.key">

--- a/src/components/layout/DmNavMoreSheet.vue
+++ b/src/components/layout/DmNavMoreSheet.vue
@@ -69,6 +69,16 @@
     <p class="mt-4 px-1 text-center text-2xs font-fell text-muted-foreground/60">
       Dot = currently pinned to the {{ ui.dmMode }} bar.
     </p>
+
+    <button
+      v-if="updateAvailable"
+      type="button"
+      class="mt-4 flex w-full items-center justify-center gap-2 rounded-md border border-primary/40 bg-primary/10 px-3 py-3 font-cinzel text-xs font-bold tracking-wider text-primary transition-colors hover:bg-primary/20"
+      @click="reloadApp"
+    >
+      <IconRefresh class="h-4 w-4 shrink-0" />
+      Reload to update
+    </button>
   </MobileSheet>
 </template>
 
@@ -76,8 +86,9 @@
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import MobileSheet from "@/components/common/MobileSheet.vue";
-import { IconAdd } from "@/lib/icons";
+import { IconAdd, IconRefresh } from "@/lib/icons";
 import { NAV_GROUPS, type NavItem } from "@/lib/nav";
+import { updateAvailable, reloadApp } from "@/composables/useAppUpdate";
 import { useUiStore } from "@/stores/ui";
 import { useCampaignStore } from "@/stores/campaign";
 import { useOptionalRules, isRuleEffectivelyEnabled } from "@/composables/useOptionalRules";

--- a/src/components/layout/PlayerNavGrid.vue
+++ b/src/components/layout/PlayerNavGrid.vue
@@ -17,12 +17,24 @@
         <span class="font-cinzel text-2xs md:text-xs tracking-wider text-center leading-tight">{{ item.label }}</span>
       </RouterLink>
     </div>
+
+    <button
+      v-if="updateAvailable"
+      type="button"
+      class="mt-4 flex w-full items-center justify-center gap-2 rounded-md border border-primary/40 bg-primary/10 px-3 py-3 font-cinzel text-xs font-bold tracking-wider text-primary transition-colors hover:bg-primary/20"
+      @click="reloadApp"
+    >
+      <IconRefresh class="h-4 w-4 shrink-0" />
+      Reload to update
+    </button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useRoute } from "vue-router";
+import { IconRefresh } from "@/lib/icons";
 import { usePlayerNavPrefs } from "@/composables/usePlayerNavPrefs";
+import { updateAvailable, reloadApp } from "@/composables/useAppUpdate";
 
 defineEmits<{
   close: [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,13 @@ export const createApp = ViteSSG(
         window.addEventListener("load", () => {
           navigator.serviceWorker.register("/sw.js").catch(() => {});
         });
+        // Capture whether a SW was already controlling the page BEFORE we add
+        // the listener. controllerchange also fires on first install (when
+        // clients.claim() runs), which is not an update — only treat it as one
+        // if there was a previous controller.
+        const hadController = !!navigator.serviceWorker.controller;
         navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (!hadController) return;
           const p = window.location.pathname;
           // Auth pages reload immediately — the user isn't mid-task and the
           // fresh SW is needed to serve up-to-date login/signup assets.
@@ -96,9 +102,8 @@ export const createApp = ViteSSG(
             window.location.reload();
             return;
           }
-          // For all other pages, surface a banner instead of force-reloading.
-          // The new service worker is already active and will serve fresh assets
-          // for any subsequent fetches; the user can reload at a convenient moment.
+          // For all other pages, signal via updateAvailable so the More menus
+          // can surface a "Reload to update" action at the user's convenience.
           updateAvailable.value = true;
         });
       }


### PR DESCRIPTION
## Summary

- **Firefox Android invisible nav**: `DmBottomNav` used `bg-card/95 backdrop-blur`. Firefox for Android has a compositing bug where `backdrop-filter` causes the element's own background to fail rendering entirely, making the nav invisible. Replaced with solid `bg-card`.
- **Update prompt false positives**: The `controllerchange` event fires on first SW install (when `clients.claim()` runs) as well as on actual updates. Added a `hadController` guard so the prompt only shows when a *new* version replaces a previous one.
- **Less intrusive update UX**: Removed the floating banner overlay. A "Reload to update" button now appears at the bottom of the DM More sheet and Player nav grid — only visible when an update is actually available, and only when the user opens the menu.

## Test plan

- [ ] Open the app on Android Firefox as a DM — bottom nav should be visible on the dashboard
- [ ] Open the app fresh (first install / incognito) — no "update available" prompt should appear
- [ ] Deploy a new version to trigger an actual SW update — prompt should appear in the More menu
- [ ] Tap "Reload to update" in DM or Player More menu — page reloads with new version

https://claude.ai/code/session_01Lgtzx7SHrhdmRbH6vHdqZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgtzx7SHrhdmRbH6vHdqZd)_