### PR TITLE
perf(css): load the datepicker stylesheets from their two consumers

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,7 +6,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800;900&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Cardo:ital@0;1&family=UnifrakturCook:wght@700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&family=Alegreya:ital,wght@0,400;0,500;0,700;1,400;1,700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Shippori+Mincho:wght@500;600;700&family=Inter:wght@400;500;600;700;800&family=Source+Sans+3:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "@vuepic/vue-datepicker/dist/main.css";
 @import "./scriptorium/theme-base.css";
 @import "./scriptorium/theme-onednd2024.css";
 @import "./scriptorium/theme-phb2014.css";
@@ -15,10 +14,14 @@
 
 /* App stylesheet manifest. Order matters: fonts and Tailwind first, then tokens,
    then everything built on them. Several rules in base.css are unlayered on
-   purpose — read the note there before moving anything. */
+   purpose — read the note there before moving anything.
+
+   The VueDatePicker stylesheets are deliberately absent: they are imported by the
+   two components that use a datepicker, so their ~30 kB does not sit on the
+   critical path for the majority of visitors who never open one. See
+   vendor/datepicker.css. */
 @import "./theme.css";
 @import "./typography.css";
 @import "./utilities.css";
 @import "./components.css";
 @import "./base.css";
-@import "./vendor/datepicker.css";

--- a/src/assets/vendor/datepicker.css
+++ b/src/assets/vendor/datepicker.css
@@ -1,24 +1,17 @@
-/* VueDatePicker (@vuepic/vue-datepicker) theme overrides.
+/* Loaded by the components that render a datepicker, not by the global manifest:
+   most visitors never open one, and this plus the library's own stylesheet is a
+   tenth of the critical-path CSS. Importing a .css file from a component is still
+   global, not scoped — which this needs, since the calendar menu teleports to
+   <body>. Only the loading is deferred.
 
-   Vendor CSS, not app CSS — kept out of main.css because it is ~140 lines of
-   `!important` fighting the library's own stylesheet.
-
-   Imported by the two components that render a datepicker (NoteEditor,
-   SchedulingTab) rather than by the global manifest, so this and the library's own
-   24 kB stay off the critical path for the majority of visitors who never open one.
-   Importing a plain .css file from a component is still GLOBAL, not scoped — which
-   matters, because the calendar menu teleports to <body> and could not be reached
-   by scoped styles. It is only the *loading* that is deferred, not the scope. */
-
-/* The library's own stylesheet, imported here rather than by each consumer so
-   the two always land in the same chunk in this order — some overrides below
-   are not `!important` and would lose if the vendor CSS happened to load after. */
+   The library's stylesheet is pulled in here rather than beside this file at each
+   call site so the two share a chunk: some overrides below are not `!important`
+   and would lose if the vendor CSS happened to load second. */
 @import "@vuepic/vue-datepicker/dist/main.css";
 
 /* ─────────────────────────────────────────────────────────────────────────────
-   VueDatePicker theme — maps --dp-* vars to app theme vars so the datepicker
-   respects both light and dark mode automatically. The calendar menu teleports
-   to <body>, so overrides must live here in the global stylesheet (not scoped).
+   --dp-* mapped onto the app's theme vars, so the picker follows a theme change
+   rather than needing a dark/light variant of its own.
 ───────────────────────────────────────────────────────────────────────────── */
 :root {
   --dp-background-color: var(--card);

--- a/src/assets/vendor/datepicker.css
+++ b/src/assets/vendor/datepicker.css
@@ -1,8 +1,19 @@
 /* VueDatePicker (@vuepic/vue-datepicker) theme overrides.
 
    Vendor CSS, not app CSS — kept out of main.css because it is ~140 lines of
-   `!important` fighting the library's own stylesheet. The calendar menu teleports
-   to <body>, so these must be global rather than scoped. */
+   `!important` fighting the library's own stylesheet.
+
+   Imported by the two components that render a datepicker (NoteEditor,
+   SchedulingTab) rather than by the global manifest, so this and the library's own
+   24 kB stay off the critical path for the majority of visitors who never open one.
+   Importing a plain .css file from a component is still GLOBAL, not scoped — which
+   matters, because the calendar menu teleports to <body> and could not be reached
+   by scoped styles. It is only the *loading* that is deferred, not the scope. */
+
+/* The library's own stylesheet, imported here rather than by each consumer so
+   the two always land in the same chunk in this order — some overrides below
+   are not `!important` and would lose if the vendor CSS happened to load after. */
+@import "@vuepic/vue-datepicker/dist/main.css";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    VueDatePicker theme — maps --dp-* vars to app theme vars so the datepicker

--- a/src/components/campaign/SchedulingTab.vue
+++ b/src/components/campaign/SchedulingTab.vue
@@ -313,6 +313,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { VueDatePicker } from "@vuepic/vue-datepicker";
+import "@/assets/vendor/datepicker.css";
 import { useTheme } from "@/composables/useTheme";
 import { IconAdd, IconAddEvent, IconCalendar, IconCalendarCheck, IconCheck, IconClose, IconCopy, IconDelete, IconDownload, IconEdit, IconRefresh, IconRemoveEvent } from '@/lib/icons';
 import {

--- a/src/components/notes/NoteEditor.vue
+++ b/src/components/notes/NoteEditor.vue
@@ -247,6 +247,7 @@ const { confirm } = useConfirm();
 import { ref, computed, watch } from "vue";
 import { useRouter } from "vue-router";
 import { VueDatePicker } from "@vuepic/vue-datepicker";
+import "@/assets/vendor/datepicker.css";
 import RichTextEditor from "../common/RichTextEditor.vue";
 import InlineCalendarEventModal from "@/components/calendar/InlineCalendarEventModal.vue";
 import ChroniclerGenerateDialog from "./ChroniclerGenerateDialog.vue";


### PR DESCRIPTION
Follow-up from the main.css split (#627) — spotted while reviewing where that vendor block ended up.

## Why

The VueDatePicker stylesheets sat in the global manifest, so **every visitor paid for them whether or not they ever opened a date field**. Only two components render one:

- `src/components/notes/NoteEditor.vue`
- `src/components/campaign/SchedulingTab.vue`

Between the library's own CSS (24 kB) and our overrides (5.5 kB) that is ~27 kB — a shade over **11% of the critical-path stylesheet**.

## What

| | before | after |
|---|--:|--:|
| critical-path CSS | 240,450 B | **213,143 B** |
| `.dp__` rules in it | 175 | **0** |
| datepicker CSS | eager | one non-eager 27,111 B chunk |

Importing a plain `.css` file from a component is still **global, not scoped** — which is exactly what this needs, since the calendar menu teleports to `<body>` and could never have been reached by scoped styles. Only the *loading* is deferred.

## The ordering trap

My first attempt imported the library CSS and our overrides side by side in each component. That builds and looks fine — but they landed in **different chunks**: the library in `vendor`, the overrides in the consumer's chunk. Not every override is `!important`, so any that aren't would have lost had the vendor chunk happened to load second.

So the library's stylesheet is now imported from the top of `vendor/datepicker.css` instead. One file, one chunk, guaranteed order.

## Verification

- No `.dp__` rule remains in the main stylesheet.
- All 27,111 bytes sit in a single chunk.
- `index.html` references neither that chunk nor the vendor bundle, so both are genuinely lazy.
- `lint` · `vue-tsc` · `build` clean, `2551 tests / 222 files` pass.

Worth clicking a date field on the preview (a note's reminder, or Campaign Settings → Scheduling) to confirm it still looks right on first open.