### PR TITLE
feat(dev): component catalogue at /dev/components (#622)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,10 @@ Tests are colocated next to the module they cover — never a `__tests__/` direc
 
 ## Component Granularity
 
+**The shared control primitives are catalogued at `/dev/components`** (dev-only route, stripped from production). It renders every variant and size of `AppButton`, `SegmentedControl`, `AppSelect`, `AppInput` and the two action-row wrappers, in any theme via `?theme=<id>`.
+
+Add a variant or size and you must add it to `BUTTON_VARIANTS` / `BUTTON_SIZES` in `appButtonVariants.ts` — a compile-time assertion there fails otherwise, so the catalogue cannot silently omit it. Check the page at a narrow width too: label collapse is invisible to lint, typecheck and unit tests, and has regressed twice.
+
 **CRITICAL — extract shared UI, never duplicate it:**
 
 If two pieces of UI share structure and differ only in a few values, the structure becomes a component and the diff becomes props. Identify this *before* writing a second copy, not after.

--- a/src/components/common/appButtonVariants.ts
+++ b/src/components/common/appButtonVariants.ts
@@ -102,3 +102,30 @@ export const buttonVariants = cva(
 export type ButtonVariants = VariantProps<typeof buttonVariants>;
 export type ButtonVariant = NonNullable<ButtonVariants["variant"]>;
 export type ButtonSize = NonNullable<ButtonVariants["size"]>;
+
+/* ── Enumerations for the component catalogue (#622) ──────────────────────────
+   `cva` does not expose its own config, so the catalogue at /dev/components
+   cannot read the variant and size keys back off `buttonVariants`. Listing them
+   here would normally rot the moment someone adds a variant — which is exactly
+   the failure the catalogue exists to prevent — so the two assertions below make
+   that a compile error instead of a silently missing column. */
+
+type Assert<T extends true> = T;
+
+export const BUTTON_VARIANTS = [
+  "primary", "outline", "subtle", "ghost", "link", "destructive", "chip", "tinted",
+] as const satisfies readonly ButtonVariant[];
+
+export const BUTTON_SIZES = [
+  "inline-xs", "inline", "xs", "sm", "md", "lg", "icon-xs", "icon-sm",
+] as const satisfies readonly ButtonSize[];
+
+// `[X] extends [never]` rather than `X extends never`: a naked conditional
+// distributes over `never` and collapses to `never`, which would make the guard
+// vacuously pass.
+export type AssertVariantsListed = Assert<
+  [Exclude<ButtonVariant, (typeof BUTTON_VARIANTS)[number]>] extends [never] ? true : false
+>;
+export type AssertSizesListed = Assert<
+  [Exclude<ButtonSize, (typeof BUTTON_SIZES)[number]>] extends [never] ? true : false
+>;

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -877,6 +877,15 @@ export const routes: RouteRecordRaw[] = [
           component: () => import("@/views/dev/SheetCalibrationView.vue"),
           meta: { requiresAuth: false, title: "Sheet Calibration" },
         },
+        {
+          path: "/dev/components",
+          name: "component-catalogue",
+          // No auth, same reason as above: a headless pass screenshots the
+          // primitives per theme via ?theme=<id> to catch visual drift that
+          // lint, typecheck and unit tests cannot see (#622).
+          component: () => import("@/views/dev/ComponentCatalogueView.vue"),
+          meta: { requiresAuth: false, title: "Component Catalogue" },
+        },
       ]
     : []),
 

--- a/src/views/dev/CatalogueSection.vue
+++ b/src/views/dev/CatalogueSection.vue
@@ -1,0 +1,24 @@
+<template>
+  <section class="flex flex-col gap-3">
+    <div>
+      <h2 class="text-heading text-foreground">{{ title }}</h2>
+      <p v-if="note" class="text-caption text-muted-foreground max-w-3xl">{{ note }}</p>
+    </div>
+    <div class="rounded-md border border-border bg-card p-4">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+/**
+ * One titled block in the component catalogue (#622). Split out purely so the
+ * catalogue view stays a list of specimens rather than a list of specimens
+ * interleaved with heading markup.
+ */
+defineProps<{
+  title: string;
+  /** What to look at, or what regressed here before. */
+  note?: string;
+}>();
+</script>

--- a/src/views/dev/ComponentCatalogueView.vue
+++ b/src/views/dev/ComponentCatalogueView.vue
@@ -1,0 +1,248 @@
+<template>
+  <div class="min-h-screen bg-background p-6 flex flex-col gap-8">
+    <header class="flex flex-wrap items-end gap-4 border-b border-border pb-4">
+      <div class="mr-auto">
+        <h1 class="text-title text-foreground">Component catalogue</h1>
+        <p class="text-caption text-muted-foreground max-w-2xl">
+          Every variant and size of the shared control primitives, rendered in the real app
+          build. Dev-only — this route does not exist in production. Drive it headlessly with
+          <code class="text-caption-sm">?theme=&lt;id&gt;</code>.
+        </p>
+      </div>
+      <label class="flex items-center gap-2">
+        <span class="text-eyebrow font-semibold text-muted-foreground">Theme</span>
+        <AppSelect v-model="theme" size="md" aria-label="Theme">
+          <option v-for="t in themes" :key="t.id" :value="t.id">{{ t.label }}</option>
+        </AppSelect>
+      </label>
+    </header>
+
+    <!-- The matrix. Rows are variants, columns are sizes; both come from the
+         enumerations in appButtonVariants.ts, which a compile-time assertion keeps
+         in step with the cva config — so a new variant cannot go unrendered. -->
+    <CatalogueSection
+      title="AppButton — variant × size"
+      note="Every cell is one button. A missing row or column means the enumeration and the cva config have diverged, which will not compile."
+    >
+      <div class="overflow-x-auto">
+        <table class="border-separate border-spacing-3">
+          <thead>
+            <tr>
+              <th class="text-eyebrow font-semibold text-muted-foreground text-left">variant</th>
+              <th
+                v-for="size in BUTTON_SIZES"
+                :key="size"
+                class="text-eyebrow font-semibold text-muted-foreground text-left"
+              >{{ size }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="variant in BUTTON_VARIANTS" :key="variant">
+              <th class="text-label font-semibold text-foreground text-left align-middle">
+                {{ variant }}
+              </th>
+              <td v-for="size in BUTTON_SIZES" :key="size" class="align-middle">
+                <!-- The icon-* sizes are fixed squares meant for a glyph alone;
+                     giving them a label too would overflow the box and misrepresent
+                     them. -->
+                <AppButton
+                  :variant="variant"
+                  :size="size"
+                  :icon="IconWand"
+                  :label="isIconSize(size) ? undefined : 'Aa'"
+                  :aria-label="isIconSize(size) ? `${variant} ${size}` : undefined"
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </CatalogueSection>
+
+    <CatalogueSection
+      title="AppButton — states"
+      note="`active` colours the border only on variants that draw one; on ghost/link/chip a border colour would paint nothing."
+    >
+      <div class="flex flex-col gap-3">
+        <div v-for="variant in BUTTON_VARIANTS" :key="variant" class="flex flex-wrap items-center gap-2">
+          <span class="text-label text-muted-foreground w-24 shrink-0">{{ variant }}</span>
+          <AppButton :variant="variant" label="Default" />
+          <AppButton :variant="variant" label="Active" active />
+          <AppButton :variant="variant" label="Disabled" disabled />
+          <AppButton :variant="variant" label="Loading" loading />
+          <AppButton :variant="variant" label="Icon" :icon="IconWand" />
+          <AppButton :variant="variant" label="Trailing" :icon-right="IconChevronRight" />
+          <AppButton :variant="variant" size="icon-sm" aria-label="Icon only" :icon="IconWand" />
+        </div>
+      </div>
+    </CatalogueSection>
+
+    <CatalogueSection
+      title="AppButton — label collapse"
+      note="Resize the window across the sm (40rem) and lg (64rem) breakpoints. This is the behaviour that has regressed twice: a label that should stay visible silently disappearing, or an inline link gaining a box."
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <AppButton label="Collapses below sm" :icon="IconWand" collapse-label-on-mobile />
+        <AppButton
+          label="Collapses below lg"
+          :icon="IconWand"
+          collapse-label-on-mobile
+          collapse-below="lg"
+        />
+        <AppButton label="Short form below sm" :icon="IconWand" mobile-label="Short" />
+        <AppButton label="Never collapses" :icon="IconWand" />
+      </div>
+      <div class="mt-3 flex flex-wrap items-center gap-2">
+        <ListActionButton label="ListActionButton" :icon="IconWand" />
+        <ListActionButton label="…primary" :icon="IconWand" variant="primary" />
+        <PageHeaderAction label="PageHeaderAction" :icon="IconWand" />
+        <PageHeaderAction label="…destructive" :icon="IconWand" variant="destructive" />
+        <PageHeaderAction label="…never collapses" :collapse-label-on-mobile="false" />
+      </div>
+    </CatalogueSection>
+
+    <CatalogueSection
+      title="SegmentedControl"
+      note="Roving focus: Tab reaches the group once, then the arrow keys move between options and wrap."
+    >
+      <div class="flex flex-col gap-3">
+        <SegmentedControl v-model="segment" :options="SEGMENT_OPTIONS" size="xs" />
+        <SegmentedControl v-model="segment" :options="SEGMENT_OPTIONS" size="sm" />
+        <SegmentedControl v-model="segment" :options="SEGMENT_OPTIONS" size="md" />
+        <SegmentedControl v-model="segment" :options="SEGMENT_OPTIONS" variant="ghost" />
+        <SegmentedControl v-model="segment" :options="SEGMENT_OPTIONS" block />
+        <!-- An option whose value is "" must stay selectable — treating it as a
+             deselect made "All subraces" / "General — all campaigns" unreachable. -->
+        <SegmentedControl v-model="emptyable" :options="EMPTY_VALUE_OPTIONS" />
+        <SegmentedControl v-model="segment" :options="MANY_OPTIONS" wrap size="xs" />
+      </div>
+    </CatalogueSection>
+
+    <CatalogueSection
+      title="AppSelect"
+      note="Native picker with appearance:none — the caret is drawn by the base rule in main.css and follows the theme. Opening one still gives the OS menu, which is the point on mobile."
+    >
+      <div class="flex flex-wrap items-end gap-3">
+        <label v-for="size in SELECT_SIZES" :key="size" class="flex flex-col gap-1">
+          <span class="text-eyebrow font-semibold text-muted-foreground">{{ size }}</span>
+          <AppSelect v-model="selectValue" :size="size" :aria-label="`Select ${size}`">
+            <option value="a">Created</option>
+            <option value="b">A much longer option label</option>
+          </AppSelect>
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="text-eyebrow font-semibold text-muted-foreground">ListFilterSelect</span>
+          <ListFilterSelect v-model="selectValue" aria-label="Filter">
+            <option value="a">Created</option>
+            <option value="b">Updated</option>
+          </ListFilterSelect>
+        </label>
+      </div>
+    </CatalogueSection>
+
+    <CatalogueSection title="AppInput" note="size × tone, plus centre alignment for numeric steppers.">
+      <div class="flex flex-col gap-3">
+        <div v-for="tone in INPUT_TONES" :key="tone" class="flex flex-wrap items-end gap-3">
+          <span class="text-label text-muted-foreground w-16 shrink-0 self-center">{{ tone }}</span>
+          <label v-for="size in INPUT_SIZES" :key="size" class="flex flex-col gap-1">
+            <span class="text-eyebrow font-semibold text-muted-foreground">{{ size }}</span>
+            <AppInput
+              v-model="inputValue"
+              :size="size"
+              :tone="tone"
+              placeholder="Placeholder"
+              class="w-40"
+            />
+          </label>
+          <AppInput v-model="numberValue" type="number" :tone="tone" align="center" class="w-20" />
+        </div>
+      </div>
+    </CatalogueSection>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * /dev/components — the rendered matrix for the shared control primitives (#622).
+ *
+ * It exists because the two regressions that got through #620 were both visual and
+ * both invisible to lint, typecheck and the unit tests: thirteen padding-free links
+ * silently gained a box, and seven Save buttons silently lost their label. A grid
+ * shows either at a glance.
+ *
+ * Dev-only and unauthenticated, matching SheetCalibrationView, so a headless
+ * browser can screenshot it per theme via `?theme=<id>` without a login.
+ */
+import { computed, onBeforeUnmount, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import type { LocationQueryValue } from "vue-router";
+import { IconWand, IconChevronRight } from "@/lib/icons";
+import { useTheme } from "@/composables/useTheme";
+import AppButton from "@/components/common/AppButton.vue";
+import AppInput from "@/components/common/AppInput.vue";
+import AppSelect from "@/components/common/AppSelect.vue";
+import ListFilterSelect from "@/components/common/ListFilterSelect.vue";
+import ListActionButton from "@/components/common/ListActionButton.vue";
+import PageHeaderAction from "@/components/common/PageHeaderAction.vue";
+import SegmentedControl from "@/components/common/SegmentedControl.vue";
+import CatalogueSection from "./CatalogueSection.vue";
+import {
+  BUTTON_VARIANTS,
+  BUTTON_SIZES,
+  type ButtonSize,
+} from "@/components/common/appButtonVariants";
+
+const SEGMENT_OPTIONS = [
+  { value: "url", label: "URL" },
+  { value: "upload", label: "Upload" },
+  { value: "browse", label: "Browse" },
+] as const;
+
+const EMPTY_VALUE_OPTIONS = [
+  { value: "", label: "General — all campaigns" },
+  { value: "campaign", label: "This campaign" },
+] as const;
+
+const MANY_OPTIONS = Array.from({ length: 9 }, (_, i) => ({
+  value: `d${i}`,
+  label: `Discipline ${i + 1}`,
+}));
+
+const isIconSize = (size: ButtonSize) => size.startsWith("icon-");
+
+const SELECT_SIZES = ["xs", "sm", "md", "lg"] as const;
+const INPUT_SIZES = ["xs", "sm", "md", "lg"] as const;
+const INPUT_TONES = ["default", "muted", "bare"] as const;
+
+const segment = ref<string>("url");
+const emptyable = ref<string>("campaign");
+const selectValue = ref<string>("a");
+const inputValue = ref<string | number | null>("Ancient Red Dragon");
+const numberValue = ref<string | number | null>(12);
+
+const route = useRoute();
+const router = useRouter();
+const { themes, setTheme, activeThemeId } = useTheme();
+
+// Restore whatever the developer had before they opened this page: setTheme
+// persists to localStorage, and a catalogue should not quietly repaint the app.
+const themeOnEntry = activeThemeId.value;
+onBeforeUnmount(() => setTheme(themeOnEntry));
+
+function firstQuery(v: LocationQueryValue | LocationQueryValue[]): string | undefined {
+  const val = Array.isArray(v) ? v[0] : v;
+  return val ?? undefined;
+}
+
+const theme = computed<string>({
+  get: () => firstQuery(route.query.theme) ?? activeThemeId.value,
+  set: (id) => {
+    setTheme(id);
+    router.replace({ query: { ...route.query, theme: id } });
+  },
+});
+
+// Apply a theme arriving by query string, so a headless pass gets what it asked for.
+const requested = firstQuery(route.query.theme);
+if (requested && requested !== activeThemeId.value) setTheme(requested);
+</script>


### PR DESCRIPTION
Closes #622.

## Why

The two regressions that got through #620 were both visual and both invisible to lint, typecheck and the unit tests:

- 13 padding-free inline links silently gained a `px-3 py-1.5` box
- 7 Save buttons silently lost their label (and their "Saving…" state) when a default flipped

I only caught them by scripting diff analysis. A rendered matrix shows either at a glance.

## What

`/dev/components` — every variant and size of `AppButton`, `SegmentedControl`, `AppSelect`, `AppInput` and the two action-row wrappers, in any theme via `?theme=<id>`.

Follows the existing `SheetCalibrationView` pattern: dev-only, unauthenticated so a headless browser can drive it, and **stripped from production** (verified — the route name appears nowhere in `dist/`).

## Why not Storybook

Cost was the smaller reason. The decisive one: this renders inside the real app shell and the real Tailwind v4 build, so it **cannot drift from what ships**. A parallel Storybook build can, and a catalogue that renders differently from the app is worse than no catalogue.

What we give up — args/controls panel, per-story isolation, a11y addon, a shareable URL for non-devs — is not load-bearing for "did the matrix shift?". #622 records Storybook as the escalation if that changes; Histoire is not a live option (stalled at `1.0.0-beta.1` since January).

## The anti-drift guarantee

`cva` does not expose its own config, so the catalogue can't read the variant/size keys back off `buttonVariants`. Hard-coded lists would rot the moment someone adds a variant — exactly the failure this page exists to prevent.

So `appButtonVariants.ts` now exports `BUTTON_VARIANTS` / `BUTTON_SIZES` plus two type-level assertions that make divergence a **compile error**. Verified by deleting `tinted` from the list:

```
appButtonVariants.ts(127,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

(`[X] extends [never]` rather than `X extends never` — a naked conditional distributes over `never` and the guard would pass vacuously.)

## It paid for itself while being built

- The `icon-xs` / `icon-sm` cells overflowed, because a label was being passed into a fixed square. Fixed in the catalogue.
- Rendering `tinted` beside `outline` makes #623's complaint — that it is a naming convention, not a variant — visible rather than theoretical. It shows as a plain bordered box, because it resolves to just `border`.
- At 420px, all seven label-collapse specimens behave correctly: icon-only for the collapsing ones, full label for `:collapse-label-on-mobile="false"`. That is the check that would have caught the 7 Save buttons.

## Verification

`lint` · `vue-tsc` · `build` clean, `2542 tests / 221 files` pass. Screenshotted in both `tome` (light) and `grimoire` (dark), and at 420px for the collapse behaviour. `CLAUDE.md` gained a pointer under Component Granularity so the next person adding a variant updates the list.