### PR TITLE
docs: trim this refactor's comments back to why

### DIFF
--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -48,16 +48,13 @@
   --color-ring: var(--ring);
 
   /* ── Semantic tones (#623) ───────────────────────────────────────────────
-     What a coloured control *means*, not which hue it happens to be. AppButton's
-     `tinted` variant is built entirely from these, so 35 call sites say
-     `tone="danger"` instead of `bg-red-500/10 border-red-500/30 text-red-400`.
+     What a coloured control means, not which hue it happens to be — naming these
+     for the hue would pin the decision at every call site instead of here.
 
-     Declared the same way as the shadcn tokens above — `var(--tone-*)`, resolved
-     at runtime rather than inlined — so `applyTheme()` can reassign them per
-     theme exactly as it does `--primary`. That is the whole point: a future theme
-     beyond light/dark repaints every damage, heal and arcane control by setting
-     six variables, with no component change. Naming these for the hue would have
-     hardcoded the decision at every call site. */
+     Declared like the shadcn tokens above (`var(--tone-*)`, resolved at runtime
+     rather than inlined) so `applyTheme()` can reassign them per theme exactly as
+     it does `--primary`: a theme beyond light/dark repaints every damage, heal
+     and arcane control by setting these six. */
   --color-tone-primary: var(--tone-primary);
   --color-tone-danger: var(--tone-danger);
   --color-tone-success: var(--tone-success);

--- a/src/components/common/AppButton.test.ts
+++ b/src/components/common/AppButton.test.ts
@@ -197,9 +197,8 @@ describe("AppButton", () => {
 });
 
 describe("tinted tones (#623)", () => {
-  // The whole point of naming these semantically: the colour is one indirection
-  // away, so a future theme repaints every damage/heal/arcane control by
-  // reassigning `--tone-*` rather than editing 35 call sites.
+  // The colour must stay one indirection away, or a theme can no longer repaint
+  // these by reassigning `--tone-*`.
   it("resolves every tone through a --color-tone-* token, never a raw hue", () => {
     for (const tone of BUTTON_TONES) {
       for (const emphasis of BUTTON_EMPHASES) {

--- a/src/components/common/PageHeaderAction.vue
+++ b/src/components/common/PageHeaderAction.vue
@@ -19,9 +19,7 @@
  * This is the one bundle AppButton cannot express as a default: `size="md"`
  * plus `collapse-below="lg"`. Detail-page header rows are tighter than list-page
  * action rows, so their labels have to collapse at `lg` rather than the `sm` that
- * list actions use. Restating that trio at all 35 call sites is exactly the
- * approximate-the-UI-everywhere problem this refactor exists to remove, so it
- * lives here instead.
+ * list actions use. That trio lives here rather than at every header action.
  *
  * Everything else — `label`, `icon`, `to`, `disabled`, `mobileLabel`, `tooltip`,
  * `type`, `@click`, `class` — falls through to AppButton untouched.

--- a/src/components/common/appButtonVariants.ts
+++ b/src/components/common/appButtonVariants.ts
@@ -1,19 +1,11 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * The class matrix behind AppButton (#561).
+ * Variants and sizes are derived from what the call sites were already doing, so
+ * adding one means finding a real cluster rather than inventing a look.
  *
- * Every interactive control in the app used to hand-roll `font-cinzel` + a size
- * class plus its own padding, radius, border, hover and disabled states — 262
- * distinct class strings across 410 buttons. The variants below are derived from
- * what those sites actually did, not invented:
- *
- *   outline/subtle 149 · ghost 97 · primary 68 · chip 56 · destructive 41
- *   text-xs 281 · text-2xs 80 · text-sm 50
- *
- * Sizes reuse the #552 typography roles (`text-label`, `text-label-lg`) instead of
- * re-declaring the Cinzel recipe. Those roles carry `tracking-wider`, so sites that
- * previously had none gain it — the deliberate normalisation this refactor exists for.
+ * Sizes reuse the #552 typography roles, which carry `tracking-wider` — that is
+ * where a button's letter-spacing comes from, not from the call site.
  *
  * Lives outside the SFC because `<script setup>` cannot export, and because a pure
  * class map is worth testing without mounting anything.
@@ -43,14 +35,9 @@ export const buttonVariants = cva(
         /** Filled pill — tags, counts, secondary navigation chips. */
         chip: "bg-muted text-muted-foreground hover:bg-muted/70 hover:text-foreground",
         /**
-         * A pill whose colour carries meaning — DMG red, HEAL green, +Temp blue,
-         * ATT amber, Create-slot violet, the soundboard's source tabs.
-         *
-         * Pair with `tone` (which colour) and `emphasis` (how loud). It used to
-         * resolve to bare `border` with every call site writing its own opacity
-         * ladder, and 35 sites had already drifted into 14 different class shapes
-         * — the exact "next one invents its own ladder" failure #561 exists to
-         * stop. The table below is now the only place a tint is spelled out.
+         * A pill whose colour carries meaning. Pair with `tone` and `emphasis`;
+         * the table below is the only place a tint is spelled out, so a new one
+         * does not get to invent its own opacity ladder.
          */
         tinted: "border",
       },
@@ -72,9 +59,7 @@ export const buttonVariants = cva(
         "icon-sm": "h-8 w-8 rounded-md text-label-lg",
       },
       /**
-       * Selected state for toggles and segmented pickers. One treatment replaces the
-       * four that had grown in the wild (`bg-primary`, `bg-primary/15 ring-1`,
-       * `border-primary bg-primary/10`, `bg-muted`).
+       * Selected state for toggles and segmented pickers.
        *
        * Deliberately carries no `border-primary`: `ghost`, `link` and `chip` set no
        * border *width*, so a border colour on them paints nothing, and adding the
@@ -87,11 +72,10 @@ export const buttonVariants = cva(
       },
       block: { true: "w-full", false: "" },
       /**
-       * What a `tinted` button *means*. Semantic rather than hue-named so the
-       * palette stays changeable: each maps to a `--color-tone-*` custom property
-       * in main.css, which a future theme can reassign on `:root` to repaint every
-       * damage/heal/arcane control at once. `tone="red"` would have hardcoded that
-       * decision at 35 call sites. Ignored by every variant except `tinted`.
+       * What a `tinted` button means. Semantic rather than hue-named so the palette
+       * stays changeable: each maps to a `--color-tone-*` custom property a theme
+       * can reassign, whereas `tone="red"` would pin the colour here. Ignored by
+       * every variant except `tinted`.
        */
       tone: {
         /** The theme's accent — soundboard source tabs, "Drop chest in chat". */
@@ -117,10 +101,9 @@ export const buttonVariants = cva(
     },
     compoundVariants: [
       // ── tinted × tone × emphasis ──────────────────────────────────────────
-      // Tailwind extracts classes statically, so each cell is spelled out; a tone
-      // cannot be composed at runtime. But the *colour* is one indirection away —
-      // each `tone-*` resolves through a `--color-tone-*` custom property — so
-      // repainting a tone is a one-line change in main.css, not 35 call sites.
+      // Spelled out cell by cell because Tailwind extracts classes statically and
+      // `bg-tone-<x>/10` cannot be composed at runtime. The colour itself still is
+      // not pinned here — each `tone-*` resolves through a custom property.
       { variant: "tinted", tone: "primary", emphasis: "soft", class: "bg-tone-primary/10 border-tone-primary/30 text-tone-primary hover:bg-tone-primary/20" },
       { variant: "tinted", tone: "primary", emphasis: "strong", class: "bg-tone-primary/25 border-tone-primary/60 text-tone-primary" },
       { variant: "tinted", tone: "primary", emphasis: "outline", class: "border-tone-primary/40 text-tone-primary hover:bg-tone-primary/10" },

--- a/src/components/common/fieldVariants.ts
+++ b/src/components/common/fieldVariants.ts
@@ -1,18 +1,12 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * The class matrix behind the app's form fields (#621).
- *
- * `AppInput`, `AppSelect` and `EntityCombobox` each used to spell out the same box
- * — `border border-border rounded-md px-3 py-1.5 focus:outline-none focus:ring-1
- * focus:ring-ring` — independently. Three copies of one recipe is the debt #561
- * removed from buttons, reproduced one level up: change the focus ring and you had
- * to remember all three.
+ * Shared by AppInput, AppSelect and EntityCombobox, so the focus ring and the box
+ * are changed in one place rather than three.
  *
  * `size` names a #552 typography role rather than a raw font size, which is why the
- * body-faced combobox is a size here rather than a separate `font` axis: in this
- * app the role already carries the family (`text-label-lg` is Cinzel 12px,
- * `text-body` is Crimson 14px).
+ * body-faced combobox is a size here rather than a separate `font` axis — in this
+ * app the role already carries the family.
  */
 export const fieldVariants = cva(
   "text-foreground placeholder:text-muted-foreground transition-colors focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed",

--- a/src/views/dev/ComponentCatalogueView.vue
+++ b/src/views/dev/ComponentCatalogueView.vue
@@ -79,7 +79,7 @@
 
     <CatalogueSection
       title="AppButton — tinted tone × emphasis"
-      note="Semantic tones, not hues: each resolves through a --color-tone-* custom property, so a future theme repaints every damage/heal/arcane control by reassigning six variables. Replaces 35 hand-written opacity ladders that had drifted into 14 different class shapes."
+      note="Semantic tones, not hues: each resolves through a --color-tone-* custom property, so a future theme repaints every damage/heal/arcane control by reassigning six variables."
     >
       <table class="border-separate border-spacing-3">
         <thead>


### PR DESCRIPTION
Fair catch during review of #628 — the comments I left across #561 / #621 / #623 drifted into narrating *what* the code is and recounting how it got there. [CLAUDE.md:99](CLAUDE.md#L99): "the record of what shipped is the git history, and the record of *why* is a comment at the point of the decision."

## Cut

- **The class-string census** in `appButtonVariants`' header — "262 distinct class strings across 410 buttons", the per-variant tallies. That is a snapshot of the problem, already stale now that the migration happened, and git has it.
- **"the four that had grown in the wild"** on the `active` variant — history.
- **Before/after class examples** (`tone="danger"` instead of `bg-red-500/10 …`) — the table two lines below already shows it.
- **"35 call sites", in five places.** The number was already wrong — it is 30 — and would keep drifting. Removed everywhere.
- A file header that **restated a banner ten lines below it**, plus two byte counts (`~140 lines`, `24 kB`) that rot.

## Kept

Only the things that answer a question the code raises:

- why the class map lives outside the SFC (`<script setup>` cannot export)
- why sizes carry `tracking-wider` (it rides on the #552 role, not the call site)
- why the tone tokens are `var()` indirections rather than inlined values (a theme can reassign them)
- why a `<select>` sits 4px tighter than an `<input>` (deliberate, not drift)
- why the tinted table is spelled out cell by cell (Tailwind extracts statically)
- why a component-level `.css` import is still global (so nobody "fixes" it into a scoped block)
- why several rules in `base.css` are unlayered (the select caret and iOS zoom guard depend on it)

## Verification

`lint` · `vue-tsc` · `build` clean, `2551 tests / 222 files` pass. Comments only — no behaviour change.