### PR TITLE
ci: Supabase migration validate (PR) + deploy (main) workflow

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,64 @@
+name: Supabase Migrations
+
+# Two jobs:
+#   • validate — on every PR that touches a migration, boot a throwaway local
+#     Postgres and apply ALL migrations from scratch. If any migration fails to
+#     apply cleanly, the job (and the PR check) fails. This is the pre-merge gate.
+#   • deploy   — on merge to main (migration touched), link the production project
+#     and `supabase db push` the new migrations to the remote DB.
+#
+# ⚠️ REQUIRED SECRETS — set these in the repo before enabling (Settings → Secrets
+#    and variables → Actions). Until they exist, the `deploy` job will fail:
+#      SUPABASE_ACCESS_TOKEN   Personal access token (supabase.com/dashboard/account/tokens)
+#      PRODUCTION_DB_PASSWORD  The production database password
+#      PRODUCTION_PROJECT_ID   The production project ref (the 20-char ref from the
+#                              project URL / dashboard — NOT the local "grimoire" alias)
+#    The `validate` job needs no secrets (it only runs a local Postgres).
+
+on:
+  pull_request:
+    paths:
+      - "supabase/migrations/**"
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+  workflow_dispatch:
+
+jobs:
+  # ── PR gate: apply every migration to a fresh local DB ──────────────────────
+  validate:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # `db start` boots the local Postgres and applies all migrations in order;
+      # a broken migration fails the step, blocking the merge.
+      - name: Apply migrations to a throwaway local DB
+        run: supabase db start
+
+  # ── Deploy: push migrations to production on merge to main ──────────────────
+  deploy:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link the production project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Push migrations to production
+        run: supabase db push


### PR DESCRIPTION
Adds `.github/workflows/supabase-migrations.yml` with two jobs:

- **validate** — on any PR that touches `supabase/migrations/**`, boots a throwaway local Postgres and applies **all** migrations from scratch (`supabase db start`). A migration that fails to apply cleanly fails the PR check. This is the pre-merge gate (replaces the manual dry-run-against-prod step). Needs **no secrets**.
- **deploy** — on merge to `main` (migration touched), links the production project and runs `supabase db push`.

> [!WARNING]
> **The `deploy` job will fail until you add these three repository secrets** (Settings → Secrets and variables → Actions). I've assumed the names below — rename in the workflow if you prefer different ones:
>
> | Secret | What it is | Where to find it |
> | --- | --- | --- |
> | `SUPABASE_ACCESS_TOKEN` | Personal access token for the CLI | supabase.com/dashboard/account/tokens |
> | `PRODUCTION_DB_PASSWORD` | The production database password | Project → Settings → Database (reset if unknown) |
> | `PRODUCTION_PROJECT_ID` | The production **project ref** (20-char string in the project URL) — **not** the local `grimoire` alias in `config.toml` | Project → Settings → General (Reference ID) |
>
> Until the secrets exist, **merging still works** but the `deploy` run red-Xes. The `validate` job runs regardless. You said you'd need to go look these up — this PR is safe to leave open until then.

Kept deliberately separate from the ~49 unpushed player-journey commits on `main`, as requested — this branch is off `origin/main` and contains only the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)