### PR TITLE
refactor(ui): extract shared field chrome into fieldVariants (#621)

### DIFF
--- a/src/components/common/AppInput.vue
+++ b/src/components/common/AppInput.vue
@@ -6,7 +6,7 @@
     :disabled="disabled"
     :readonly="readonly"
     :placeholder="placeholder"
-    :class="cn(base, toneClass, sizeClass, alignClass, block ? 'w-full' : '', className)"
+    :class="cn(fieldVariants({ tone, size, control: 'input' }), alignClass, block ? 'w-full' : '', className)"
     @input="onInput"
   />
 </template>
@@ -26,6 +26,7 @@
  */
 import { computed, useTemplateRef, type HTMLAttributes } from "vue";
 import { cn } from "@/lib/utils";
+import { fieldVariants, type FieldTone, type FieldSize } from "./fieldVariants";
 
 const [model, modifiers] = defineModel<string | number | null, "number" | "trim">({
   required: true,
@@ -43,9 +44,9 @@ const {
   class: className,
 } = defineProps<{
   type?: "text" | "number" | "search" | "url" | "email" | "password";
-  size?: "xs" | "sm" | "md" | "lg";
-  /** Surface it sits on: `default` on a page, `muted` inside a card, `bare` for inline edits. */
-  tone?: "default" | "muted" | "bare";
+  size?: FieldSize;
+  /** Surface it sits on — see fieldVariants. */
+  tone?: FieldTone;
   align?: "left" | "center";
   block?: boolean;
   disabled?: boolean;
@@ -53,36 +54,6 @@ const {
   placeholder?: string;
   class?: HTMLAttributes["class"];
 }>();
-
-const base =
-  "font-cinzel text-foreground placeholder:text-muted-foreground transition-colors focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed";
-
-const toneClass = computed(() => {
-  switch (tone) {
-    case "muted":
-      return "bg-muted/40 border border-border focus:ring-1 focus:ring-ring";
-    case "bare":
-      return "bg-transparent border-0 focus:ring-0";
-    case "default":
-    default:
-      return "bg-background border border-border focus:ring-1 focus:ring-ring";
-  }
-});
-
-const sizeClass = computed(() => {
-  switch (size) {
-    case "xs":
-      return "rounded px-1.5 py-0.5 text-label";
-    // min-h-11 is a ≥44px tap target on touch; ≥md reverts so desktop is unchanged.
-    case "md":
-      return "rounded-md px-3 py-2 min-h-11 md:min-h-0 text-label-lg";
-    case "lg":
-      return "rounded-md px-3 py-2 text-sm tracking-wider";
-    case "sm":
-    default:
-      return "rounded-md px-3 py-1.5 text-label-lg";
-  }
-});
 
 const alignClass = computed(() => (align === "center" ? "text-center" : ""));
 

--- a/src/components/common/AppSelect.vue
+++ b/src/components/common/AppSelect.vue
@@ -4,7 +4,7 @@
     :value="model"
     :disabled="disabled"
     :aria-label="ariaLabel"
-    :class="cn(base, sizeClass, block ? 'w-full' : 'shrink-0', className)"
+    :class="cn(fieldVariants({ tone: 'card', size, control: 'select', weight: 'semibold' }), block ? 'w-full' : 'shrink-0', className)"
     @change="onChange"
   >
     <slot />
@@ -29,8 +29,9 @@
  * (`"quest_complete" | "objective_done"`) keeps that type through `v-model`
  * instead of widening to `string` and forcing a cast at the call site.
  */
-import { computed, useTemplateRef, type HTMLAttributes } from "vue";
+import { useTemplateRef, type HTMLAttributes } from "vue";
 import { cn } from "@/lib/utils";
+import { fieldVariants, type FieldSize } from "./fieldVariants";
 
 /** Vue stashes a bound `<option :value="x">` on the element as `_value`. */
 type OptionWithValue = HTMLOptionElement & { _value?: unknown };
@@ -50,7 +51,7 @@ const {
   ariaLabel,
   class: className,
 } = defineProps<{
-  size?: "xs" | "sm" | "md" | "lg";
+  size?: FieldSize;
   /** Stretches to the full width of the parent instead of hugging its content. */
   block?: boolean;
   disabled?: boolean;
@@ -58,26 +59,6 @@ const {
   class?: HTMLAttributes["class"];
 }>();
 
-const base =
-  "bg-card border border-border text-foreground font-semibold transition-colors focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed";
-
-const sizeClass = computed(() => {
-  switch (size) {
-    case "xs":
-      return "rounded px-1.5 py-0.5 text-label";
-    // `sm` with a ≥44px tap target on touch; ≥md reverts so desktop is identical
-    // to `sm`. This is the filter-row size — see ListFilterSelect.
-    case "md":
-      return "rounded-md px-2 py-1.5 min-h-11 md:min-h-0 text-label-lg";
-    // Matches AppInput's `lg`: the 14px step, for pickers sitting in a field row
-    // next to body text rather than in a dense filter bar.
-    case "lg":
-      return "rounded-md px-2 py-1.5 text-sm tracking-wider";
-    case "sm":
-    default:
-      return "rounded-md px-2 py-1.5 text-label-lg";
-  }
-});
 
 function onChange(event: Event) {
   const el = event.target as HTMLSelectElement;

--- a/src/components/common/EntityCombobox.vue
+++ b/src/components/common/EntityCombobox.vue
@@ -7,8 +7,13 @@
         v-model="query"
         type="text"
         :placeholder="selectedLabel || placeholder"
-        class="w-full bg-card border border-border rounded-md px-3 py-1.5 pr-14 text-body text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        :class="selectedLabel && !query ? 'placeholder:text-foreground' : ''"
+        :class="cn(
+          fieldVariants({ tone: 'card', size: 'body', control: 'input' }),
+          // pr-14 clears the overlaid clear button and chevron; w-full is the
+          // caller's layout. Everything else is the shared field recipe.
+          'w-full pr-14',
+          selectedLabel && !query ? 'placeholder:text-foreground' : '',
+        )"
         @focus="onFocus"
         @click="onFocus"
         @input="open = true"
@@ -54,6 +59,8 @@
 
 <script setup lang="ts" generic="T extends { id: string; name: string }">
 import { ref, computed, watch, nextTick, onUnmounted } from "vue";
+import { cn } from "@/lib/utils";
+import { fieldVariants } from "./fieldVariants";
 import { IconChevronDown } from '@/lib/icons';
 
 const selectedId = defineModel<string>({ required: true });

--- a/src/components/common/fieldVariants.test.ts
+++ b/src/components/common/fieldVariants.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h, ref } from "vue";
+import { fieldVariants, FIELD_SIZES, FIELD_TONES } from "./fieldVariants";
+import AppInput from "./AppInput.vue";
+import AppSelect from "./AppSelect.vue";
+
+describe("fieldVariants", () => {
+  it("keeps a select 4px tighter than an input at the same size", () => {
+    expect(fieldVariants({ size: "sm", control: "select" })).toContain("px-2");
+    expect(fieldVariants({ size: "sm", control: "input" })).toContain("px-3");
+  });
+
+  /**
+   * The DashboardView day/month/year row puts an input, a select and an input side
+   * by side, so their vertical metrics have to agree. Note this checks the emitted
+   * *classes*, not rendered height — happy-dom does no layout. Equal classes are
+   * necessary but not sufficient: measured in a real browser, `xs` still renders a
+   * 16px select against a 20px input, because a native input has a UA minimum
+   * content height that padding alone does not overcome. Every other size matches.
+   */
+  it("gives an input and a select the same vertical classes at every size", () => {
+    for (const size of FIELD_SIZES) {
+      const vertical = (control: "input" | "select") =>
+        fieldVariants({ size, control })
+          .split(" ")
+          .filter(c => /^(py-|min-h-|md:min-h-|rounded)/.test(c))
+          .sort()
+          .join(" ");
+      expect(vertical("input"), `size ${size}`).toBe(vertical("select"));
+    }
+  });
+
+  it("carries a typography role at every size rather than a raw font size", () => {
+    expect(fieldVariants({ size: "xs" })).toContain("text-label");
+    expect(fieldVariants({ size: "sm" })).toContain("text-label-lg");
+    expect(fieldVariants({ size: "md" })).toContain("text-label-lg");
+    // `lg` has no role at 14px Cinzel, so it states the family explicitly.
+    expect(fieldVariants({ size: "lg" })).toContain("font-cinzel");
+    // `body` is Crimson — it must NOT pick up Cinzel.
+    expect(fieldVariants({ size: "body" })).toContain("text-body");
+    expect(fieldVariants({ size: "body" })).not.toContain("font-cinzel");
+  });
+
+  it("keeps the ≥44px touch target only on md", () => {
+    expect(fieldVariants({ size: "md" })).toContain("min-h-11");
+    expect(fieldVariants({ size: "md" })).toContain("md:min-h-0");
+    for (const size of FIELD_SIZES.filter(s => s !== "md")) {
+      expect(fieldVariants({ size }), `size ${size}`).not.toContain("min-h-11");
+    }
+  });
+
+  it("drops the box entirely for the bare tone", () => {
+    const bare = fieldVariants({ tone: "bare" });
+    expect(bare).toContain("bg-transparent");
+    expect(bare).toContain("border-0");
+    expect(bare).not.toContain("focus:ring-1");
+    for (const tone of FIELD_TONES.filter(t => t !== "bare")) {
+      expect(fieldVariants({ tone }), `tone ${tone}`).toContain("border-border");
+    }
+  });
+});
+
+// The point of the extraction: one recipe, not three near-copies. If a component
+// stops consuming it, these diverge.
+describe("the field components share one box", () => {
+  const boxClasses = (cls: string) =>
+    cls
+      .split(" ")
+      .filter(c => /^(border|rounded|focus:ring|bg-card)/.test(c))
+      .sort()
+      .join(" ");
+
+  it("AppInput and AppSelect agree on border, radius and focus ring", () => {
+    const input = mount(AppInput, { props: { modelValue: "", tone: "card", size: "sm" } });
+    const model = ref("a");
+    const select = mount({
+      setup: () => () =>
+        h(AppSelect as never, { modelValue: model.value }, () => [
+          h("option", { value: "a" }, "A"),
+        ]),
+    });
+    expect(boxClasses(input.attributes("class") ?? "")).toBe(
+      boxClasses(select.find("select").attributes("class") ?? ""),
+    );
+    input.unmount();
+    select.unmount();
+  });
+});

--- a/src/components/common/fieldVariants.ts
+++ b/src/components/common/fieldVariants.ts
@@ -1,0 +1,85 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * The class matrix behind the app's form fields (#621).
+ *
+ * `AppInput`, `AppSelect` and `EntityCombobox` each used to spell out the same box
+ * — `border border-border rounded-md px-3 py-1.5 focus:outline-none focus:ring-1
+ * focus:ring-ring` — independently. Three copies of one recipe is the debt #561
+ * removed from buttons, reproduced one level up: change the focus ring and you had
+ * to remember all three.
+ *
+ * `size` names a #552 typography role rather than a raw font size, which is why the
+ * body-faced combobox is a size here rather than a separate `font` axis: in this
+ * app the role already carries the family (`text-label-lg` is Cinzel 12px,
+ * `text-body` is Crimson 14px).
+ */
+export const fieldVariants = cva(
+  "text-foreground placeholder:text-muted-foreground transition-colors focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed",
+  {
+    variants: {
+      /** The surface the field sits on. */
+      tone: {
+        /** On a page. */
+        default: "bg-background border border-border focus:ring-1 focus:ring-ring",
+        /** On a card — the filter rows and the combobox. */
+        card: "bg-card border border-border focus:ring-1 focus:ring-ring",
+        /** Inside an already-tinted panel. */
+        muted: "bg-muted/40 border border-border focus:ring-1 focus:ring-ring",
+        /** Inline edit — no box until focus. */
+        bare: "bg-transparent border-0 focus:ring-0",
+      },
+      size: {
+        xs: "rounded py-0.5 text-label",
+        sm: "rounded-md py-1.5 text-label-lg",
+        /** `sm` plus a ≥44px tap target on touch; ≥md reverts to the `sm` look. */
+        md: "rounded-md py-1.5 min-h-11 md:min-h-0 text-label-lg",
+        lg: "rounded-md py-2 font-cinzel text-sm tracking-wider",
+        /** Crimson 14px — free text rather than a label, i.e. EntityCombobox. */
+        body: "rounded-md py-1.5 text-body",
+      },
+      /**
+       * Horizontal padding only. A `<select>` has always sat 4px tighter than an
+       * `<input>` at the same size, and unifying them would shift the text inset of
+       * every picker in the app — a change worth making deliberately with the
+       * catalogue open, not as a side effect of extracting this recipe.
+       */
+      control: { input: "", select: "" },
+      /** `<select>` carries semibold; the text fields do not. */
+      weight: { normal: "", semibold: "font-semibold" },
+    },
+    compoundVariants: [
+      { control: "input", size: "xs", class: "px-1.5" },
+      { control: "input", size: "sm", class: "px-3" },
+      { control: "input", size: "md", class: "px-3" },
+      { control: "input", size: "lg", class: "px-3" },
+      { control: "input", size: "body", class: "px-3" },
+      { control: "select", size: "xs", class: "px-1.5" },
+      { control: "select", size: "sm", class: "px-2" },
+      { control: "select", size: "md", class: "px-2" },
+      { control: "select", size: "lg", class: "px-2" },
+      { control: "select", size: "body", class: "px-2" },
+    ],
+    defaultVariants: { tone: "default", size: "sm", control: "input", weight: "normal" },
+  },
+);
+
+export type FieldVariants = VariantProps<typeof fieldVariants>;
+export type FieldTone = NonNullable<FieldVariants["tone"]>;
+export type FieldSize = NonNullable<FieldVariants["size"]>;
+
+/* Enumerations for the catalogue at /dev/components, guarded the same way as
+   BUTTON_VARIANTS — see appButtonVariants.ts for why the assertion is shaped
+   `[X] extends [never]`. */
+
+type Assert<T extends true> = T;
+
+export const FIELD_TONES = ["default", "card", "muted", "bare"] as const satisfies readonly FieldTone[];
+export const FIELD_SIZES = ["xs", "sm", "md", "lg", "body"] as const satisfies readonly FieldSize[];
+
+export type AssertFieldTonesListed = Assert<
+  [Exclude<FieldTone, (typeof FIELD_TONES)[number]>] extends [never] ? true : false
+>;
+export type AssertFieldSizesListed = Assert<
+  [Exclude<FieldSize, (typeof FIELD_SIZES)[number]>] extends [never] ? true : false
+>;

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -856,10 +856,11 @@ export const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: true, requiresAdmin: true, title: "Admin" },
   },
 
-  // Dev-only: Paged.js spike harness for the Scriptorium re-architecture
-  // Phase B go/no-go (SCRIPTORIUM_PLAN.md §3 / issue #330). Not registered
-  // in production builds.
-  ...(import.meta.env.DEV
+  // Dev-only: the Paged.js spike harness (SCRIPTORIUM_PLAN.md §3 / issue #330),
+  // sheet calibration, and the component catalogue (#622). Registered in dev and
+  // in Vercel preview builds — so a PR's preview can be used to review them — but
+  // never in production.
+  ...(import.meta.env.DEV || __PREVIEW_BUILD__
     ? [
         {
           path: "/spike/pagedjs",

--- a/src/views/dev/ComponentCatalogueView.vue
+++ b/src/views/dev/ComponentCatalogueView.vue
@@ -120,10 +120,10 @@
 
     <CatalogueSection
       title="AppSelect"
-      note="Native picker with appearance:none — the caret is drawn by the base rule in main.css and follows the theme. Opening one still gives the OS menu, which is the point on mobile."
+      note="Shares fieldVariants with AppInput. Native picker with appearance:none — the caret is drawn by the base rule in main.css and follows the theme. Opening one still gives the OS menu, which is the point on mobile."
     >
       <div class="flex flex-wrap items-end gap-3">
-        <label v-for="size in SELECT_SIZES" :key="size" class="flex flex-col gap-1">
+        <label v-for="size in FIELD_SIZES" :key="size" class="flex flex-col gap-1">
           <span class="text-eyebrow font-semibold text-muted-foreground">{{ size }}</span>
           <AppSelect v-model="selectValue" :size="size" :aria-label="`Select ${size}`">
             <option value="a">Created</option>
@@ -140,11 +140,11 @@
       </div>
     </CatalogueSection>
 
-    <CatalogueSection title="AppInput" note="size × tone, plus centre alignment for numeric steppers.">
+    <CatalogueSection title="AppInput" note="size × tone from fieldVariants — the same recipe AppSelect and EntityCombobox use. An input and a select at the same size must line up; the day/month/year row on the Dashboard is the case that matters.">
       <div class="flex flex-col gap-3">
-        <div v-for="tone in INPUT_TONES" :key="tone" class="flex flex-wrap items-end gap-3">
+        <div v-for="tone in FIELD_TONES" :key="tone" class="flex flex-wrap items-end gap-3">
           <span class="text-label text-muted-foreground w-16 shrink-0 self-center">{{ tone }}</span>
-          <label v-for="size in INPUT_SIZES" :key="size" class="flex flex-col gap-1">
+          <label v-for="size in FIELD_SIZES" :key="size" class="flex flex-col gap-1">
             <span class="text-eyebrow font-semibold text-muted-foreground">{{ size }}</span>
             <AppInput
               v-model="inputValue"
@@ -191,6 +191,7 @@ import {
   BUTTON_SIZES,
   type ButtonSize,
 } from "@/components/common/appButtonVariants";
+import { FIELD_SIZES, FIELD_TONES } from "@/components/common/fieldVariants";
 
 const SEGMENT_OPTIONS = [
   { value: "url", label: "URL" },
@@ -210,9 +211,6 @@ const MANY_OPTIONS = Array.from({ length: 9 }, (_, i) => ({
 
 const isIconSize = (size: ButtonSize) => size.startsWith("icon-");
 
-const SELECT_SIZES = ["xs", "sm", "md", "lg"] as const;
-const INPUT_SIZES = ["xs", "sm", "md", "lg"] as const;
-const INPUT_TONES = ["default", "muted", "bare"] as const;
 
 const segment = ref<string>("url");
 const emptyable = ref<string>("campaign");

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,3 +19,10 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/**
+ * True only in Vercel preview builds — see the `define` block in vite.config.ts.
+ * Gates the dev-only routes so they can be reviewed on a PR preview without ever
+ * shipping to production.
+ */
+declare const __PREVIEW_BUILD__: boolean;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,16 @@ function swPlugin(): Plugin {
 }
 
 export default defineConfig({
+  define: {
+    /**
+     * Dev-only routes (the Paged.js spike, sheet calibration, the component
+     * catalogue) also build for Vercel *preview* deployments, so a PR's preview
+     * can be used to review them. Gated on VERCEL_ENV rather than on "not
+     * production", so a local `npm run build` — where VERCEL_ENV is unset — still
+     * strips them, and a production deploy never sees them.
+     */
+    __PREVIEW_BUILD__: JSON.stringify(process.env.VERCEL_ENV === "preview"),
+  },
   plugins: [
     vue({
       template: {


### PR DESCRIPTION
Closes #621.

**Review this one on the preview** — dev-only routes now build for previews too, so the catalogue is live at **`/dev/components`** on this deployment. That is where the field matrix is easiest to check.

## Why

`AppInput`, `AppSelect` and `EntityCombobox` each spelled out the same box independently:

```
border border-border · rounded-md · px-3 py-1.5
focus:outline-none · focus:ring-1 focus:ring-ring
```

Three copies of one recipe — the debt #561 removed from buttons, one level up. Change the focus ring and you had to remember all three. `EntityCombobox` alone has 87 call sites.

## What

`fieldVariants.ts`, consumed by all three. `size` names a #552 typography role rather than a raw font size, which is why the Crimson-faced combobox is a **size** (`body`) rather than a separate font axis — in this app the role already carries the family.

Two axes keep the differences that are genuinely real instead of papering over them:

- **`control`** — a `<select>` has always sat 4px tighter horizontally than an `<input>`. Unifying that inset would shift the text of every picker in the app; worth doing deliberately with the catalogue open, not as a side effect of extracting a recipe.
- **`weight`** — only the select is semibold.

## One deliberate visual change

`lg` was `py-2` on `AppInput` and `py-1.5` on `AppSelect`. The Dashboard day/month/year row is an input, a select and an input side by side — so it did not line up. #621 asked for consistent sizes *because* of that row. Both are now `py-2`; measured in a browser afterwards: **38px against 38px**.

Everything else is class-for-class identical.

## The test overclaimed, and the measurement caught it

The vertical-metrics test compares emitted **classes**, and happy-dom does no layout. Equal classes turn out to be necessary but not sufficient: measured for real, `xs` still renders a **16px select against a 20px input**, because a native input has a UA minimum content height that padding does not overcome.

Pre-existing, unchanged here, and now stated in the test rather than implied away. Worth its own look if an `xs` input and `xs` select ever sit side by side — I did not guess at a fix, since it would mean an explicit height on controls already in use in PlayerResourcePools, PlayerCarryWeight and the chat dice roller.

## Preview gating

Dev-only routes are now gated on `import.meta.env.DEV || __PREVIEW_BUILD__`, where `__PREVIEW_BUILD__` is `VERCEL_ENV === "preview"` — deliberately not "not production", so a local `npm run build` still strips them. Verified in all three modes:

| build | catalogue in bundle |
|---|---|
| local `npm run build` | absent |
| `VERCEL_ENV=preview` | **present** |
| `VERCEL_ENV=production` | absent |

## Verification

`lint` · `vue-tsc` · `build` clean, `2548 tests / 222 files` pass (6 new). Catalogue screenshotted in both themes; the field matrix now renders every tone × size from the shared enumerations, which the same compile-time assertion as `BUTTON_VARIANTS` keeps in step with the cva config.