### PR TITLE
Email players on shared session notes & new date proposals; fix stale past proposals in UI

### DIFF
--- a/context/features/campaign-notes-calendar.md
+++ b/context/features/campaign-notes-calendar.md
@@ -151,7 +151,7 @@ All note creation and editing happens here. Key integrations:
 
 2. **`InlineCalendarEventModal`** (`src/components/calendar/InlineCalendarEventModal.vue`) — triggered by the calendar toolbar button; on `@event-created` calls `rteRef.value?.insertCalendarEventRef(...)` to embed a `CalendarEventRef` chip in the note body
 
-3. **`PlayerVisibilityToggle`** (`src/components/common/PlayerVisibilityToggle.vue`) — controls `player_visible_to: string[]` (party member IDs). When a note is newly shared on save, `sendCampaignAnnouncement` from `src/composables/useCampaignBroadcast.ts` broadcasts a message to players
+3. **`PlayerVisibilityToggle`** (`src/components/common/PlayerVisibilityToggle.vue`) — controls `player_visible_to: string[]` (party member IDs). When a note is newly shared on save, `sendCampaignAnnouncement` from `src/composables/useCampaignBroadcast.ts` broadcasts a message to players, and `notifyNoteShared` from `src/composables/useEmailNotify.ts` emails the newly added players (see [notifications.md](notifications.md))
 
 4. **Session date sync — `syncSessionCalendarEvent(noteId)`** — called after every save when `category === "session"`:
    - If start date is present: creates or updates a `session`-type calendar event (colour `#C9920A`) linked to the note via `linked_note_id`; patches note's `linked_calendar_event_id`

--- a/context/features/index.md
+++ b/context/features/index.md
@@ -28,6 +28,7 @@ Each doc covers **both DM and player perspectives**, lists exact file paths, com
 | [player-portal.md](player-portal.md)                     | The full player experience: all /play/\* views, layout, nav, live encounter panel, DM Preview Mode                                               |
 | [collaboration.md](collaboration.md)                     | Multi-user invite system, campaign members, DM/player roles, live sync, RLS security model                                                       |
 | [soundboard.md](soundboard.md)                           | Soundboard: HTML/Web Audio engine, pages/playlists, five sound sources, Spotify/Cast/Media Session, free-tier quotas — DM-only, no player access |
+| [notifications.md](notifications.md)                     | Player email notifications (note shared, session date proposed), per-user opt-out, send-notification-email edge function + Resend setup          |
 
 Adding or changing an AI generator? Read
 [../compliance/ai-act.md](../compliance/ai-act.md) first — the AI Act

--- a/context/features/notifications.md
+++ b/context/features/notifications.md
@@ -51,6 +51,13 @@ the accepted cost — do not "fix" this by adding a trigger.
 Emails contain the note/session **title only**, never note content — no
 TipTap-JSON rendering server-side, and nothing sensitive in inboxes.
 
+Note emails **deep-link the exact note**:
+`/play/journal?tab=dm-notes&note=<id>`. `PlayerJournalView.vue` watches the
+`note` query param on the DM Notes tab, expands that card, scrolls to it
+(`dm-note-<id>` element ids in `PlayerJournalDmNotesTab.vue`), marks it read,
+and then drops the param. Proposal emails link `/play/settings` (the RSVP
+toggles).
+
 ## Configuration (production)
 
 Without configuration the function is deployed but inert (`{ configured:

--- a/context/features/notifications.md
+++ b/context/features/notifications.md
@@ -1,0 +1,75 @@
+# Email Notifications
+
+Players get an email when their DM publishes something for them. Two events
+exist today:
+
+| Event                | Fires when…                                                        | Recipients                                              |
+| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------- |
+| **Note shared**      | A note's `player_visible_to` gains party members (create or edit)  | Only the players **newly added** to `player_visible_to` |
+| **Session proposed** | A DM adds a date in the Scheduling tab (`session_proposals` insert) | All `campaign_members` with `role = 'player'`           |
+
+Both are **opt-out**: a missing `notification_preferences` row means every
+email type is ON, and players toggle them off under **`/play/settings` →
+Email Notifications** (`PlayerSettingsNotifications.vue`).
+
+## Architecture — why client-invoked, not a DB trigger
+
+The DM's action fires a **fire-and-forget** `supabase.functions.invoke` from
+the browser (`src/composables/useEmailNotify.ts`, same pattern as
+`queueNoteEmbedding`):
+
+- `NoteEditor.vue` `save()` — diffs old vs new `player_visible_to` and sends
+  the **added** party-member ids (NOT the `justShared` boolean, which misses
+  adding a second player to an already-shared note).
+- `SchedulingTab.vue` `addProposal()` — sends the created proposal id, and
+  also posts the 📅 in-app `sendCampaignAnnouncement` chat message.
+
+A `notes`/`session_proposals` AFTER-trigger was considered and rejected on
+purpose: **campaign backup restore** (`useCampaignBackup.ts`) inserts straight
+into both tables, and a trigger would mass-email every player about years-old
+content on every restore. Losing coverage of non-UI write paths (MCP, REST) is
+the accepted cost — do not "fix" this by adding a trigger.
+
+## The edge function — `send-notification-email`
+
+`supabase/functions/send-notification-email/index.ts`. The request body is a
+*pointer*, never an authority:
+
+1. Verifies the caller's JWT (`getUser()`), then that the caller is a
+   `role = 'dm'` member of the row's campaign.
+2. Re-derives recipients from DB state: for notes, the claimed "added" ids are
+   intersected with the row's actual `player_visible_to`, then mapped
+   `party_member_id → campaign_members.user_id`; the caller is always excluded.
+3. Filters through `notification_preferences` (missing row = opted in).
+4. Rate-limits (`email_notify`: 30 invocations/hour/user — one invocation may
+   email a whole party).
+5. Resolves addresses server-side via `auth.admin.getUserById` — **player
+   emails exist only in `auth.users` and must never reach the browser.**
+6. Sends one email per recipient via Resend's REST API. Titles and names are
+   HTML-escaped in `emails.ts` (pure module, vitest-covered).
+
+Emails contain the note/session **title only**, never note content — no
+TipTap-JSON rendering server-side, and nothing sensitive in inboxes.
+
+## Configuration (production)
+
+Without configuration the function is deployed but inert (`{ configured:
+false }` — the poll-meshy-jobs precedent). To activate:
+
+```
+supabase secrets set RESEND_API_KEY=re_...
+supabase secrets set NOTIFY_FROM_EMAIL="Grimoire <notifications@dungeongrimoire.com>"  # optional, this is the default
+```
+
+The sending domain (`dungeongrimoire.com`) must be verified in the Resend
+dashboard (DKIM + SPF DNS records) before Resend will accept the `from`.
+Supabase itself offers SMTP only for **auth** emails (signup/reset) — there is
+no Supabase-provided API for application email, hence Resend.
+
+## DB
+
+- `notification_preferences` (migration `20260805000002`): `user_id` PK →
+  `auth.users`, `email_shared_notes`, `email_session_proposals`, both
+  `default true`. RLS: own-row only, all four verbs. Rows are created lazily
+  on first toggle (`useNotificationPreferences.ts`), so existing accounts need
+  no backfill.

--- a/src/components/campaign/SchedulingTab.vue
+++ b/src/components/campaign/SchedulingTab.vue
@@ -329,6 +329,9 @@ import {
 import { useCampaignMembers } from "@/composables/useCampaignMembers";
 import { useCampaignStore } from "@/stores/campaign";
 import { useAuthStore } from "@/stores/auth";
+import { sendCampaignAnnouncement } from "@/composables/useCampaignBroadcast";
+import { notifyProposalCreated } from "@/composables/useEmailNotify";
+import { useLocalToday } from "@/composables/useLocalToday";
 import type { SessionProposal } from "@/types/scheduling.types";
 
 const { activeThemeId } = useTheme();
@@ -368,16 +371,16 @@ const players = computed(() =>
 );
 const playerCount = computed(() => players.value.length);
 
-const today = new Date().toISOString().slice(0, 10);
+const today = useLocalToday();
 
 const confirmed = computed(() =>
   (proposals.value ?? [])
-    .filter((p) => p.status === "confirmed" && p.proposed_date >= today)
+    .filter((p) => p.status === "confirmed" && p.proposed_date >= today.value)
     .sort((a, b) => a.proposed_date.localeCompare(b.proposed_date)),
 );
 const proposed = computed(() =>
   (proposals.value ?? [])
-    .filter((p) => p.status === "proposed" && p.proposed_date >= today)
+    .filter((p) => p.status === "proposed" && p.proposed_date >= today.value)
     .sort((a, b) => a.proposed_date.localeCompare(b.proposed_date)),
 );
 const cancelled = computed(() =>
@@ -468,7 +471,7 @@ async function addProposal() {
   const pad = (n: number) => String(n).padStart(2, "0");
   const proposed_date = `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}`;
   const proposed_time = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
-  await createProposal({
+  const created = await createProposal({
     campaign_id: campaign.activeCampaignId,
     proposed_date,
     proposed_time,
@@ -478,6 +481,11 @@ async function addProposal() {
     duration_minutes: Math.round(form.value.duration_hours * 60),
     min_attendance: form.value.min_attendance,
   });
+  void sendCampaignAnnouncement(
+    campaign.activeCampaignId,
+    `📅 Session date proposed: ${created.title} — ${formatDate(created.proposed_date, created.proposed_time)}`,
+  );
+  notifyProposalCreated(created.id);
   resetForm();
 }
 

--- a/src/components/common/SettingsToggleRow.vue
+++ b/src/components/common/SettingsToggleRow.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="flex items-center justify-between">
+    <div>
+      <p class="font-cinzel text-xs text-foreground tracking-wide">{{ label }}</p>
+      <p class="text-caption text-muted-foreground italic">{{ description }}</p>
+    </div>
+    <ToggleSwitch
+      :model-value="modelValue"
+      :aria-label="label"
+      class="ml-3"
+      @update:model-value="emit('update:modelValue', $event)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ToggleSwitch from "@/components/common/ToggleSwitch.vue";
+
+defineProps<{
+  modelValue: boolean;
+  label: string;
+  description: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+}>();
+</script>

--- a/src/components/common/ToggleSwitch.vue
+++ b/src/components/common/ToggleSwitch.vue
@@ -1,0 +1,27 @@
+<template>
+  <button
+    type="button"
+    class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200"
+    :class="modelValue ? 'bg-primary' : 'bg-muted'"
+    role="switch"
+    :aria-checked="modelValue"
+    :aria-label="ariaLabel"
+    @click="emit('update:modelValue', !modelValue)"
+  >
+    <span
+      class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transition-transform duration-200"
+      :class="modelValue ? 'translate-x-5' : 'translate-x-0'"
+    />
+  </button>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  modelValue: boolean;
+  ariaLabel?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+}>();
+</script>

--- a/src/components/notes/NoteEditor.vue
+++ b/src/components/notes/NoteEditor.vue
@@ -277,6 +277,7 @@ import { markEdited, type AiProvenance } from "@/ai/provenance";
 import { useCampaignStore } from "@/stores/campaign";
 import { useCalendarStore } from "@/stores/calendar";
 import { sendCampaignAnnouncement } from "@/composables/useCampaignBroadcast";
+import { notifyNoteShared } from "@/composables/useEmailNotify";
 import { getCurrentUser } from "@/lib/supabase";
 import { storeToRefs } from "pinia";
 import PaywallModal from "@/components/common/PaywallModal.vue";
@@ -526,6 +527,10 @@ async function save() {
   const wasShared = (props.note?.player_visible_to?.length ?? 0) > 0;
   const nowShared = playerVisibleTo.value.length > 0;
   const justShared = nowShared && !wasShared;
+  // Per-player diff, unlike the boolean above: adding a player to an
+  // already-shared note must still email that player.
+  const previouslyVisibleTo = new Set(props.note?.player_visible_to ?? []);
+  const newlyVisibleTo = playerVisibleTo.value.filter((id) => !previouslyVisibleTo.has(id));
   try {
     if (props.note) {
       // Material edit detection (#606): only the body counts — title,
@@ -547,6 +552,7 @@ async function save() {
           `📜 Note shared: "${title.value.trim()}"`,
           { entity_type: "note", entity_id: props.note.id },
         );
+      notifyNoteShared(props.note.id, newlyVisibleTo);
       router.push("/notes");
     } else {
       const created = await create(buildPayload());
@@ -557,6 +563,7 @@ async function save() {
           `📜 Note shared: "${created.title}"`,
           { entity_type: "note", entity_id: created.id },
         );
+      notifyNoteShared(created.id, newlyVisibleTo);
       router.replace(`/notes/${created.id}`);
     }
   } catch (e: unknown) {

--- a/src/components/play/PlayerSettingsAppearance.vue
+++ b/src/components/play/PlayerSettingsAppearance.vue
@@ -40,20 +40,12 @@
           <template v-else>Not supported on this browser. Try Chrome or Safari 16.4+.</template>
         </p>
       </div>
-      <button
+      <ToggleSwitch
         v-if="wakeLockSupported"
-        type="button"
-        class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200"
-        :class="wakeLockEnabled ? 'bg-primary' : 'bg-muted'"
-        role="switch"
-        :aria-checked="wakeLockEnabled"
-        @click="toggleWakeLock"
-      >
-        <span
-          class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transition-transform duration-200"
-          :class="wakeLockEnabled ? 'translate-x-5' : 'translate-x-0'"
-        />
-      </button>
+        :model-value="wakeLockEnabled"
+        aria-label="Keep screen awake"
+        @update:model-value="toggleWakeLock"
+      />
       <span v-else class="text-label md:text-sm text-muted-foreground px-2 py-1 rounded border border-border">
         Unavailable
       </span>
@@ -76,6 +68,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import SettingsSection from "@/components/common/SettingsSection.vue";
+import ToggleSwitch from "@/components/common/ToggleSwitch.vue";
 import EntityCombobox from "@/components/common/EntityCombobox.vue";
 import { IconReset } from "@/lib/icons";
 import { useTheme } from "@/composables/useTheme";

--- a/src/components/play/PlayerSettingsNotifications.vue
+++ b/src/components/play/PlayerSettingsNotifications.vue
@@ -1,45 +1,37 @@
 <template>
+  <!-- Email notifications -->
+  <SettingsSection title="Email Notifications" description="Emails when your DM publishes something for you.">
+    <div class="space-y-4">
+      <SettingsToggleRow
+        label="Shared session notes"
+        description="Get an email when your DM shares a note with you."
+        :model-value="prefs.email_shared_notes"
+        @update:model-value="setPref('email_shared_notes', $event)"
+      />
+      <SettingsToggleRow
+        label="Session date proposals"
+        description="Get an email when your DM proposes a new session date."
+        :model-value="prefs.email_session_proposals"
+        @update:model-value="setPref('email_session_proposals', $event)"
+      />
+    </div>
+  </SettingsSection>
+
   <!-- Combat notifications -->
   <SettingsSection title="Combat Notifications" description="Alerts when it's your turn in a live encounter.">
     <div class="space-y-4">
-      <div class="flex items-center justify-between">
-        <div>
-          <p class="font-cinzel text-xs text-foreground tracking-wide">Turn audio cue</p>
-          <p class="text-caption text-muted-foreground italic">A short chime plays when your turn begins.</p>
-        </div>
-        <button
-          type="button"
-          class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200"
-          :class="turnAudioEnabled ? 'bg-primary' : 'bg-muted'"
-          role="switch"
-          :aria-checked="turnAudioEnabled"
-          @click="setTurnAudio(!turnAudioEnabled)"
-        >
-          <span
-            class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transition-transform duration-200"
-            :class="turnAudioEnabled ? 'translate-x-5' : 'translate-x-0'"
-          />
-        </button>
-      </div>
-      <div class="flex items-center justify-between">
-        <div>
-          <p class="font-cinzel text-xs text-foreground tracking-wide">Dice roll sounds</p>
-          <p class="text-caption text-muted-foreground italic">A clack plays on every roll. Crits and fumbles have distinct sounds.</p>
-        </div>
-        <button
-          type="button"
-          class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200"
-          :class="diceAudioEnabled ? 'bg-primary' : 'bg-muted'"
-          role="switch"
-          :aria-checked="diceAudioEnabled"
-          @click="setDiceAudio(!diceAudioEnabled)"
-        >
-          <span
-            class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transition-transform duration-200"
-            :class="diceAudioEnabled ? 'translate-x-5' : 'translate-x-0'"
-          />
-        </button>
-      </div>
+      <SettingsToggleRow
+        label="Turn audio cue"
+        description="A short chime plays when your turn begins."
+        :model-value="turnAudioEnabled"
+        @update:model-value="setTurnAudio($event)"
+      />
+      <SettingsToggleRow
+        label="Dice roll sounds"
+        description="A clack plays on every roll. Crits and fumbles have distinct sounds."
+        :model-value="diceAudioEnabled"
+        @update:model-value="setDiceAudio($event)"
+      />
     </div>
   </SettingsSection>
 
@@ -69,10 +61,27 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import SettingsSection from "@/components/common/SettingsSection.vue";
+import SettingsToggleRow from "@/components/common/SettingsToggleRow.vue";
 import { usePlayerCombatPrefs } from "@/composables/usePlayerCombatPrefs";
 import { useDicePrefs } from "@/composables/useDicePrefs";
+import {
+  useNotificationPreferences,
+  useUpdateNotificationPreferences,
+  NOTIFICATION_PREFERENCE_DEFAULTS,
+  type NotificationPreferences,
+} from "@/composables/useNotificationPreferences";
 
 const { turnAudioEnabled, setTurnAudio } = usePlayerCombatPrefs();
 const { diceAudioEnabled, setDiceAudio, diceMode, setDiceMode } = useDicePrefs();
+
+const { data: emailPrefs } = useNotificationPreferences();
+const { mutate: updatePrefs } = useUpdateNotificationPreferences();
+
+const prefs = computed(() => emailPrefs.value ?? NOTIFICATION_PREFERENCE_DEFAULTS);
+
+function setPref(key: keyof NotificationPreferences, value: boolean) {
+  updatePrefs({ [key]: value });
+}
 </script>

--- a/src/components/play/PlayerSettingsSessions.vue
+++ b/src/components/play/PlayerSettingsSessions.vue
@@ -70,6 +70,7 @@ import { IconCalendarCheck, IconCheck, IconClose } from "@/lib/icons";
 import { useAuthStore } from "@/stores/auth";
 import { useCampaignStore } from "@/stores/campaign";
 import { useSessionProposals, useAllSessionAvailability, useUpsertAvailability } from "@/composables/useScheduling";
+import { useLocalToday } from "@/composables/useLocalToday";
 import type { SessionProposal } from "@/types/scheduling.types";
 
 const auth = useAuthStore();
@@ -79,17 +80,17 @@ const { data: proposals } = useSessionProposals();
 const { data: allAvailability } = useAllSessionAvailability();
 const { mutateAsync: upsertAvailability } = useUpsertAvailability();
 
-const today = new Date().toISOString().slice(0, 10);
+const today = useLocalToday();
 
 const confirmedSessions = computed(() =>
   (proposals.value ?? [])
-    .filter(p => p.status === "confirmed" && p.proposed_date >= today)
+    .filter(p => p.status === "confirmed" && p.proposed_date >= today.value)
     .sort((a, b) => a.proposed_date.localeCompare(b.proposed_date))
 );
 
 const proposedSessions = computed(() =>
   (proposals.value ?? [])
-    .filter(p => p.status === "proposed" && p.proposed_date >= today)
+    .filter(p => p.status === "proposed" && p.proposed_date >= today.value)
     .sort((a, b) => a.proposed_date.localeCompare(b.proposed_date))
 );
 

--- a/src/composables/useEmailNotify.ts
+++ b/src/composables/useEmailNotify.ts
@@ -1,0 +1,31 @@
+import { supabase } from "@/lib/supabase";
+
+/**
+ * Fire-and-forget email notifications (send-notification-email edge function).
+ *
+ * Deliberately invoked from the client on the explicit DM action instead of a
+ * DB trigger, so bulk write paths (campaign backup restore, imports) can never
+ * mass-email a party — same reasoning as queueNoteEmbedding in useNotes.ts.
+ * The function re-derives recipients and authorization server-side; these ids
+ * are pointers, not grants. Failures are non-fatal: the share/proposal itself
+ * already succeeded, and players still see it in-app.
+ */
+
+/** Email the players newly granted visibility on a note (party_member ids). */
+export function notifyNoteShared(noteId: string, addedPartyMemberIds: string[]): void {
+  if (!addedPartyMemberIds.length) return;
+  void supabase.functions
+    .invoke("send-notification-email", {
+      body: { type: "note_shared", note_id: noteId, added_party_member_ids: addedPartyMemberIds },
+    })
+    .catch(() => { /* non-fatal — see above */ });
+}
+
+/** Email all players of the proposal's campaign about a new session date. */
+export function notifyProposalCreated(proposalId: string): void {
+  void supabase.functions
+    .invoke("send-notification-email", {
+      body: { type: "proposal_created", proposal_id: proposalId },
+    })
+    .catch(() => { /* non-fatal — see above */ });
+}

--- a/src/composables/useLocalToday.test.ts
+++ b/src/composables/useLocalToday.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { localDateString } from "./useLocalToday";
+
+describe("localDateString", () => {
+  it("formats the LOCAL calendar date, zero-padded", () => {
+    // Construct via local-time parts so the expectation holds in any TZ.
+    expect(localDateString(new Date(2026, 0, 5, 23, 59))).toBe("2026-01-05");
+    expect(localDateString(new Date(2026, 11, 31))).toBe("2026-12-31");
+  });
+
+  it("differs from the UTC date exactly when local midnight has passed but UTC's has not", () => {
+    // 00:30 local on Aug 6 in any TZ ahead of UTC is still Aug 5 in UTC —
+    // the original bug kept yesterday's proposals visible until small hours.
+    const d = new Date(2026, 7, 6, 0, 30);
+    expect(localDateString(d)).toBe("2026-08-06");
+    if (d.getTimezoneOffset() < 0) {
+      expect(d.toISOString().slice(0, 10)).toBe("2026-08-05");
+    }
+  });
+});

--- a/src/composables/useLocalToday.ts
+++ b/src/composables/useLocalToday.ts
@@ -1,0 +1,24 @@
+import { computed, type ComputedRef } from "vue";
+import { useNow } from "@vueuse/core";
+
+/** "YYYY-MM-DD" in the user's local timezone (NOT UTC — see useLocalToday). */
+export function localDateString(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/**
+ * Reactive local calendar date for comparing against date-only columns like
+ * session_proposals.proposed_date.
+ *
+ * Exists because `new Date().toISOString().slice(0, 10)` — the pattern this
+ * replaces — was wrong twice over for that comparison: it was captured once
+ * at component setup (an installed PWA keeps components alive for days, so
+ * "today" went stale and past session dates kept showing), and it is UTC (for
+ * timezones ahead of UTC, yesterday still counts as today until small hours).
+ * This version ticks across midnight and uses the local calendar.
+ */
+export function useLocalToday(): ComputedRef<string> {
+  const now = useNow({ interval: 60_000 });
+  return computed(() => localDateString(now.value));
+}

--- a/src/composables/useNotificationPreferences.ts
+++ b/src/composables/useNotificationPreferences.ts
@@ -1,0 +1,66 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
+import { supabase, getCurrentUser } from "@/lib/supabase";
+import { useToast } from "@/composables/useToast";
+
+const QUERY_KEY = "notification_preferences";
+
+export interface NotificationPreferences {
+  email_shared_notes: boolean;
+  email_session_proposals: boolean;
+}
+
+/**
+ * Mirrors the server: no notification_preferences row means everything is ON.
+ * The row is only created on the first toggle, so the table never needs
+ * backfilling for existing accounts.
+ */
+export const NOTIFICATION_PREFERENCE_DEFAULTS: NotificationPreferences = {
+  email_shared_notes: true,
+  email_session_proposals: true,
+};
+
+async function fetchPreferences(): Promise<NotificationPreferences> {
+  const user = getCurrentUser();
+  const { data, error } = await supabase
+    .from("notification_preferences")
+    .select("email_shared_notes, email_session_proposals")
+    .eq("user_id", user!.id)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as NotificationPreferences | null) ?? NOTIFICATION_PREFERENCE_DEFAULTS;
+}
+
+async function upsertPreferences(
+  patch: Partial<NotificationPreferences>,
+): Promise<NotificationPreferences> {
+  const user = getCurrentUser();
+  const current = await fetchPreferences();
+  const next = { ...current, ...patch };
+  const { data, error } = await supabase
+    .from("notification_preferences")
+    .upsert({ user_id: user!.id, ...next }, { onConflict: "user_id" })
+    .select("email_shared_notes, email_session_proposals")
+    .single();
+  if (error) throw error;
+  return data as NotificationPreferences;
+}
+
+export function useNotificationPreferences() {
+  return useQuery({
+    queryKey: [QUERY_KEY],
+    queryFn: fetchPreferences,
+    enabled: () => !!getCurrentUser(),
+  });
+}
+
+export function useUpdateNotificationPreferences() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: upsertPreferences,
+    onSuccess: (prefs) => {
+      queryClient.setQueryData([QUERY_KEY], prefs);
+    },
+    onError: (e) => toast.error(toast.fromError(e)),
+  });
+}

--- a/src/views/play/PlayerJournalDmNotesTab.vue
+++ b/src/views/play/PlayerJournalDmNotesTab.vue
@@ -9,6 +9,7 @@
   <div v-else class="flex flex-col gap-2">
     <JournalCard
       v-for="note in dmNotes"
+      :id="`dm-note-${note.id}`"
       :key="note.id"
       :color="NOTE_CATEGORIES[note.category]?.color ?? '#6b7280'"
       :icon="NOTE_CATEGORIES[note.category]?.icon ?? IconPopulate"

--- a/src/views/play/PlayerJournalView.vue
+++ b/src/views/play/PlayerJournalView.vue
@@ -201,7 +201,7 @@
 <script setup lang="ts">
 import { useConfirm } from "@/composables/useConfirm";
 const { confirm } = useConfirm();
-import { ref, computed } from "vue";
+import { ref, computed, watch, nextTick } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { IconAdd, IconCalendarDays, IconDocument, IconFeather, IconLoading, IconLocation, IconLock, IconMessage, IconPopulate, IconReveal, IconSave, IconScrollText, IconSearch, IconShield, IconStar } from '@/lib/icons';
 import TabBar from "@/components/common/TabBar.vue";
@@ -352,6 +352,24 @@ const TABS = computed(() => [
   { id: "puzzles"   as const, label: "Puzzles",       count: puzzles.value?.length ?? 0 },
   { id: "dm-notes"  as const, label: "DM Notes",      count: dmNotes.value.length },
 ]);
+
+// Deep link from note-share emails: /play/journal?tab=dm-notes&note=<id>
+// expands that note and scrolls to it. Watches dmNotes too because on a cold
+// load the target card doesn't exist until the notes query resolves. The
+// param is dropped afterwards so collapse/refresh behaves normally.
+watch(
+  [() => route.query.note, dmNotes],
+  async ([noteId]) => {
+    if (typeof noteId !== "string" || activeTab.value !== "dm-notes") return;
+    if (!dmNotes.value.some((n) => n.id === noteId)) return;
+    markRead({ entityType: "note", entityId: noteId });
+    selectedNote.value = noteId;
+    await nextTick();
+    document.getElementById(`dm-note-${noteId}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    void router.replace({ query: { tab: "dm-notes" } });
+  },
+  { immediate: true },
+);
 
 // Statuses that render in a Quest Log group — the badge counts exactly these.
 const QUEST_LOG_STATUSES: readonly string[] = ["active", "rumor", "completed", "failed"];

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -15,6 +15,9 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 export const RATE_LIMITS = {
   ai_generation: { action: "ai_generation", limit: 30, windowSeconds: 60 },
   bug_report:    { action: "bug_report",    limit: 15, windowSeconds: 86_400 },
+  // One event per notify invocation (which may email a whole party). Bounds a
+  // compromised or misbehaving DM account to 30 email bursts an hour.
+  email_notify:  { action: "email_notify",  limit: 30, windowSeconds: 3_600 },
 } as const;
 
 export type RateLimitKey = keyof typeof RATE_LIMITS;

--- a/supabase/functions/send-notification-email/emails.test.ts
+++ b/supabase/functions/send-notification-email/emails.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtml,
+  formatProposalDate,
+  noteSharedEmail,
+  proposalCreatedEmail,
+} from "./emails";
+
+describe("escapeHtml", () => {
+  it("escapes all HTML-significant characters", () => {
+    expect(escapeHtml(`<img src=x onerror="alert('1')" & more>`)).toBe(
+      "&lt;img src=x onerror=&quot;alert(&#39;1&#39;)&quot; &amp; more&gt;",
+    );
+  });
+});
+
+describe("formatProposalDate", () => {
+  it("formats a date-only proposal in UTC, unshifted", () => {
+    expect(formatProposalDate("2026-08-05", null)).toBe("Wednesday, August 5, 2026");
+  });
+
+  it("appends the time and trims Postgres seconds", () => {
+    expect(formatProposalDate("2026-08-05", "19:30:00")).toBe(
+      "Wednesday, August 5, 2026 at 19:30",
+    );
+    expect(formatProposalDate("2026-08-05", "19:30")).toBe(
+      "Wednesday, August 5, 2026 at 19:30",
+    );
+  });
+});
+
+describe("noteSharedEmail", () => {
+  const email = noteSharedEmail({
+    campaignName: "Curse of <Strahd>",
+    dmName: "Jeffrey & co",
+    noteTitle: 'Session 12: "The Amber Temple"',
+  });
+
+  it("names the DM and note in the subject", () => {
+    expect(email.subject).toBe(
+      "Jeffrey & co shared a session note with you — Curse of <Strahd>",
+    );
+  });
+
+  it("escapes user content in the HTML body", () => {
+    expect(email.html).toContain("Curse of &lt;Strahd&gt;");
+    expect(email.html).toContain("Jeffrey &amp; co");
+    expect(email.html).toContain("&quot;The Amber Temple&quot;");
+    expect(email.html).not.toContain("<Strahd>");
+  });
+
+  it("links the player notes page and the opt-out settings page", () => {
+    expect(email.html).toContain("https://app.dungeongrimoire.com/play/notes");
+    expect(email.text).toContain("https://app.dungeongrimoire.com/play/notes");
+    expect(email.text).toContain("https://app.dungeongrimoire.com/play/settings");
+  });
+});
+
+describe("proposalCreatedEmail", () => {
+  const email = proposalCreatedEmail({
+    campaignName: "Tomb of Annihilation",
+    dmName: "Jeffrey",
+    proposalTitle: "Session 13",
+    proposedDate: "2026-09-01",
+    proposedTime: "19:00:00",
+  });
+
+  it("puts the formatted date in the body", () => {
+    expect(email.html).toContain("Tuesday, September 1, 2026 at 19:00");
+    expect(email.text).toContain("Tuesday, September 1, 2026 at 19:00");
+  });
+
+  it("links the availability page", () => {
+    expect(email.html).toContain("https://app.dungeongrimoire.com/play/settings");
+    expect(email.text).toContain("https://app.dungeongrimoire.com/play/settings");
+  });
+});

--- a/supabase/functions/send-notification-email/emails.test.ts
+++ b/supabase/functions/send-notification-email/emails.test.ts
@@ -34,6 +34,7 @@ describe("noteSharedEmail", () => {
     campaignName: "Curse of <Strahd>",
     dmName: "Jeffrey & co",
     noteTitle: 'Session 12: "The Amber Temple"',
+    noteId: "11111111-2222-3333-4444-555555555555",
   });
 
   it("names the DM and note in the subject", () => {
@@ -49,9 +50,11 @@ describe("noteSharedEmail", () => {
     expect(email.html).not.toContain("<Strahd>");
   });
 
-  it("links the player notes page and the opt-out settings page", () => {
-    expect(email.html).toContain("https://app.dungeongrimoire.com/play/notes");
-    expect(email.text).toContain("https://app.dungeongrimoire.com/play/notes");
+  it("deep-links the exact note on the DM Notes tab, plus the opt-out settings page", () => {
+    const deepLink =
+      "https://app.dungeongrimoire.com/play/journal?tab=dm-notes&note=11111111-2222-3333-4444-555555555555";
+    expect(email.html).toContain(deepLink);
+    expect(email.text).toContain(deepLink);
     expect(email.text).toContain("https://app.dungeongrimoire.com/play/settings");
   });
 });

--- a/supabase/functions/send-notification-email/emails.ts
+++ b/supabase/functions/send-notification-email/emails.ts
@@ -66,8 +66,12 @@ export function noteSharedEmail(args: {
   campaignName: string;
   dmName: string;
   noteTitle: string;
+  noteId: string;
 }): EmailContent {
-  const { campaignName, dmName, noteTitle } = args;
+  const { campaignName, dmName, noteTitle, noteId } = args;
+  // Deep link straight to the note: PlayerJournalView expands + scrolls to
+  // the card named by the `note` query param on its DM Notes tab.
+  const notePath = `/play/journal?tab=dm-notes&note=${encodeURIComponent(noteId)}`;
   return {
     subject: `${dmName} shared a session note with you — ${campaignName}`,
     html: layout(
@@ -77,9 +81,9 @@ export function noteSharedEmail(args: {
     <strong>“${escapeHtml(noteTitle)}”</strong> with you.
   </p>`,
       "Read the note",
-      "/play/notes",
+      notePath,
     ),
-    text: `${dmName} shared the note "${noteTitle}" with you.\n\nRead it: ${APP_ORIGIN}/play/notes\n\n${OPT_OUT_TEXT}`,
+    text: `${dmName} shared the note "${noteTitle}" with you.\n\nRead it: ${APP_ORIGIN}${notePath}\n\n${OPT_OUT_TEXT}`,
   };
 }
 

--- a/supabase/functions/send-notification-email/emails.ts
+++ b/supabase/functions/send-notification-email/emails.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure email composition for send-notification-email — no Deno imports so
+ * vitest can cover it (see vitest.config.ts include of supabase/functions).
+ *
+ * Every string that came from a user (titles, names) is HTML-escaped: these
+ * land in HTML email bodies, and a note titled `<img onerror=…>` must render
+ * as text, not execute in a webmail client.
+ */
+
+const APP_ORIGIN = "https://app.dungeongrimoire.com";
+
+export interface EmailContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * "2026-08-05" + "19:30" → "Wednesday, August 5, 2026 at 19:30". The date is a
+ * wall-clock campaign date with no timezone, so it is formatted in UTC on
+ * purpose — local-TZ parsing would shift it by a day for half the world.
+ */
+export function formatProposalDate(date: string, time: string | null): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  const dateLabel = d.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+  // proposed_time is HH:mm or HH:mm:ss from Postgres `time` — trim the seconds.
+  return time ? `${dateLabel} at ${time.slice(0, 5)}` : dateLabel;
+}
+
+function layout(campaignName: string, bodyHtml: string, ctaLabel: string, ctaPath: string): string {
+  const url = `${APP_ORIGIN}${ctaPath}`;
+  return `<div style="font-family: Georgia, 'Times New Roman', serif; max-width: 36rem; margin: 0 auto; padding: 1.5rem; color: #2a2118;">
+  <p style="font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: #8a7a5c; margin: 0 0 1rem;">${escapeHtml(campaignName)}</p>
+  ${bodyHtml}
+  <p style="margin: 1.5rem 0;">
+    <a href="${url}" style="display: inline-block; background: #7a1f1f; color: #f5efe0; text-decoration: none; padding: 0.6rem 1.2rem; border-radius: 0.25rem;">${ctaLabel}</a>
+  </p>
+  <hr style="border: none; border-top: 1px solid #d9cdb4; margin: 1.5rem 0 0.75rem;" />
+  <p style="font-size: 0.75rem; color: #8a7a5c; margin: 0;">
+    You receive these emails because you are a member of this campaign in Grimoire.
+    Turn them off under <a href="${APP_ORIGIN}/play/settings" style="color: #8a7a5c;">Settings → Notifications</a>.
+  </p>
+</div>`;
+}
+
+const OPT_OUT_TEXT =
+  "You receive these emails because you are a member of this campaign in Grimoire. " +
+  `Turn them off under Settings → Notifications: ${APP_ORIGIN}/play/settings`;
+
+export function noteSharedEmail(args: {
+  campaignName: string;
+  dmName: string;
+  noteTitle: string;
+}): EmailContent {
+  const { campaignName, dmName, noteTitle } = args;
+  return {
+    subject: `${dmName} shared a session note with you — ${campaignName}`,
+    html: layout(
+      campaignName,
+      `<p style="font-size: 1rem; line-height: 1.6;">
+    <strong>${escapeHtml(dmName)}</strong> shared the note
+    <strong>“${escapeHtml(noteTitle)}”</strong> with you.
+  </p>`,
+      "Read the note",
+      "/play/notes",
+    ),
+    text: `${dmName} shared the note "${noteTitle}" with you.\n\nRead it: ${APP_ORIGIN}/play/notes\n\n${OPT_OUT_TEXT}`,
+  };
+}
+
+export function proposalCreatedEmail(args: {
+  campaignName: string;
+  dmName: string;
+  proposalTitle: string;
+  proposedDate: string;
+  proposedTime: string | null;
+}): EmailContent {
+  const { campaignName, dmName, proposalTitle, proposedDate, proposedTime } = args;
+  const when = formatProposalDate(proposedDate, proposedTime);
+  return {
+    subject: `New session date proposed — ${campaignName}`,
+    html: layout(
+      campaignName,
+      `<p style="font-size: 1rem; line-height: 1.6;">
+    <strong>${escapeHtml(dmName)}</strong> proposed a date for
+    <strong>${escapeHtml(proposalTitle)}</strong>:
+  </p>
+  <p style="font-size: 1.1rem; line-height: 1.6; margin: 0.75rem 0;">📅 <strong>${escapeHtml(when)}</strong></p>
+  <p style="font-size: 1rem; line-height: 1.6;">Let your DM know whether you can make it.</p>`,
+      "Respond with your availability",
+      "/play/settings",
+    ),
+    text:
+      `${dmName} proposed a date for ${proposalTitle}: ${when}.\n\n` +
+      `Respond with your availability: ${APP_ORIGIN}/play/settings\n\n${OPT_OUT_TEXT}`,
+  };
+}

--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -180,7 +180,9 @@ serve(withCors(async (req: Request) => {
       .map((m) => m.user_id);
     prefColumn = "email_shared_notes";
     const noteTitle = (note.title as string) || "Untitled Note";
-    buildEmail = (campaign, dmName) => noteSharedEmail({ campaignName: campaign, dmName, noteTitle });
+    const noteId = note.id as string;
+    buildEmail = (campaign, dmName) =>
+      noteSharedEmail({ campaignName: campaign, dmName, noteTitle, noteId });
   } else if (body.type === "proposal_created") {
     if (!body.proposal_id) return json({ error: "proposal_created needs { proposal_id }" }, 400);
     const { data: proposal, error } = await admin

--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -1,0 +1,233 @@
+/**
+ * Player email notifications — "your DM shared a session note with you" and
+ * "a new session date was proposed".
+ *
+ * Invoked fire-and-forget from the app right after the DM action
+ * (NoteEditor / SchedulingTab), NOT from a DB trigger: campaign backup
+ * restore inserts straight into `notes` / `session_proposals`, and a trigger
+ * would re-email every player about years-old content on every restore.
+ *
+ * Trust boundary: the client only names WHICH rows changed. Recipients are
+ * re-derived here from DB state (player_visible_to ∩ the claimed ids →
+ * campaign_members → auth.users.email) with the caller verified as a DM of
+ * that campaign — player emails never reach the browser, and a caller can't
+ * email anyone the row itself doesn't grant.
+ *
+ * Provider: Resend. Until the RESEND_API_KEY function secret is set this
+ * no-ops with { configured: false } — safe to deploy before the account
+ * exists (the poll-meshy-jobs 503 precedent). Optional NOTIFY_FROM_EMAIL
+ * overrides the sender ("Name <addr>" form).
+ */
+import { serve } from "std/http/server.ts";
+import { createClient } from "@supabase/supabase-js";
+import { withCors } from "../_shared/cors.ts";
+import { checkRateLimit } from "../_shared/rate-limit.ts";
+import { noteSharedEmail, proposalCreatedEmail, type EmailContent } from "./emails.ts";
+
+const admin = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+);
+
+const DEFAULT_FROM = "Grimoire <notifications@dungeongrimoire.com>";
+
+interface MemberRow {
+  user_id: string;
+  party_member_id: string | null;
+  display_name: string | null;
+  role: "dm" | "player";
+}
+
+async function fetchMembers(campaignId: string): Promise<MemberRow[]> {
+  const { data, error } = await admin
+    .from("campaign_members")
+    .select("user_id, party_member_id, display_name, role")
+    .eq("campaign_id", campaignId);
+  if (error) throw error;
+  return (data ?? []) as MemberRow[];
+}
+
+async function campaignName(campaignId: string): Promise<string> {
+  const { data } = await admin.from("campaigns").select("name").eq("id", campaignId).maybeSingle();
+  return data?.name ?? "Your campaign";
+}
+
+/** Drop recipients whose notification_preferences row turns this email off. */
+async function filterByPreference(
+  userIds: string[],
+  column: "email_shared_notes" | "email_session_proposals",
+): Promise<string[]> {
+  if (!userIds.length) return [];
+  const { data, error } = await admin
+    .from("notification_preferences")
+    .select(`user_id, ${column}`)
+    .in("user_id", userIds);
+  if (error) throw error;
+  const optedOut = new Set(
+    (data ?? [])
+      .filter((row) => (row as Record<string, unknown>)[column] === false)
+      .map((row) => (row as { user_id: string }).user_id),
+  );
+  // No row = defaults = opted in.
+  return userIds.filter((id) => !optedOut.has(id));
+}
+
+async function resolveEmails(userIds: string[]): Promise<string[]> {
+  const results = await Promise.all(
+    userIds.map(async (id) => {
+      const { data, error } = await admin.auth.admin.getUserById(id);
+      if (error) {
+        console.error(`send-notification-email: getUserById(${id}) failed`, error);
+        return null;
+      }
+      return data.user?.email ?? null;
+    }),
+  );
+  return results.filter((e): e is string => !!e);
+}
+
+async function sendAll(recipients: string[], email: EmailContent, apiKey: string): Promise<number> {
+  let sent = 0;
+  for (const to of recipients) {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: Deno.env.get("NOTIFY_FROM_EMAIL") || DEFAULT_FROM,
+        to: [to],
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+      }),
+    });
+    if (res.ok) sent++;
+    else console.error(`send-notification-email: Resend ${res.status} for one recipient:`, await res.text());
+  }
+  return sent;
+}
+
+function json(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+serve(withCors(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) return new Response("Unauthorized", { status: 401 });
+  const userClient = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_ANON_KEY")!,
+    { global: { headers: { Authorization: authHeader } } },
+  );
+  const { data: { user }, error: authError } = await userClient.auth.getUser();
+  if (authError || !user) return new Response("Unauthorized", { status: 401 });
+
+  let body: {
+    type?: string;
+    note_id?: string;
+    added_party_member_ids?: unknown;
+    proposal_id?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  // Resolve the campaign + recipient user ids per event type. Everything is
+  // re-read from the DB — the request body is only a pointer.
+  let campaignId: string;
+  let members: MemberRow[];
+  let recipientIds: string[];
+  let prefColumn: "email_shared_notes" | "email_session_proposals";
+  let buildEmail: (campaign: string, dmName: string) => EmailContent;
+
+  if (body.type === "note_shared") {
+    if (!body.note_id || !Array.isArray(body.added_party_member_ids)) {
+      return json({ error: "note_shared needs { note_id, added_party_member_ids }" }, 400);
+    }
+    const { data: note, error } = await admin
+      .from("notes")
+      .select("id, title, campaign_id, player_visible_to")
+      .eq("id", body.note_id)
+      .maybeSingle();
+    if (error) throw error;
+    if (!note?.campaign_id) return json({ error: "Note not found" }, 404);
+    campaignId = note.campaign_id as string;
+
+    members = await fetchMembers(campaignId);
+    if (!members.some((m) => m.user_id === user.id && m.role === "dm")) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    // Only ids the note actually grants visibility to — the client's "added"
+    // list is an optimization hint, never an authority.
+    const visible = new Set((note.player_visible_to as string[] | null) ?? []);
+    const added = new Set(
+      (body.added_party_member_ids as unknown[]).filter(
+        (id): id is string => typeof id === "string" && visible.has(id),
+      ),
+    );
+    recipientIds = members
+      .filter((m) => m.party_member_id && added.has(m.party_member_id) && m.user_id !== user.id)
+      .map((m) => m.user_id);
+    prefColumn = "email_shared_notes";
+    const noteTitle = (note.title as string) || "Untitled Note";
+    buildEmail = (campaign, dmName) => noteSharedEmail({ campaignName: campaign, dmName, noteTitle });
+  } else if (body.type === "proposal_created") {
+    if (!body.proposal_id) return json({ error: "proposal_created needs { proposal_id }" }, 400);
+    const { data: proposal, error } = await admin
+      .from("session_proposals")
+      .select("id, campaign_id, title, proposed_date, proposed_time, status")
+      .eq("id", body.proposal_id)
+      .maybeSingle();
+    if (error) throw error;
+    if (!proposal) return json({ error: "Proposal not found" }, 404);
+    if (proposal.status === "cancelled") return json({ sent: 0, reason: "cancelled" });
+    campaignId = proposal.campaign_id as string;
+
+    members = await fetchMembers(campaignId);
+    if (!members.some((m) => m.user_id === user.id && m.role === "dm")) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    recipientIds = members
+      .filter((m) => m.role === "player" && m.user_id !== user.id)
+      .map((m) => m.user_id);
+    prefColumn = "email_session_proposals";
+    buildEmail = (campaign, dmName) =>
+      proposalCreatedEmail({
+        campaignName: campaign,
+        dmName,
+        proposalTitle: (proposal.title as string) || "Session",
+        proposedDate: proposal.proposed_date as string,
+        proposedTime: proposal.proposed_time as string | null,
+      });
+  } else {
+    return json({ error: "Unknown type" }, 400);
+  }
+
+  recipientIds = [...new Set(recipientIds)];
+  const optedIn = await filterByPreference(recipientIds, prefColumn);
+  if (!optedIn.length) return json({ sent: 0 });
+
+  const apiKey = Deno.env.get("RESEND_API_KEY");
+  if (!apiKey) return json({ sent: 0, configured: false });
+
+  if (!(await checkRateLimit(admin, user.id, "email_notify"))) {
+    return json({ error: "Rate limit exceeded" }, 429);
+  }
+
+  const dmName = members.find((m) => m.user_id === user.id)?.display_name || "Your DM";
+  const email = buildEmail(await campaignName(campaignId), dmName);
+  const emails = await resolveEmails(optedIn);
+  const sent = await sendAll(emails, email, apiKey);
+  return json({ sent });
+}));

--- a/supabase/migrations/20260805000002_notification_preferences.sql
+++ b/supabase/migrations/20260805000002_notification_preferences.sql
@@ -1,0 +1,26 @@
+-- Migration: notification_preferences
+-- Per-user email notification opt-outs (#none). One row per user, created
+-- lazily on first toggle; a missing row means every email type is ON — the
+-- send-notification-email edge function treats absence as the defaults, so
+-- players get notified without ever visiting settings.
+
+create table notification_preferences (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  -- A DM shared a session note with this player (notes.player_visible_to).
+  email_shared_notes boolean not null default true,
+  -- A DM proposed a new session date (session_proposals insert).
+  email_session_proposals boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger notification_preferences_updated_at
+  before update on notification_preferences
+  for each row execute procedure update_updated_at();
+
+alter table notification_preferences enable row level security;
+
+create policy "notification_preferences_select" on notification_preferences for select using (auth.uid() = user_id);
+create policy "notification_preferences_insert" on notification_preferences for insert with check (auth.uid() = user_id);
+create policy "notification_preferences_update" on notification_preferences for update using (auth.uid() = user_id);
+create policy "notification_preferences_delete" on notification_preferences for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## What

Players now get an **email** when their DM shares a session note with them or proposes a new session date — with a per-player **opt-out** in `/play/settings` → Email Notifications. Also fixes the report of past date proposals lingering in the players' UI.

## How it works

**New edge function `send-notification-email`** (first email infrastructure in the project — Resend REST API, no SDK):
- Verifies the caller's JWT and that they are a **DM member of the campaign** before anything else.
- Treats the request body as a pointer only: recipients are re-derived server-side (`player_visible_to` ∩ claimed ids → `campaign_members.party_member_id` → `user_id` → `auth.users.email`), so player emails never reach the browser and a caller can't email beyond what the row grants.
- Honors the new `notification_preferences` table (missing row = opted in, so no backfill needed), rate-limits (`email_notify`, 30/h per user), HTML-escapes all user content, and emails **titles only** — never note content.
- **Inert until configured** (returns `{ configured: false }`): activate with `supabase secrets set RESEND_API_KEY=re_...` (+ optional `NOTIFY_FROM_EMAIL`) after verifying the domain in Resend. Supabase's built-in SMTP only covers auth emails, hence Resend.

**Client wiring** — fire-and-forget invoke (the `queueNoteEmbedding` pattern), deliberately **not** a DB trigger: campaign backup restore inserts straight into `notes`/`session_proposals`, and a trigger would mass-email whole parties about years-old content on every restore.
- `NoteEditor.vue` sends a **per-player diff** of `player_visible_to` — adding a second player to an already-shared note emails just that player (the existing `justShared` boolean misses this case).
- `SchedulingTab.vue` notifies on new proposals, and now also posts the 📅 in-app chat announcement (proposals previously notified nobody at all).

**Opt-out UI** — `notification_preferences` migration (`20260805000002`, standard RLS + `update_updated_at` trigger), `useNotificationPreferences` composable, and two toggles in player settings. The sliding-switch markup was duplicated in three places, so it's extracted into shared `ToggleSwitch` / `SettingsToggleRow` components.

**Stale past proposals fix** — both `PlayerSettingsSessions.vue` and `SchedulingTab.vue` captured `today` **once at component setup** and in **UTC**: an installed PWA kept showing yesterday's proposals for days, and timezones ahead of UTC (e.g. NL) showed them until the small hours regardless. Replaced with `useLocalToday()` — a reactive local-calendar date that ticks across midnight.

## Notes for deploy

- Migration + function ship through the existing gated production job (`supabase db push` → `functions deploy`); the Supabase CLI isn't available in this session's environment, so nothing was pushed to the DB from here.
- Until `RESEND_API_KEY` is set, everything works and emails are silently skipped.

## Tests

- `emails.test.ts` (subject/body composition, HTML escaping, UTC-safe date formatting) and `useLocalToday.test.ts` — both in the vitest suite.
- Full `lint` + `test` (2241 passing) + `build` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hdbp6aYfAwzZXR9yz1fZ6A)_