### PR TITLE
fix(build): remove stray </content> tag breaking main build

### DIFF
--- a/src/components/items/WeaponMasteryBadge.vue
+++ b/src/components/items/WeaponMasteryBadge.vue
@@ -43,4 +43,3 @@ const { is2024 } = useRuleset();
 
 const def = computed(() => (mastery ? WEAPON_MASTERY_DEFINITIONS[mastery] : null));
 </script>
-</content>


### PR DESCRIPTION
## Summary

The `main` build was failing. Root cause: `src/components/items/WeaponMasteryBadge.vue` had a stray `</content>` tag left after `</script>` — an editing artifact. The Vue SFC compiler rejects it as an *"Invalid end tag"*, aborting `vite build` during the transform phase.

Because the build never wrote `dist/`, the custom `grimoire-sw` service-worker plugin's `closeBundle` hook then threw a secondary `ENOENT: no such file or directory, scandir '.../dist'`, which masked the real cause in the CI output.

`vue-tsc` passed (it doesn't flag this template artifact the way the rolldown/Vue SFC build path does), so only `vite build` surfaced it.

## Fix

Removed the single stray `</content>` line. No behavioral change to the component.

## Verification

- `npm run build` — ✓ succeeds, `dist/` produced, `grimoire-sw` plugin runs (`SW built: 420 precached`)
- `npm run lint` — ✓ passes
- `npm test -- --run` — ✓ 1115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqRbW35VPpnCoPKqqFCCaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqRbW35VPpnCoPKqqFCCaH)_