### PR TITLE
feat: soundboard free vs pro tier gating

### DIFF
--- a/src/components/admin/AdminPlansTab.vue
+++ b/src/components/admin/AdminPlansTab.vue
@@ -163,7 +163,7 @@ watch(
 );
 
 function defaultQuotaRecord(): Record<QuotaResource, number> {
-  return { campaigns: 0, npcs: 0, monsters: 0, encounters: 0, scriptorium_documents: 0, notes: 0 };
+  return { campaigns: 0, npcs: 0, monsters: 0, encounters: 0, scriptorium_documents: 0, notes: 0, sounds: 0, soundboard_pages: 0, soundboard_playlists: 0 };
 }
 
 async function savePlanQuotas(plan: Plan) {

--- a/src/components/common/PaywallModal.vue
+++ b/src/components/common/PaywallModal.vue
@@ -150,6 +150,7 @@ const limitText = computed(() => {
 const BENEFITS = [
   "Unlimited campaigns, NPCs, monsters, encounters & notes",
   "AI generation — NPCs, monsters, items, spells & artwork",
+  "Soundboard uploads, AI music, and unlimited pages & playlists",
   "Full world-building, combat, and publishing toolkit",
   "Your whole table plays free — always",
 ]

--- a/src/components/soundboard/PlaylistsPanel.vue
+++ b/src/components/soundboard/PlaylistsPanel.vue
@@ -7,11 +7,14 @@
         <template v-else>All playlists in this campaign.</template>
       </p>
       <button
-        class="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border font-cinzel text-xs tracking-wide text-muted-foreground hover:text-foreground hover:border-border/80 transition-colors"
-        @click="showEditor = true"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border font-cinzel text-xs tracking-wide text-muted-foreground hover:text-foreground hover:border-border/80 transition-colors relative"
+        :title="canCreatePlaylist ? undefined : 'Pro feature — upgrade for unlimited playlists'"
+        @click="openNewPlaylist()"
       >
         <IconAdd class="h-3.5 w-3.5" />
         New Playlist
+        <span v-if="playlistQuota && !playlistQuota.unlimited" class="font-fell text-[10px] tabular-nums opacity-60">{{ playlistQuota.current }}/{{ playlistQuota.limit }}</span>
+        <span v-if="!canCreatePlaylist" class="absolute -top-1.5 -right-1.5 px-1 rounded text-[9px] font-cinzel bg-amber-500 text-black leading-4">PRO</span>
       </button>
     </div>
 
@@ -30,7 +33,7 @@
       </p>
       <button
         class="mt-2 px-4 py-2 rounded-md border border-gold-500/30 font-cinzel text-xs tracking-wide text-gold-400 hover:bg-gold-500/10 transition-colors"
-        @click="showEditor = true"
+        @click="openNewPlaylist()"
       >
         Create Playlist
       </button>
@@ -54,6 +57,8 @@
       :page-id="pageId"
       @close="closeEditor"
     />
+
+    <PaywallModal v-model="showPlaylistPaywall" resource="soundboard_playlists" />
   </div>
 </template>
 
@@ -62,8 +67,10 @@ import { ref, computed } from "vue";
 import { IconAdd, IconListOrdered } from "@/lib/icons";
 import { usePlaylists, useDeletePlaylist } from "@/composables/useSoundboardPlaylists";
 import { useSoundboardStore } from "@/stores/soundboard";
+import { useQuota } from "@/composables/useQuota";
 import type { SoundboardPlaylist } from "@/types/sound.types";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
+import PaywallModal from "@/components/common/PaywallModal.vue";
 import PlaylistCard from "./PlaylistCard.vue";
 import PlaylistEditorDialog from "./PlaylistEditorDialog.vue";
 
@@ -72,6 +79,8 @@ const { pageId } = defineProps<{ pageId: string | null }>();
 const { data: playlists, isPending } = usePlaylists();
 const { mutate: deletePlaylist } = useDeletePlaylist();
 const store = useSoundboardStore();
+const { canCreate: canCreatePlaylist, quota: playlistQuota } = useQuota("soundboard_playlists");
+const showPlaylistPaywall = ref(false);
 
 const showEditor = ref(false);
 const editTarget = ref<SoundboardPlaylist | null>(null);
@@ -82,6 +91,11 @@ const visible = computed(() => {
   if (pageId === null) return all;
   return all.filter((pl) => pl.page_id === pageId || pl.page_id === null);
 });
+
+function openNewPlaylist() {
+  if (!canCreatePlaylist.value) { showPlaylistPaywall.value = true; return; }
+  showEditor.value = true;
+}
 
 function startEdit(pl: SoundboardPlaylist) {
   editTarget.value = pl;

--- a/src/components/soundboard/SoundForm.vue
+++ b/src/components/soundboard/SoundForm.vue
@@ -59,15 +59,19 @@
         </button>
         <button
           type="button"
-          class="flex-1 py-1.5 rounded-md border text-xs font-cinzel tracking-wide transition-colors"
+          class="flex-1 py-1.5 rounded-md border text-xs font-cinzel tracking-wide transition-colors relative"
           :class="
             activeSourceTab === 'upload'
               ? 'bg-gold-500/20 border-gold-500/60 text-gold-300'
-              : 'border-border text-muted-foreground hover:text-foreground'
+              : isPro
+                ? 'border-border text-muted-foreground hover:text-foreground'
+                : 'border-border text-muted-foreground/40 cursor-not-allowed'
           "
-          @click="onUploadTabClick"
+          :title="isPro ? undefined : 'Pro feature — upgrade to upload your own audio files'"
+          @click="isPro ? onUploadTabClick() : undefined"
         >
           Upload
+          <span v-if="!isPro" class="absolute -top-1.5 -right-1.5 px-1 rounded text-[9px] font-cinzel bg-amber-500 text-black leading-4">PRO</span>
         </button>
         <button
           v-if="spotifyStore.isEnabled"
@@ -85,15 +89,19 @@
         <button
           v-if="geminiApiKey || campaignId"
           type="button"
-          class="flex-1 py-1.5 rounded-md border text-xs font-cinzel tracking-wide transition-colors"
+          class="flex-1 py-1.5 rounded-md border text-xs font-cinzel tracking-wide transition-colors relative"
           :class="
             activeSourceTab === 'generate'
               ? 'bg-violet-500/20 border-violet-500/60 text-violet-300'
-              : 'border-border text-muted-foreground hover:text-foreground'
+              : isPro
+                ? 'border-border text-muted-foreground hover:text-foreground'
+                : 'border-border text-muted-foreground/40 cursor-not-allowed'
           "
-          @click="activeSourceTab = 'generate'"
+          :title="isPro ? undefined : 'Pro feature — upgrade to generate AI music'"
+          @click="isPro ? (activeSourceTab = 'generate') : undefined"
         >
           Generate
+          <span v-if="!isPro" class="absolute -top-1.5 -right-1.5 px-1 rounded text-[9px] font-cinzel bg-amber-500 text-black leading-4">PRO</span>
         </button>
         <button
           type="button"
@@ -281,6 +289,7 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from "vue";
 import { useCreateSound, useSoundUpload } from "@/composables/useSounds";
 import { useSpotifyStore } from "@/stores/spotify";
+import { useSubscription } from "@/composables/useSubscription";
 import { generateMusicWithLyria, structureMusicPrompt, LYRIA_MODELS, LYRICS_MAX_CHARS, type LyriaModel } from "@/lib/aiMusic";
 import { logUsage, useAiCredits } from "@/composables/useAiCredits";
 import { supabase } from "@/lib/supabase";
@@ -289,6 +298,7 @@ import type { SoundCategory } from "@/types/sound.types";
 
 const spotifyStore = useSpotifyStore();
 const { costOf } = useAiCredits();
+const { isPro } = useSubscription();
 
 const { pageId = null, geminiApiKey = null, campaignId = null } = defineProps<{
   pageId?: string | null;

--- a/src/components/soundboard/SoundboardPageTabs.vue
+++ b/src/components/soundboard/SoundboardPageTabs.vue
@@ -100,14 +100,17 @@
 
     <!-- Add page button -->
     <button
-      class="shrink-0 flex items-center gap-1 px-2 py-1 rounded-md border border-dashed border-border text-xs font-cinzel text-muted-foreground hover:text-foreground hover:border-border/80 transition-colors"
-      title="Add page"
+      class="shrink-0 flex items-center gap-1 px-2 py-1 rounded-md border border-dashed border-border text-xs font-cinzel text-muted-foreground hover:text-foreground hover:border-border/80 transition-colors relative"
+      :title="canCreatePage ? 'Add page' : 'Pro feature — upgrade to create multiple soundboard pages'"
       @click="addPage"
     >
       <IconAdd class="h-3 w-3" />
       Add Page
+      <span v-if="!canCreatePage" class="absolute -top-1.5 -right-1.5 px-1 rounded text-[9px] font-cinzel bg-amber-500 text-black leading-4">PRO</span>
     </button>
   </div>
+
+  <PaywallModal v-model="showPagePaywall" resource="soundboard_pages" />
 </template>
 
 <script setup lang="ts">
@@ -121,6 +124,8 @@ import {
   useDeleteSoundboardPage,
   useReorderSoundboardPages,
 } from "@/composables/useSoundboardPages";
+import { useQuota } from "@/composables/useQuota";
+import PaywallModal from "@/components/common/PaywallModal.vue";
 import type { SoundboardPage } from "@/types/sound.types";
 
 const activePageId = defineModel<string | null>({ required: true });
@@ -132,6 +137,8 @@ const { mutate: createPage } = useCreateSoundboardPage();
 const { mutate: updatePage } = useUpdateSoundboardPage();
 const { mutate: deletePage_m } = useDeleteSoundboardPage();
 const { mutate: reorderPages } = useReorderSoundboardPages();
+const { canCreate: canCreatePage } = useQuota("soundboard_pages");
+const showPagePaywall = ref(false);
 
 // Local ordered copy for drag-and-drop
 const orderedPages = ref<SoundboardPage[]>([]);
@@ -199,6 +206,7 @@ onBeforeUnmount(() => {
 // ── Add ───────────────────────────────────────────────────────────────────
 
 function addPage() {
+  if (!canCreatePage.value) { showPagePaywall.value = true; return; }
   const nextOrder = (orderedPages.value.at(-1)?.sort_order ?? -1) + 1;
   createPage(
     { name: "New Page", sort_order: nextOrder },

--- a/src/types/subscription.types.ts
+++ b/src/types/subscription.types.ts
@@ -28,6 +28,9 @@ export type QuotaResource =
   | 'encounters'
   | 'scriptorium_documents'
   | 'notes'
+  | 'sounds'
+  | 'soundboard_pages'
+  | 'soundboard_playlists'
 
 export const QUOTA_RESOURCE_LABELS: Record<QuotaResource, string> = {
   campaigns:             'Campaigns',
@@ -36,6 +39,9 @@ export const QUOTA_RESOURCE_LABELS: Record<QuotaResource, string> = {
   encounters:            'Encounters',
   scriptorium_documents: 'Scriptorium documents',
   notes:                 'Notes',
+  sounds:                'Sounds',
+  soundboard_pages:      'Soundboard pages',
+  soundboard_playlists:  'Playlists',
 } as const
 
 export interface UserSubscription {

--- a/src/views/soundboard/SoundboardView.vue
+++ b/src/views/soundboard/SoundboardView.vue
@@ -32,9 +32,9 @@
       <ListActionButton
         v-if="ui.soundboardViewMode === 'sounds'"
         :icon="IconAdd"
-        label="Add Sound"
+        :label="soundQuota?.unlimited === false ? `Add Sound (${soundQuota.current}/${soundQuota.limit})` : 'Add Sound'"
         variant="primary"
-        @click="showForm = !showForm"
+        @click="openAddSound()"
       />
     </template>
 
@@ -95,6 +95,8 @@
       @close="showForm = false"
     />
 
+    <PaywallModal v-model="showSoundPaywall" resource="sounds" />
+
     <!-- Loading -->
     <LoadingSpinner v-if="isPending" />
 
@@ -105,7 +107,7 @@
       title="No sounds yet"
       description="Add ambient tracks, music, and effects for your sessions."
       action-label="Add Sound"
-      @action="showForm = true"
+      @action="openAddSound()"
     />
 
     <div
@@ -166,6 +168,7 @@ import { useSoundboardPages, useCreateSoundboardPage } from "@/composables/useSo
 import { useSoundboardStore } from "@/stores/soundboard";
 import { useSpotifyStore } from "@/stores/spotify";
 import { useUiStore } from "@/stores/ui";
+import { useQuota } from "@/composables/useQuota";
 import { storeToRefs } from "pinia";
 import { useCampaignStore } from "@/stores/campaign";
 import type { Sound } from "@/types/sound.types";
@@ -175,6 +178,7 @@ import ListFilterBar from "@/components/common/ListFilterBar.vue";
 import ListSearchInput from "@/components/common/ListSearchInput.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
+import PaywallModal from "@/components/common/PaywallModal.vue";
 import SoundCard from "@/components/soundboard/SoundCard.vue";
 import AddSoundDialog from "@/components/soundboard/AddSoundDialog.vue";
 import SoundCategoryFilter from "@/components/soundboard/SoundCategoryFilter.vue";
@@ -185,6 +189,8 @@ import PlaylistsPanel from "@/components/soundboard/PlaylistsPanel.vue";
 const ui = useUiStore();
 const soundboardStore = useSoundboardStore();
 const spotifyStore = useSpotifyStore();
+const { canCreate: canCreateSound, quota: soundQuota } = useQuota("sounds");
+const showSoundPaywall = ref(false);
 const campaignStore = useCampaignStore();
 const { activeCampaignId } = storeToRefs(campaignStore);
 const geminiApiKey = computed(() => campaignStore.decryptedGeminiKey || null);
@@ -215,6 +221,11 @@ watch(
 );
 
 const showForm = ref(false);
+
+function openAddSound() {
+  if (!canCreateSound.value) { showSoundPaywall.value = true; return; }
+  showForm.value = true;
+}
 
 // Page to assign new sounds to:
 // - specific page active → use it

--- a/supabase/migrations/20260614000001_soundboard_free_tier_quotas.sql
+++ b/supabase/migrations/20260614000001_soundboard_free_tier_quotas.sql
@@ -1,0 +1,85 @@
+-- Migration: soundboard_free_tier_quotas
+-- Add quota enforcement for sounds, soundboard_pages, and soundboard_playlists; gate uploads/AI generation behind Pro
+
+-- ── 1. Extend check_quota to accept soundboard resource types ──────────────
+
+create or replace function "public"."check_quota"("resource_type" "text") returns "jsonb"
+    language "plpgsql" security definer
+    set "search_path" to 'public'
+    as $_$
+declare
+  v_quotas  jsonb;
+  v_limit   int;
+  v_current int;
+begin
+  -- App admins are always unlimited — short-circuit before any DB work
+  if (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin' then
+    return jsonb_build_object('allowed', true, 'current', 0, 'limit', -1, 'unlimited', true);
+  end if;
+
+  -- Validate resource_type to prevent arbitrary table scanning via dynamic SQL
+  if resource_type not in (
+    'campaigns', 'npcs', 'monsters', 'encounters', 'scriptorium_documents', 'notes',
+    'sounds', 'soundboard_pages', 'soundboard_playlists'
+  ) then
+    raise exception 'invalid resource_type: %', resource_type;
+  end if;
+
+  -- Look up the user's plan quotas; default to free if no subscription row exists
+  select p.quotas
+    into v_quotas
+    from user_subscriptions s
+    join plans p on p.id = s.plan_id
+   where s.user_id = auth.uid()
+     and s.status in ('active', 'trialing');
+
+  if not found then
+    select quotas into v_quotas from plans where id = 'free';
+  end if;
+
+  -- Missing key in quotas JSONB = unlimited (pro plan has empty {})
+  if not (v_quotas ? resource_type) then
+    return jsonb_build_object('allowed', true, 'current', 0, 'limit', -1, 'unlimited', true);
+  end if;
+
+  v_limit := (v_quotas ->> resource_type)::int;
+
+  -- Count the user's current rows in the relevant table
+  execute format('select count(*) from %I where user_id = $1', resource_type)
+    into v_current using auth.uid();
+
+  return jsonb_build_object(
+    'allowed',   v_current < v_limit,
+    'current',   v_current,
+    'limit',     v_limit,
+    'unlimited', false
+  );
+end;
+$_$;
+
+-- ── 2. Enforce quota on insert for soundboard tables ──────────────────────
+
+create or replace trigger "sounds_enforce_quota"
+  before insert on "public"."sounds"
+  for each row execute function "public"."enforce_quota"();
+
+create or replace trigger "soundboard_pages_enforce_quota"
+  before insert on "public"."soundboard_pages"
+  for each row execute function "public"."enforce_quota"();
+
+create or replace trigger "soundboard_playlists_enforce_quota"
+  before insert on "public"."soundboard_playlists"
+  for each row execute function "public"."enforce_quota"();
+
+-- ── 3. Set free plan quotas for soundboard resources ─────────────────────
+-- sounds: 20, soundboard_pages: 1, soundboard_playlists: 3
+-- Uses jsonb_set chain to merge into existing quotas without overwriting them.
+
+update "public"."plans"
+set quotas = quotas
+  || jsonb_build_object(
+       'sounds',               20,
+       'soundboard_pages',      1,
+       'soundboard_playlists',  3
+     )
+where id = 'free';


### PR DESCRIPTION
## Summary

- **Free users**: up to 20 sounds (URL / Freesound / Spotify only), 1 soundboard page, 3 playlists
- **Pro users**: unlimited sounds, pages, and playlists + file uploads and AI music generation
- Upload and Generate tabs in the Add Sound dialog show a PRO badge and are disabled for free accounts
- Add Sound / New Playlist / Add Page buttons open `PaywallModal` when the quota is reached
- Sound count is shown in the Add Sound button label while under the limit (e.g. `Add Sound (12/20)`)
- Playlist count shown inline in the New Playlist button

## Changes

- `supabase/migrations/20260614000001_soundboard_free_tier_quotas.sql` — extends `check_quota()` to accept `sounds`, `soundboard_pages`, and `soundboard_playlists`; adds `enforce_quota` triggers to those three tables; seeds free plan quotas (`sounds: 20`, `soundboard_pages: 1`, `soundboard_playlists: 3`)
- `src/types/subscription.types.ts` — adds three new `QuotaResource` values + labels
- `src/components/soundboard/SoundForm.vue` — gates Upload and Generate tabs behind `isPro`
- `src/views/soundboard/SoundboardView.vue` — `useQuota('sounds')` + `PaywallModal`
- `src/components/soundboard/SoundboardPageTabs.vue` — `useQuota('soundboard_pages')` + `PaywallModal`
- `src/components/soundboard/PlaylistsPanel.vue` — `useQuota('soundboard_playlists')` + `PaywallModal`
- `src/components/admin/AdminPlansTab.vue` — `defaultQuotaRecord()` updated with new keys
- `src/components/common/PaywallModal.vue` — benefits list mentions soundboard

## Test plan

- [ ] As free user: Upload tab shows PRO badge, clicking it does nothing
- [ ] As free user: Generate tab shows PRO badge, clicking it does nothing
- [ ] As free user: Add Page shows PRO badge, clicking opens PaywallModal
- [ ] As free user at 3 playlists: New Playlist button opens PaywallModal
- [ ] As free user at 20 sounds: Add Sound button opens PaywallModal
- [ ] As pro user: all tabs and buttons work normally
- [ ] `supabase db push` applies the migration cleanly

https://claude.ai/code/session_01HFdYYeEYy1CnMhsE9DxFzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFdYYeEYy1CnMhsE9DxFzD)_