### PR TITLE
GDPR account deletion: erase the person, keep the books (#631)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,22 @@ Tests are colocated next to the module they cover — never a `__tests__/` direc
 
 Add a variant or size and you must add it to `BUTTON_VARIANTS` / `BUTTON_SIZES` in `appButtonVariants.ts` — a compile-time assertion there fails otherwise, so the catalogue cannot silently omit it. Check the page at a narrow width too: label collapse is invisible to lint, typecheck and unit tests, and has regressed twice.
 
+**CRITICAL — reach for the primitive, never hand-roll the control:**
+
+A new `<button class="px-2 py-0.5 border rounded …">` or `<input class="bg-muted border border-border rounded-md …">` is not a small local styling choice — it is a 263rd copy of a recipe that `AppButton` / `AppInput` / `AppSelect` already own, and it will drift. This keeps regressing because each site looks harmless on its own; #561 and #621 exist precisely because 410 buttons and ~34 fields had each made that call independently.
+
+| You are about to write                                | Use instead                                 |
+| ----------------------------------------------------- | ------------------------------------------- |
+| `<button>` with any padding/border/radius/hover class | `AppButton` — variant + size, never classes |
+| `<input>` with the field recipe                       | `AppInput` — tone + size                    |
+| `<select>` with chrome (small fixed option set)       | `AppSelect`; dynamic/searchable → `EntityCombobox` |
+| A coloured pill whose colour means something          | `AppButton variant="tinted"` + `tone` + `emphasis` |
+| A toggle/segmented picker                             | `AppButton :active` or `SegmentedControl`   |
+
+Every variant is rendered at `/dev/components` — open it rather than guessing which one matches. If none does, add a variant to `appButtonVariants.ts` / `fieldVariants.ts` (the compile-time assertion forces it into the catalogue); do **not** fall back to a class string. A raw `<button>`/`<input>` is fine only when it carries *no* chrome — a bare word of clickable text, or a checkbox/radio/file input.
+
+`cn()` registers the #552 typography roles in tailwind-merge's `font-size` group, so a call-site `class="text-caption"` genuinely overrides a variant's `text-label-lg`. Overriding one token on a primitive is expected; re-declaring the whole box is not.
+
 **CRITICAL — extract shared UI, never duplicate it:**
 
 If two pieces of UI share structure and differ only in a few values, the structure becomes a component and the diff becomes props. Identify this *before* writing a second copy, not after.

--- a/src/components/account/AccountSettings.vue
+++ b/src/components/account/AccountSettings.vue
@@ -1,16 +1,16 @@
 <template>
   <SettingsSection title="Account">
-    <div class="space-y-2">
+    <div class="space-y-3">
       <div class="flex items-center gap-2">
         <span class="text-caption text-muted-foreground w-16">Email</span>
         <span class="text-body text-foreground">{{ auth.userEmail ?? '—' }}</span>
       </div>
-      <div class="flex items-center gap-2">
-        <span class="text-caption text-muted-foreground w-16">Role</span>
-        <span class="text-label-lg px-1.5 py-0.5 rounded bg-primary/15 text-primary">
-          {{ auth.currentRole ?? '—' }}
-        </span>
-      </div>
+      <RouterLink
+        to="/billing"
+        class="inline-block text-label font-semibold text-primary hover:opacity-80 transition-opacity"
+      >
+        Billing & Subscription →
+      </RouterLink>
     </div>
   </SettingsSection>
 

--- a/src/components/account/AccountSettings.vue
+++ b/src/components/account/AccountSettings.vue
@@ -1,18 +1,5 @@
 <template>
-  <SettingsSection title="Account">
-    <div class="space-y-3">
-      <div class="flex items-center gap-2">
-        <span class="text-caption text-muted-foreground w-16">Email</span>
-        <span class="text-body text-foreground">{{ auth.userEmail ?? '—' }}</span>
-      </div>
-      <RouterLink
-        to="/billing"
-        class="inline-block text-label font-semibold text-primary hover:opacity-80 transition-opacity"
-      >
-        Billing & Subscription →
-      </RouterLink>
-    </div>
-  </SettingsSection>
+  <AccountSummarySection link-to="/billing" link-label="Billing &amp; Subscription →" />
 
   <!-- Danger zone (#631) — same accent-recoloured section shell as PlayerSettingsInstall,
        since SettingsSection has no accent prop. -->
@@ -45,13 +32,11 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import SettingsSection from "@/components/common/SettingsSection.vue";
+import AccountSummarySection from "@/components/account/AccountSummarySection.vue";
 import ConfirmByNameInput from "@/components/common/ConfirmByNameInput.vue";
 import AppButton from "@/components/common/AppButton.vue";
-import { useAuthStore } from "@/stores/auth";
 import { useAccountDeletion } from "@/composables/useAccountDeletion";
 
-const auth = useAuthStore();
 const { deleting, error, deleteAccount } = useAccountDeletion();
 
 const deleteConfirmInput = ref("");

--- a/src/components/account/AccountSummarySection.vue
+++ b/src/components/account/AccountSummarySection.vue
@@ -1,0 +1,31 @@
+<template>
+  <SettingsSection title="Account">
+    <div class="space-y-3">
+      <div class="flex items-center gap-2">
+        <span class="text-caption text-muted-foreground w-16">Email</span>
+        <span class="text-body text-foreground">{{ auth.userEmail ?? '—' }}</span>
+      </div>
+      <AppButton variant="link" size="inline" :to="linkTo" :label="linkLabel" />
+    </div>
+  </SettingsSection>
+</template>
+
+<script setup lang="ts">
+/**
+ * The "Account" settings block — email plus one link onward. Both surfaces that
+ * show it (#631) render the identical email row and differ only in where the
+ * link goes: `/account` sends a player to the deletion UI, `/billing` sends a DM
+ * on from it. Two copies of this markup is what the second surface started as.
+ */
+import type { RouteLocationRaw } from "vue-router";
+import SettingsSection from "@/components/common/SettingsSection.vue";
+import AppButton from "@/components/common/AppButton.vue";
+import { useAuthStore } from "@/stores/auth";
+
+defineProps<{
+  linkTo: RouteLocationRaw;
+  linkLabel: string;
+}>();
+
+const auth = useAuthStore();
+</script>

--- a/src/components/admin/AdminUsersTab.vue
+++ b/src/components/admin/AdminUsersTab.vue
@@ -14,6 +14,7 @@
       Failed to load users.
     </div>
     <div v-else class="space-y-2">
+      <p v-if="deleteError" class="text-caption-sm text-destructive">{{ deleteError }}</p>
       <div
         v-for="user in filteredUsers"
         :key="user.user_id"
@@ -79,6 +80,15 @@
           >
             {{ user.banned ? 'Unlock' : 'Lock out' }}
           </button>
+
+          <!-- Permanent erasure (#631) -->
+          <button
+            class="px-2 py-0.5 text-label font-semibold border border-destructive rounded bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
+            :disabled="usersQuery.deleteUser.isPending.value"
+            @click="deleteUserAccount(user)"
+          >
+            Delete
+          </button>
         </div>
       </div>
       <p v-if="filteredUsers.length === 0" class="text-body text-muted-foreground text-center py-8">
@@ -91,11 +101,13 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useAdminUsers, type AdminUser } from "@/composables/useAdminUsers";
+import { accountDeletionErrorMessage } from "@/composables/useAccountDeletion";
 import { useConfirm } from "@/composables/useConfirm";
 import type { PlanId } from "@/types/subscription.types";
 
 const usersQuery = useAdminUsers();
 const { confirm } = useConfirm();
+const deleteError = ref("");
 
 async function toggleFreeze(user: AdminUser) {
   const suspend = !user.suspended_at;
@@ -124,6 +136,21 @@ async function toggleBan(user: AdminUser) {
   );
   if (!ok) return;
   usersQuery.setBanned.mutate({ userId: user.user_id, banned: ban });
+}
+
+async function deleteUserAccount(user: AdminUser) {
+  const ok = await confirm(
+    `Permanently delete ${user.email}? This deletes their auth account immediately: campaigns they own — and everything in them — are erased, and content they created in other campaigns is removed. Billing ledger rows are kept, anonymized, as legally required. This cannot be undone.`,
+    { title: "Delete account", confirmLabel: "Delete permanently", danger: true },
+  );
+  if (!ok) return;
+  deleteError.value = "";
+  try {
+    await usersQuery.deleteUser.mutateAsync(user.user_id);
+  } catch (err) {
+    const code = err instanceof Error ? err.message : String(err);
+    deleteError.value = accountDeletionErrorMessage(code);
+  }
 }
 
 const PLAN_IDS: PlanId[] = ["free", "tester", "pro"];

--- a/src/components/admin/AdminUsersTab.vue
+++ b/src/components/admin/AdminUsersTab.vue
@@ -58,37 +58,37 @@
           </div>
 
           <!-- Soft freeze (paid actions) -->
-          <button
-            class="px-2 py-0.5 text-label font-semibold border rounded transition-colors"
-            :class="user.suspended_at
-              ? 'border-amber-500/40 text-amber-400 hover:bg-amber-500/10'
-              : 'border-border text-muted-foreground hover:text-foreground hover:border-foreground/40'"
+          <AppButton
+            size="xs"
+            :variant="user.suspended_at ? 'tinted' : 'subtle'"
+            :tone="user.suspended_at ? 'caution' : undefined"
+            :emphasis="user.suspended_at ? 'outline' : undefined"
+            :label="user.suspended_at ? 'Unfreeze' : 'Freeze'"
             :disabled="usersQuery.setSuspended.isPending.value"
             @click="toggleFreeze(user)"
-          >
-            {{ user.suspended_at ? 'Unfreeze' : 'Freeze' }}
-          </button>
+          />
 
           <!-- Hard lock-out (login ban) -->
-          <button
-            class="px-2 py-0.5 text-label font-semibold border rounded transition-colors"
-            :class="user.banned
-              ? 'border-elven-green/40 text-elven-green hover:bg-elven-green/10'
-              : 'border-destructive/40 text-destructive hover:bg-destructive/10'"
+          <AppButton
+            size="xs"
+            :variant="user.banned ? 'tinted' : 'destructive'"
+            :tone="user.banned ? 'success' : undefined"
+            :emphasis="user.banned ? 'outline' : undefined"
+            :label="user.banned ? 'Unlock' : 'Lock out'"
             :disabled="usersQuery.setBanned.isPending.value"
             @click="toggleBan(user)"
-          >
-            {{ user.banned ? 'Unlock' : 'Lock out' }}
-          </button>
+          />
 
           <!-- Permanent erasure (#631) -->
-          <button
-            class="px-2 py-0.5 text-label font-semibold border border-destructive rounded bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
+          <AppButton
+            size="xs"
+            variant="tinted"
+            tone="danger"
+            emphasis="soft"
+            label="Delete"
             :disabled="usersQuery.deleteUser.isPending.value"
             @click="deleteUserAccount(user)"
-          >
-            Delete
-          </button>
+          />
         </div>
       </div>
       <p v-if="filteredUsers.length === 0" class="text-body text-muted-foreground text-center py-8">
@@ -103,6 +103,7 @@ import { ref, computed } from "vue";
 import { useAdminUsers, type AdminUser } from "@/composables/useAdminUsers";
 import { accountDeletionErrorMessage } from "@/composables/useAccountDeletion";
 import { useConfirm } from "@/composables/useConfirm";
+import AppButton from "@/components/common/AppButton.vue";
 import type { PlanId } from "@/types/subscription.types";
 
 const usersQuery = useAdminUsers();

--- a/src/components/admin/AdminUsersTab.vue
+++ b/src/components/admin/AdminUsersTab.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="space-y-4">
-    <input
+    <AppInput
       v-model="userSearch"
       type="search"
+      size="body"
+      tone="muted"
       placeholder="Search by email or name…"
-      class="w-full bg-muted border border-border rounded-md px-3 py-2 text-body text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
     />
 
     <div v-if="usersQuery.isPending.value" class="text-muted-foreground text-body">
@@ -41,20 +42,18 @@
           </span>
           <span class="text-caption text-muted-foreground">{{ user.ai_credits }} cr</span>
           <div class="flex gap-1">
-            <button
+            <!-- The current plan is the `active` one; AppButton blocks the click
+                 while disabled, so the guard the raw handler carried is gone. -->
+            <AppButton
               v-for="pid in PLAN_IDS"
               :key="pid"
-              class="px-2 py-0.5 text-label font-semibold border rounded transition-colors"
-              :class="
-                user.plan_id === pid
-                  ? 'border-primary/40 text-primary bg-primary/10 cursor-default'
-                  : 'border-border text-muted-foreground hover:text-foreground hover:border-foreground/40'
-              "
+              variant="subtle"
+              size="xs"
+              :active="user.plan_id === pid"
+              :label="pid"
               :disabled="user.plan_id === pid || usersQuery.setPlan.isPending.value"
-              @click="user.plan_id !== pid && usersQuery.setPlan.mutate({ userId: user.user_id, planId: pid })"
-            >
-              {{ pid }}
-            </button>
+              @click="usersQuery.setPlan.mutate({ userId: user.user_id, planId: pid })"
+            />
           </div>
 
           <!-- Soft freeze (paid actions) -->
@@ -104,6 +103,7 @@ import { useAdminUsers, type AdminUser } from "@/composables/useAdminUsers";
 import { accountDeletionErrorMessage } from "@/composables/useAccountDeletion";
 import { useConfirm } from "@/composables/useConfirm";
 import AppButton from "@/components/common/AppButton.vue";
+import AppInput from "@/components/common/AppInput.vue";
 import type { PlanId } from "@/types/subscription.types";
 
 const usersQuery = useAdminUsers();

--- a/src/components/common/ConfirmByNameInput.vue
+++ b/src/components/common/ConfirmByNameInput.vue
@@ -3,13 +3,14 @@
     <p class="text-eyebrow font-semibold text-muted-foreground">
       TYPE <span class="text-foreground">{{ name }}</span> TO CONFIRM
     </p>
-    <input
+    <AppInput
       v-model="typed"
       type="text"
+      size="body"
+      tone="muted"
       autocomplete="off"
       :placeholder="name"
       :disabled="disabled"
-      class="w-full bg-muted border border-border rounded-md px-3 py-2 font-fell text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 disabled:opacity-50 disabled:cursor-not-allowed"
       :class="accent === 'destructive' ? 'focus:ring-destructive' : 'focus:ring-primary'"
     />
   </div>
@@ -21,6 +22,8 @@
  * ownership). The parent owns the "does it match" decision so it can fold that
  * into whatever other preconditions the action has.
  */
+import AppInput from "./AppInput.vue";
+
 const typed = defineModel<string>({ required: true });
 
 const { accent = "destructive" } = defineProps<{

--- a/src/components/common/ConfirmByNameInput.vue
+++ b/src/components/common/ConfirmByNameInput.vue
@@ -8,7 +8,8 @@
       type="text"
       autocomplete="off"
       :placeholder="name"
-      class="w-full bg-muted border border-border rounded-md px-3 py-2 font-fell text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1"
+      :disabled="disabled"
+      class="w-full bg-muted border border-border rounded-md px-3 py-2 font-fell text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 disabled:opacity-50 disabled:cursor-not-allowed"
       :class="accent === 'destructive' ? 'focus:ring-destructive' : 'focus:ring-primary'"
     />
   </div>
@@ -27,5 +28,6 @@ const { accent = "destructive" } = defineProps<{
   name: string;
   /** Focus-ring colour; `primary` for actions that are permanent but not deletions. */
   accent?: "destructive" | "primary";
+  disabled?: boolean;
 }>();
 </script>

--- a/src/components/layout/AccountMenuItem.vue
+++ b/src/components/layout/AccountMenuItem.vue
@@ -1,0 +1,50 @@
+<template>
+  <AppButton
+    variant="ghost"
+    size="inline"
+    block
+    :to="to"
+    :tooltip="tooltip"
+    :aria-label="label"
+    :class="cn('justify-start gap-2 px-3 py-2 text-caption hover:bg-secondary/60', danger && 'text-red-400/80 hover:text-red-400')"
+    @click="emit('click', $event)"
+  >
+    <template #icon>
+      <component :is="icon" class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+    </template>
+    <span>{{ label }}</span>
+    <slot name="trailing" />
+  </AppButton>
+</template>
+
+<script setup lang="ts">
+/**
+ * One row of the sidebar's account popover. The six rows (edit name, Account,
+ * Billing, Install, Report a bug, Sign out) were six copies of the same class
+ * string split across `<button>` and `<RouterLink>`, so adding the Account row
+ * for #631 meant writing a seventh — the case CLAUDE.md says to extract before
+ * the second copy, not after the sixth.
+ *
+ * `aria-label` is pinned to the visible label rather than left to AppButton's
+ * `tooltip ?? label` fallback: the Install row's tooltip is a whole sentence of
+ * instructions, and letting that become the accessible name would break WCAG
+ * 2.5.3 (Label in Name) for the one row that has a tooltip at all.
+ */
+import type { Component } from "vue";
+import AppButton from "@/components/common/AppButton.vue";
+import { cn } from "@/lib/utils";
+import type { RouteLocationRaw } from "vue-router";
+
+const { danger = false } = defineProps<{
+  label: string;
+  icon: Component;
+  /** Renders the row as a RouterLink. Omit for a plain button row. */
+  to?: RouteLocationRaw;
+  /** Supplementary hover text; never becomes the accessible name. */
+  tooltip?: string;
+  /** Sign out — the one row that reads as destructive. */
+  danger?: boolean;
+}>();
+
+const emit = defineEmits<{ (e: "click", ev: MouseEvent): void }>();
+</script>

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -13,25 +13,39 @@
         <div class="flex items-center gap-1 shrink-0 pt-0.5">
           <DiceRoller />
           <!-- AI generation in-progress spinner -->
-          <button
+          <AppButton
             v-if="isAnyAiGenerating && activeGenerator"
-            class="flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/15 border border-primary/30 hover:bg-primary/25 transition-colors"
-            :title="currentLoadingQuote"
+            variant="tinted"
+            tone="primary"
+            emphasis="soft"
+            size="xs"
+            class="px-1.5"
+            aria-label="AI generation in progress"
+            :tooltip="currentLoadingQuote"
             @click="activeGenerator.openPanel()"
           >
-            <IconLoading class="h-3 w-3 text-primary animate-spin" />
-            <span class="text-label text-primary">AI</span>
-          </button>
+            <template #icon>
+              <IconLoading class="h-3 w-3 shrink-0 animate-spin" aria-hidden="true" />
+            </template>
+            AI
+          </AppButton>
           <!-- Live encounter indicator -->
-          <RouterLink
+          <AppButton
             v-if="anyRunning && firstRunning"
             :to="`/encounters/${firstRunning.encounter_id}/run`"
-            class="flex items-center gap-1 px-1.5 py-0.5 rounded bg-green-500/15 border border-green-500/30 hover:bg-green-500/25 transition-colors"
-            title="Encounter in progress"
+            variant="tinted"
+            tone="success"
+            emphasis="soft"
+            size="xs"
+            class="px-1.5"
+            aria-label="Live"
+            tooltip="Encounter in progress"
           >
-            <span class="h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
-            <span class="text-label text-green-400">Live</span>
-          </RouterLink>
+            <template #icon>
+              <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-current animate-pulse" />
+            </template>
+            Live
+          </AppButton>
         </div>
       </div>
 
@@ -91,81 +105,82 @@
         >
           <!-- Edit name -->
           <div v-if="editingName" class="flex items-center gap-1.5 px-3 py-2">
-            <input
+            <AppInput
               v-model="nameInput"
-              class="flex-1 min-w-0 bg-background border border-border rounded px-1.5 py-0.5 text-caption text-foreground focus:outline-none focus:ring-1 focus:ring-gold-500"
+              size="xs"
+              :block="false"
+              class="flex-1 min-w-0 text-caption"
               placeholder="Your name"
               @keydown.enter="saveName"
               @keydown.esc="editingName = false"
             />
-            <button class="hover:text-foreground transition-colors shrink-0 text-muted-foreground" :disabled="nameSaving" @click="saveName">
-              <IconCheck class="h-3.5 w-3.5" />
-            </button>
-            <button class="hover:text-foreground transition-colors shrink-0 text-muted-foreground" @click="editingName = false">
-              <IconClose class="h-3.5 w-3.5" />
-            </button>
+            <AppButton
+              variant="ghost"
+              size="inline"
+              class="shrink-0"
+              :icon="IconCheck"
+              aria-label="Save display name"
+              :disabled="nameSaving"
+              @click="saveName"
+            />
+            <AppButton
+              variant="ghost"
+              size="inline"
+              class="shrink-0"
+              :icon="IconClose"
+              aria-label="Cancel"
+              @click="editingName = false"
+            />
           </div>
-          <button
+          <AccountMenuItem
             v-else
-            class="w-full flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+            :icon="IconEdit"
+            label="Edit display name"
             @click="startEdit"
-          >
-            <IconEdit class="h-3.5 w-3.5 shrink-0" />
-            <span class="font-fell">Edit display name</span>
-          </button>
+          />
 
-          <!-- Account -->
-          <RouterLink
+          <AccountMenuItem
+            :icon="IconUserCircle"
+            label="Account"
             to="/account"
-            class="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
             @click="menuOpen = false"
-          >
-            <IconUserCircle class="h-3.5 w-3.5 shrink-0" />
-            <span class="font-fell">Account</span>
-          </RouterLink>
+          />
 
           <!-- Billing (DM only) -->
-          <RouterLink
+          <AccountMenuItem
             v-if="auth.isDM"
+            :icon="IconBilling"
+            label="Billing"
             to="/billing"
-            class="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
             @click="menuOpen = false"
           >
-            <IconBilling class="h-3.5 w-3.5 shrink-0" />
-            <span class="font-fell">Billing</span>
-            <span v-if="isPro" class="ml-auto text-eyebrow font-semibold text-amber-400">Pro</span>
-          </RouterLink>
+            <template #trailing>
+              <span v-if="isPro" class="ml-auto text-eyebrow font-semibold text-amber-400">Pro</span>
+            </template>
+          </AccountMenuItem>
 
           <div class="border-t border-border my-1" />
 
-          <!-- Install PWA -->
-          <button
+          <AccountMenuItem
             v-if="canInstall"
-            class="w-full flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
-            :title="hasNativePrompt ? 'Add to home screen' : 'Open your browser menu → Add to Home Screen'"
+            :icon="IconDownload"
+            label="Install app"
+            :tooltip="hasNativePrompt ? 'Add to home screen' : 'Open your browser menu → Add to Home Screen'"
             @click="hasNativePrompt ? (install(), menuOpen = false) : undefined"
-          >
-            <IconDownload class="h-3.5 w-3.5 shrink-0" />
-            <span class="font-fell">Install app</span>
-          </button>
+          />
 
-          <!-- Bug report -->
-          <button
-            class="w-full flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+          <AccountMenuItem
+            :icon="IconBug"
+            label="Report a bug"
             @click="bugReportOpen = true; menuOpen = false"
-          >
-            <IconBug class="h-3.5 w-3.5 shrink-0" />
-            <span class="font-fell">Report a bug</span>
-          </button>
+          />
 
-          <!-- Sign out -->
-          <button
-            class="w-full flex items-center gap-2 px-3 py-2 text-xs text-red-400/80 hover:text-red-400 hover:bg-secondary/60 transition-colors"
+          <AccountMenuItem
+            :icon="IconLogOut"
+            label="Sign out"
+            danger
             @click="handleSignOut"
-          >
-            <IconLogOut class="h-3.5 w-3.5 shrink-0" />
-            <span class="font-fell">Sign out</span>
-          </button>
+          />
 
           <!-- Legal -->
           <div class="border-t border-border my-1" />
@@ -175,10 +190,15 @@
         </div>
       </Transition>
 
-      <!-- Trigger button -->
-      <button
-        class="w-full flex items-center gap-2 px-2 py-2 rounded-md hover:bg-secondary/60 transition-colors"
-        :class="menuOpen ? 'bg-secondary/60' : ''"
+      <!-- Trigger button. Not `active`: that variant paints the row gold, and this
+           only needs to look pressed while the popover is open. -->
+      <AppButton
+        variant="ghost"
+        size="inline"
+        block
+        :class="cn('justify-start gap-2 px-2 py-2 rounded-md hover:bg-secondary/60', menuOpen && 'bg-secondary/60')"
+        :aria-label="`Account menu for ${shownName}`"
+        :aria-expanded="menuOpen"
         @click="menuOpen = !menuOpen"
       >
         <div class="h-7 w-7 rounded-full bg-secondary flex items-center justify-center shrink-0">
@@ -186,7 +206,7 @@
         </div>
         <span class="flex-1 truncate text-caption text-muted-foreground text-left">{{ shownName }}</span>
         <IconSort class="h-3 w-3 text-muted-foreground/60 shrink-0" />
-      </button>
+      </AppButton>
 
       <BugReportModal v-if="bugReportMounted" v-model="bugReportOpen" />
     </div>
@@ -210,6 +230,10 @@ import { useRunningEncounters } from "@/composables/useEncounterLive";
 import { useOptionalRules, isRuleEffectivelyEnabled } from "@/composables/useOptionalRules";
 import { useSubscription } from "@/composables/useSubscription";
 import { useSimulacrumConfig } from "@/composables/useSimulacrumConfig";
+import AppButton from "@/components/common/AppButton.vue";
+import AppInput from "@/components/common/AppInput.vue";
+import { cn } from "@/lib/utils";
+import AccountMenuItem from "./AccountMenuItem.vue";
 import NavItem from "./NavItem.vue";
 import CampaignSwitcher from "./CampaignSwitcher.vue";
 import GlobalSearch from "./GlobalSearch.vue";

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -114,6 +114,16 @@
             <span class="font-fell">Edit display name</span>
           </button>
 
+          <!-- Account -->
+          <RouterLink
+            to="/account"
+            class="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+            @click="menuOpen = false"
+          >
+            <IconUserCircle class="h-3.5 w-3.5 shrink-0" />
+            <span class="font-fell">Account</span>
+          </RouterLink>
+
           <!-- Billing (DM only) -->
           <RouterLink
             v-if="auth.isDM"
@@ -187,7 +197,7 @@
 <script setup lang="ts">
 import { ref, computed, defineAsyncComponent } from "vue";
 import { useRouter } from "vue-router";
-import { IconBilling, IconBug, IconCheck, IconClose, IconDownload, IconEdit, IconLoading, IconLogOut, IconShieldCheck, IconSort } from '@/lib/icons';
+import { IconBilling, IconBug, IconCheck, IconClose, IconDownload, IconEdit, IconLoading, IconLogOut, IconShieldCheck, IconSort, IconUserCircle } from '@/lib/icons';
 import { usePwaInstall } from "@/composables/usePwaInstall";
 import { onClickOutside } from "@vueuse/core";
 import { isAnyAiGenerating, getAiGeneratorRegistry } from "@/ai/aiGeneratorRegistry";

--- a/src/components/play/PlayerSettingsAccount.vue
+++ b/src/components/play/PlayerSettingsAccount.vue
@@ -13,11 +13,51 @@
       </div>
     </div>
   </SettingsSection>
+
+  <!-- Danger zone (#631) — same accent-recoloured section shell as PlayerSettingsInstall,
+       since SettingsSection has no accent prop. -->
+  <section class="rounded-lg border border-destructive/40 bg-destructive/5 overflow-hidden">
+    <header class="px-4 py-3 border-b border-destructive/20">
+      <h3 class="font-cinzel text-sm font-bold text-destructive tracking-wide">Delete Account</h3>
+      <p class="text-caption text-muted-foreground italic mt-0.5">Permanent — there is no undo.</p>
+    </header>
+    <div class="p-4 space-y-4">
+      <p class="text-body text-muted-foreground">
+        Campaigns you own — and everything in them — are deleted, and your players lose access.
+        Content you created in other people's campaigns is removed. Billing records are kept in
+        anonymized form, as legally required. If you want your campaigns to live on, transfer
+        ownership first.
+      </p>
+      <ConfirmByNameInput v-model="deleteConfirmInput" name="DELETE" :disabled="deleting" />
+      <AppButton
+        variant="destructive"
+        size="md"
+        block
+        label="Delete account"
+        :loading="deleting"
+        :disabled="deleteConfirmInput !== 'DELETE'"
+        @click="handleDeleteAccount"
+      />
+      <p v-if="error" class="text-caption text-destructive">{{ error }}</p>
+    </div>
+  </section>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import SettingsSection from "@/components/common/SettingsSection.vue";
+import ConfirmByNameInput from "@/components/common/ConfirmByNameInput.vue";
+import AppButton from "@/components/common/AppButton.vue";
 import { useAuthStore } from "@/stores/auth";
+import { useAccountDeletion } from "@/composables/useAccountDeletion";
 
 const auth = useAuthStore();
+const { deleting, error, deleteAccount } = useAccountDeletion();
+
+const deleteConfirmInput = ref("");
+
+function handleDeleteAccount() {
+  if (deleteConfirmInput.value !== "DELETE") return;
+  void deleteAccount();
+}
 </script>

--- a/src/composables/useAccountDeletion.test.ts
+++ b/src/composables/useAccountDeletion.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  push: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { functions: { invoke: mocked.invoke } },
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mocked.push }),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: () => ({ signOut: mocked.signOut }),
+}));
+
+import { accountDeletionErrorMessage, useAccountDeletion } from "./useAccountDeletion";
+
+const { invoke: invokeMock, push: pushMock, signOut: signOutMock } = mocked;
+
+describe("accountDeletionErrorMessage", () => {
+  it("maps known server codes to human copy", () => {
+    expect(accountDeletionErrorMessage("cannot_delete_admin")).toMatch(/admin/i);
+    expect(accountDeletionErrorMessage("user_not_found")).toMatch(/could not be found/i);
+  });
+
+  it("passes an unrecognised code through verbatim", () => {
+    expect(accountDeletionErrorMessage("some_new_code")).toBe("some_new_code");
+  });
+});
+
+describe("useAccountDeletion", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    pushMock.mockReset();
+    signOutMock.mockReset();
+  });
+
+  it("self-deletion: invokes with confirm only, signs out, and redirects to login on success", async () => {
+    invokeMock.mockResolvedValue({ data: { ok: true }, error: null });
+    const { deleting, error, deleteAccount } = useAccountDeletion();
+
+    const result = await deleteAccount();
+
+    expect(result).toBe(true);
+    expect(invokeMock).toHaveBeenCalledWith("delete-account", { body: { confirm: "DELETE" } });
+    expect(signOutMock).toHaveBeenCalledOnce();
+    expect(pushMock).toHaveBeenCalledWith({ name: "login" });
+    expect(error.value).toBeNull();
+    expect(deleting.value).toBe(false);
+  });
+
+  it("admin deletion: passes targetUserId and does not sign out or redirect", async () => {
+    invokeMock.mockResolvedValue({ data: { ok: true }, error: null });
+    const { deleteAccount } = useAccountDeletion();
+
+    const result = await deleteAccount("user-123");
+
+    expect(result).toBe(true);
+    expect(invokeMock).toHaveBeenCalledWith("delete-account", {
+      body: { confirm: "DELETE", targetUserId: "user-123" },
+    });
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a functions-error JSON payload code to human copy and does not sign out", async () => {
+    invokeMock.mockResolvedValue({
+      data: null,
+      error: {
+        message: "Edge Function returned a non-2xx status code",
+        context: { json: async () => ({ error: "cannot_delete_admin" }) },
+      },
+    });
+    const { deleting, error, deleteAccount } = useAccountDeletion();
+
+    const result = await deleteAccount("user-123");
+
+    expect(result).toBe(false);
+    expect(error.value).toBe(accountDeletionErrorMessage("cannot_delete_admin"));
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(deleting.value).toBe(false);
+  });
+
+  it("falls back to the raw error message when the response has no JSON body", async () => {
+    invokeMock.mockResolvedValue({ data: null, error: { message: "network error" } });
+    const { error, deleteAccount } = useAccountDeletion();
+
+    await deleteAccount();
+
+    expect(error.value).toBe("network error");
+  });
+
+  it("surfaces a `{ error }` body returned with a 2xx status the same way", async () => {
+    invokeMock.mockResolvedValue({ data: { error: "storage_purge_failed" }, error: null });
+    const { error, deleteAccount } = useAccountDeletion();
+
+    const result = await deleteAccount();
+
+    expect(result).toBe(false);
+    expect(error.value).toBe(accountDeletionErrorMessage("storage_purge_failed"));
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
+  it("sets deleting true while in flight and false once settled", async () => {
+    let resolveInvoke!: (v: unknown) => void;
+    invokeMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInvoke = resolve;
+      }),
+    );
+    const { deleting, deleteAccount } = useAccountDeletion();
+
+    const promise = deleteAccount();
+    expect(deleting.value).toBe(true);
+    resolveInvoke({ data: { ok: true }, error: null });
+    await promise;
+
+    expect(deleting.value).toBe(false);
+  });
+});

--- a/src/composables/useAccountDeletion.ts
+++ b/src/composables/useAccountDeletion.ts
@@ -1,0 +1,80 @@
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { supabase } from "@/lib/supabase";
+import { useAuthStore } from "@/stores/auth";
+
+/** `delete-account` edge function error codes (#631) -> human copy. */
+const ERROR_MESSAGES: Record<string, string> = {
+  confirm_required: "Type DELETE exactly to confirm.",
+  cannot_delete_admin: "Admin accounts can't be deleted this way.",
+  user_not_found: "That account could not be found.",
+  storage_purge_failed: "Some of your data could not be purged. Contact support before trying again.",
+  erasure_preparation_failed: "Account deletion failed. Please try again or contact support.",
+  deletion_failed: "Account deletion failed. Please try again or contact support.",
+};
+
+/** Maps a `delete-account` error code to human copy; an unrecognised code passes through verbatim. */
+export function accountDeletionErrorMessage(code: string): string {
+  return ERROR_MESSAGES[code] ?? code;
+}
+
+/**
+ * Invokes the `delete-account` edge function, resolving on `{ ok: true }` and
+ * throwing an `Error` whose `.message` is the server's error code otherwise.
+ * Shared by `useAccountDeletion` (self-service) and `useAdminUsers.deleteUser`
+ * (admin) so the `functions.invoke` payload-extraction quirk — the JSON error
+ * body arrives on `error.context`, not `error.message`, same as
+ * `useAdminRefunds.invokeRefundFn` — lives in exactly one place.
+ */
+export async function invokeDeleteAccount(targetUserId?: string): Promise<void> {
+  const body: { confirm: "DELETE"; targetUserId?: string } = { confirm: "DELETE" };
+  if (targetUserId) body.targetUserId = targetUserId;
+
+  const { data, error } = await supabase.functions.invoke("delete-account", { body });
+  if (error) {
+    let code: string | undefined;
+    try {
+      const payload = await (error as unknown as { context?: Response }).context?.json();
+      code = payload?.error;
+    } catch {
+      /* response had no JSON body */
+    }
+    throw new Error(code ?? error.message);
+  }
+  if (data?.error) throw new Error(data.error);
+}
+
+/**
+ * GDPR self-service account deletion (#631). Self-deletion (`targetUserId`
+ * omitted) signs the user out and sends them to the login screen the instant
+ * the edge function confirms — their session is dead server-side by then.
+ * Admin deletion of another account just resolves; `useAdminUsers.deleteUser`
+ * owns refreshing the admin list.
+ */
+export function useAccountDeletion() {
+  const deleting = ref(false);
+  const error = ref<string | null>(null);
+  const router = useRouter();
+  const auth = useAuthStore();
+
+  async function deleteAccount(targetUserId?: string): Promise<boolean> {
+    deleting.value = true;
+    error.value = null;
+    try {
+      await invokeDeleteAccount(targetUserId);
+      if (!targetUserId) {
+        await auth.signOut();
+        await router.push({ name: "login" });
+      }
+      return true;
+    } catch (err) {
+      const code = err instanceof Error ? err.message : String(err);
+      error.value = accountDeletionErrorMessage(code);
+      return false;
+    } finally {
+      deleting.value = false;
+    }
+  }
+
+  return { deleting, error, deleteAccount };
+}

--- a/src/composables/useAdminUsers.ts
+++ b/src/composables/useAdminUsers.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { supabase } from '@/lib/supabase'
+import { invokeDeleteAccount } from '@/composables/useAccountDeletion'
 import type { PlanId } from '@/types/subscription.types'
 
 export interface AdminUser {
@@ -87,5 +88,12 @@ export function useAdminUsers() {
     onSettled: () => qc.invalidateQueries({ queryKey: ['admin', 'users'] }),
   })
 
-  return { ...query, setPlan, grantCredits, setSuspended, setBanned }
+  // GDPR erasure (#631) — permanent, cascades owned campaigns, rejects admin targets
+  // server-side (cannot_delete_admin). See useAccountDeletion.ts for the shared invoke.
+  const deleteUser = useMutation({
+    mutationFn: (userId: string) => invokeDeleteAccount(userId),
+    onSettled: () => qc.invalidateQueries({ queryKey: ['admin', 'users'] }),
+  })
+
+  return { ...query, setPlan, grantCredits, setSuspended, setBanned, deleteUser }
 }

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -216,6 +216,12 @@ export const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: true, title: "Billing & Subscription" },
   },
   {
+    path: "/account",
+    name: "account",
+    component: () => import("@/views/AccountSettingsView.vue"),
+    meta: { requiresAuth: true, title: "My Account" },
+  },
+  {
     path: "/campaign/settings",
     name: "campaign-settings",
     component: () => import("@/views/campaign/CampaignSettingsView.vue"),

--- a/src/views/AccountSettingsView.vue
+++ b/src/views/AccountSettingsView.vue
@@ -1,0 +1,34 @@
+<template>
+  <PageHeader title="My Account" description="Your account across every campaign">
+    <div class="max-w-lg space-y-8">
+      <AccountSettings />
+
+      <!-- Legal -->
+      <div class="flex items-center gap-5 pt-2 pb-6">
+        <a
+          :href="legalUrl('privacy')"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-cinzel text-2xs text-muted-foreground hover:text-foreground tracking-wide transition-colors"
+        >
+          Privacy Policy
+        </a>
+        <span class="text-border text-xs">·</span>
+        <a
+          :href="legalUrl('terms')"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-cinzel text-2xs text-muted-foreground hover:text-foreground tracking-wide transition-colors"
+        >
+          Terms of Service
+        </a>
+      </div>
+    </div>
+  </PageHeader>
+</template>
+
+<script setup lang="ts">
+import { legalUrl } from "@/lib/marketing";
+import PageHeader from "@/components/common/PageHeader.vue";
+import AccountSettings from "@/components/account/AccountSettings.vue";
+</script>

--- a/src/views/play/PlayerSettingsView.vue
+++ b/src/views/play/PlayerSettingsView.vue
@@ -9,7 +9,21 @@
       <PlayerSettingsNavigation />
       <PlayerSettingsNotifications />
       <PlayerSettingsAppearance />
-      <PlayerSettingsAccount />
+
+      <SettingsSection title="Account">
+        <div class="space-y-3">
+          <div class="flex items-center gap-2">
+            <span class="text-caption text-muted-foreground w-16">Email</span>
+            <span class="text-body text-foreground">{{ auth.userEmail ?? '—' }}</span>
+          </div>
+          <RouterLink
+            to="/account"
+            class="inline-block text-label font-semibold text-primary hover:opacity-80 transition-opacity"
+          >
+            Manage account & billing →
+          </RouterLink>
+        </div>
+      </SettingsSection>
 
       <!-- Legal -->
       <div class="flex items-center gap-5 pt-2 pb-6">
@@ -38,6 +52,7 @@
 <script setup lang="ts">
 import { legalUrl } from "@/lib/marketing";
 import PageHeader from "@/components/common/PageHeader.vue";
+import SettingsSection from "@/components/common/SettingsSection.vue";
 import PlayerSettingsDisplayName from "@/components/play/PlayerSettingsDisplayName.vue";
 import PlayerSettingsInstall from "@/components/play/PlayerSettingsInstall.vue";
 import PlayerSettingsCharacterClaim from "@/components/play/PlayerSettingsCharacterClaim.vue";
@@ -46,5 +61,7 @@ import PlayerSettingsCalendar from "@/components/play/PlayerSettingsCalendar.vue
 import PlayerSettingsNavigation from "@/components/play/PlayerSettingsNavigation.vue";
 import PlayerSettingsNotifications from "@/components/play/PlayerSettingsNotifications.vue";
 import PlayerSettingsAppearance from "@/components/play/PlayerSettingsAppearance.vue";
-import PlayerSettingsAccount from "@/components/play/PlayerSettingsAccount.vue";
+import { useAuthStore } from "@/stores/auth";
+
+const auth = useAuthStore();
 </script>

--- a/src/views/play/PlayerSettingsView.vue
+++ b/src/views/play/PlayerSettingsView.vue
@@ -10,20 +10,7 @@
       <PlayerSettingsNotifications />
       <PlayerSettingsAppearance />
 
-      <SettingsSection title="Account">
-        <div class="space-y-3">
-          <div class="flex items-center gap-2">
-            <span class="text-caption text-muted-foreground w-16">Email</span>
-            <span class="text-body text-foreground">{{ auth.userEmail ?? '—' }}</span>
-          </div>
-          <RouterLink
-            to="/account"
-            class="inline-block text-label font-semibold text-primary hover:opacity-80 transition-opacity"
-          >
-            Manage account & billing →
-          </RouterLink>
-        </div>
-      </SettingsSection>
+      <AccountSummarySection link-to="/account" link-label="Manage account &amp; billing →" />
 
       <!-- Legal -->
       <div class="flex items-center gap-5 pt-2 pb-6">
@@ -52,7 +39,7 @@
 <script setup lang="ts">
 import { legalUrl } from "@/lib/marketing";
 import PageHeader from "@/components/common/PageHeader.vue";
-import SettingsSection from "@/components/common/SettingsSection.vue";
+import AccountSummarySection from "@/components/account/AccountSummarySection.vue";
 import PlayerSettingsDisplayName from "@/components/play/PlayerSettingsDisplayName.vue";
 import PlayerSettingsInstall from "@/components/play/PlayerSettingsInstall.vue";
 import PlayerSettingsCharacterClaim from "@/components/play/PlayerSettingsCharacterClaim.vue";
@@ -61,7 +48,4 @@ import PlayerSettingsCalendar from "@/components/play/PlayerSettingsCalendar.vue
 import PlayerSettingsNavigation from "@/components/play/PlayerSettingsNavigation.vue";
 import PlayerSettingsNotifications from "@/components/play/PlayerSettingsNotifications.vue";
 import PlayerSettingsAppearance from "@/components/play/PlayerSettingsAppearance.vue";
-import { useAuthStore } from "@/stores/auth";
-
-const auth = useAuthStore();
 </script>

--- a/supabase/functions/_shared/storage-purge.test.ts
+++ b/supabase/functions/_shared/storage-purge.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { listAllFilePaths, chunk, type StorageEntry } from "./storage-purge";
+
+describe("listAllFilePaths", () => {
+  it("returns file paths at the top level only when there are no sub-folders", async () => {
+    const list = async (prefix: string): Promise<StorageEntry[]> => {
+      if (prefix === "user-1") {
+        return [
+          { name: "a.png", id: "1" },
+          { name: "b.png", id: "2" },
+        ];
+      }
+      return [];
+    };
+    await expect(listAllFilePaths(list, "user-1")).resolves.toEqual(["user-1/a.png", "user-1/b.png"]);
+  });
+
+  it("recurses into folders (id === null) to arbitrary depth", async () => {
+    const tree: Record<string, StorageEntry[]> = {
+      "user-1": [
+        { name: "root.png", id: "1" },
+        { name: "mini-1", id: null },
+      ],
+      "user-1/mini-1": [
+        { name: "model.glb", id: "2" },
+        { name: "textures", id: null },
+      ],
+      "user-1/mini-1/textures": [{ name: "diffuse.webp", id: "3" }],
+    };
+    const list = async (prefix: string): Promise<StorageEntry[]> => tree[prefix] ?? [];
+
+    await expect(listAllFilePaths(list, "user-1")).resolves.toEqual([
+      "user-1/root.png",
+      "user-1/mini-1/model.glb",
+      "user-1/mini-1/textures/diffuse.webp",
+    ]);
+  });
+
+  it("returns an empty list for a folder that does not exist", async () => {
+    await expect(listAllFilePaths(async () => [], "user-1")).resolves.toEqual([]);
+  });
+});
+
+describe("chunk", () => {
+  it("splits into groups of at most `size`", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("returns no chunks for an empty array", () => {
+    expect(chunk([], 100)).toEqual([]);
+  });
+
+  it("returns a single chunk when items fit within size", () => {
+    expect(chunk([1, 2], 100)).toEqual([[1, 2]]);
+  });
+});

--- a/supabase/functions/_shared/storage-purge.ts
+++ b/supabase/functions/_shared/storage-purge.ts
@@ -1,0 +1,48 @@
+/**
+ * Recursive "every file under this folder" listing for GDPR account erasure
+ * (#631).
+ *
+ * Supabase Storage's `list()` is one level deep — a sub-folder comes back as
+ * an entry with `id === null` (Supabase's own signal that it's a folder, not
+ * an object) rather than being expanded. Buckets under the `{userId}/` prefix
+ * can nest arbitrarily (e.g. `mini-models/{userId}/{miniId}/model.glb`), so
+ * purging an account has to walk the tree itself.
+ *
+ * The walk is a pure function over an injected `list` callback so it is
+ * unit-testable without a network or a real Supabase client — the same shape
+ * as the rest of `_shared` (see `r2/api.ts`).
+ */
+
+export interface StorageEntry {
+  readonly name: string;
+  /** Supabase Storage's own signal: null means "this is a folder, not a file". */
+  readonly id: string | null;
+}
+
+export type ListFolder = (prefix: string) => Promise<StorageEntry[]>;
+
+/**
+ * Every file path under `prefix`, recursing into sub-folders. `prefix` has no
+ * trailing slash (e.g. `"{userId}"` or `"{userId}/sub"`); returned paths are
+ * bucket-relative, rooted at `prefix`.
+ */
+export async function listAllFilePaths(list: ListFolder, prefix: string): Promise<string[]> {
+  const entries = await list(prefix);
+  const paths: string[] = [];
+  for (const entry of entries) {
+    const path = `${prefix}/${entry.name}`;
+    if (entry.id === null) {
+      paths.push(...(await listAllFilePaths(list, path)));
+    } else {
+      paths.push(path);
+    }
+  }
+  return paths;
+}
+
+/** Split `items` into chunks of at most `size` — Storage's `remove()` takes a bounded list per call. */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size));
+  return chunks;
+}

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -163,7 +163,14 @@ serve(withCors(async (req: Request) => {
     return json({ error: "storage_purge_failed" }, 500);
   }
 
-  const { error: prepareError } = await admin.rpc("prepare_user_erasure", { p_user_id: target.id });
+  // The actor is re-derived here from the verified caller, never from the body:
+  // it is the only record of who erased this account, so a caller-supplied
+  // value would let an admin pin their own deletions on someone else.
+  const { error: prepareError } = await admin.rpc("prepare_user_erasure", {
+    p_user_id: target.id,
+    p_actor_id: caller.id,
+    p_actor_kind: isSelfServe ? "self" : "admin",
+  });
   if (prepareError) {
     console.error("delete-account: prepare_user_erasure failed for user", target.id, prepareError);
     return json({ error: "erasure_preparation_failed" }, 500);

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,179 @@
+// GDPR account deletion (#631) — self-serve and admin-initiated.
+//
+// Deletes the auth.users row (which cascades/set-nulls through every other
+// table per migration 20260808000001) after first purging the user's storage
+// objects in BOTH stores (#577's Supabase-Storage-to-R2 transition means an
+// object can currently live in either) and anonymizing the rows that must
+// survive erasure as billing/dispute evidence
+// (ai_credit_ledger, purchase_consents — see prepare_user_erasure).
+//
+// Storage is purged BEFORE the auth user is deleted, and the whole request
+// fails if any bucket's purge fails: once the user row is gone, an orphaned
+// object with no owner cannot be found by any of our per-user listing paths
+// again, so a partial purge would leave unreachable, undeletable files behind
+// forever. Erasure-preparation and the user delete happen only after a clean
+// purge.
+
+import { serve } from "std/http/server.ts";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { withCors } from "../_shared/cors.ts";
+import { requireAdmin } from "../_shared/requireAdmin.ts";
+import { listAllFilePaths, chunk, type StorageEntry } from "../_shared/storage-purge.ts";
+import { r2ConfigFrom, r2ObjectKey, R2_BUCKET_IDS } from "../_shared/r2/config.ts";
+import { listObjects, deleteObjects } from "../_shared/r2/client.ts";
+
+const admin = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+);
+
+// Supabase Storage's remove() takes a bounded list per call; ~100 keeps each
+// request comfortably sized without adding much round-trip overhead.
+const REMOVE_CHUNK_SIZE = 100;
+// Supabase Storage's list() defaults to 100 rows; page explicitly so a folder
+// with more objects than that doesn't silently lose the tail.
+const LIST_PAGE_SIZE = 1000;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+async function listFolderPaginated(
+  client: SupabaseClient,
+  bucketId: string,
+  prefix: string,
+): Promise<StorageEntry[]> {
+  const entries: StorageEntry[] = [];
+  let offset = 0;
+  for (;;) {
+    const { data, error } = await client.storage.from(bucketId).list(prefix, { limit: LIST_PAGE_SIZE, offset });
+    if (error) throw new Error(error.message);
+    const page = (data ?? []) as StorageEntry[];
+    entries.push(...page);
+    if (page.length < LIST_PAGE_SIZE) break;
+    offset += LIST_PAGE_SIZE;
+  }
+  return entries;
+}
+
+/**
+ * Purge `userId`'s objects from every Supabase Storage bucket. Every bucket
+ * currently registered (`listBuckets()`), not just the ones this repo's
+ * BUCKETS registry knows about — a bucket the app no longer writes to can
+ * still hold objects from before it was retired.
+ */
+async function purgeSupabaseStorage(userId: string): Promise<string[]> {
+  const { data: buckets, error: bucketsError } = await admin.storage.listBuckets();
+  if (bucketsError) return [`listBuckets: ${bucketsError.message}`];
+
+  const errors: string[] = [];
+  for (const bucket of buckets ?? []) {
+    try {
+      const paths = await listAllFilePaths(
+        (prefix) => listFolderPaginated(admin, bucket.id, prefix),
+        userId,
+      );
+      for (const batch of chunk(paths, REMOVE_CHUNK_SIZE)) {
+        const { error } = await admin.storage.from(bucket.id).remove(batch);
+        if (error) errors.push(`${bucket.id}: remove failed: ${error.message}`);
+      }
+    } catch (err) {
+      errors.push(`${bucket.id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return errors;
+}
+
+/**
+ * Purge `userId`'s objects from every R2-backed bucket, mirroring r2-list /
+ * r2-delete. A missing R2 config is not an error — it means this environment
+ * hasn't been provisioned for R2 yet (see r2ConfigFrom), so every object is
+ * still in Supabase Storage and the purge above already covers it.
+ */
+async function purgeR2Storage(userId: string): Promise<string[]> {
+  const config = r2ConfigFrom((key) => Deno.env.get(key));
+  if (!config) return [];
+
+  const errors: string[] = [];
+  for (const bucketId of R2_BUCKET_IDS) {
+    try {
+      const keys = await listObjects(config, r2ObjectKey(bucketId, `${userId}/`));
+      // deleteObjects issues one concurrent DELETE per key (it was written for
+      // ~5-key image removals) — chunk so a large account doesn't fan out
+      // hundreds of simultaneous requests.
+      for (const batch of chunk(keys, REMOVE_CHUNK_SIZE)) {
+        await deleteObjects(config, batch);
+      }
+    } catch (err) {
+      errors.push(`r2:${bucketId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return errors;
+}
+
+serve(withCors(async (req: Request) => {
+  if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) return json({ error: "Unauthorized" }, 401);
+
+  const callerClient = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_ANON_KEY")!,
+    { global: { headers: { Authorization: authHeader } } },
+  );
+  const { data: { user: caller }, error: callerError } = await callerClient.auth.getUser();
+  if (callerError || !caller) return json({ error: "Unauthorized" }, 401);
+
+  let body: { confirm?: unknown; targetUserId?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const requestedTarget = typeof body.targetUserId === "string" ? body.targetUserId : undefined;
+  const targetUserId = requestedTarget && requestedTarget !== caller.id ? requestedTarget : caller.id;
+  const isSelfServe = targetUserId === caller.id;
+
+  if (!isSelfServe) {
+    const gate = await requireAdmin(req);
+    if (gate instanceof Response) return gate;
+  }
+
+  if (body.confirm !== "DELETE") return json({ error: "confirm_required" }, 400);
+
+  const { data: targetData, error: targetError } = await admin.auth.admin.getUserById(targetUserId);
+  if (targetError || !targetData?.user) return json({ error: "user_not_found" }, 404);
+  const target = targetData.user;
+
+  // An admin account must be de-privileged (role changed away from "admin")
+  // before it can be deleted. This also stops an admin nuking their own
+  // account by accident via the self-serve path — self-serve resolves to the
+  // caller's own id, and this check does not distinguish self-serve from
+  // admin-initiated.
+  if (target.app_metadata?.role === "admin") return json({ error: "cannot_delete_admin" }, 400);
+
+  const [supabaseErrors, r2Errors] = await Promise.all([
+    purgeSupabaseStorage(target.id),
+    purgeR2Storage(target.id),
+  ]);
+  const purgeErrors = [...supabaseErrors, ...r2Errors];
+  if (purgeErrors.length > 0) {
+    console.error("delete-account: storage purge failed for user", target.id, purgeErrors);
+    return json({ error: "storage_purge_failed" }, 500);
+  }
+
+  const { error: prepareError } = await admin.rpc("prepare_user_erasure", { p_user_id: target.id });
+  if (prepareError) {
+    console.error("delete-account: prepare_user_erasure failed for user", target.id, prepareError);
+    return json({ error: "erasure_preparation_failed" }, 500);
+  }
+
+  const { error: deleteError } = await admin.auth.admin.deleteUser(target.id);
+  if (deleteError) {
+    console.error("delete-account: deleteUser failed for user", target.id);
+    return json({ error: "deletion_failed" }, 500);
+  }
+
+  return json({ ok: true });
+}));

--- a/supabase/migrations/20260808000001_account_deletion_erasure_path.sql
+++ b/supabase/migrations/20260808000001_account_deletion_erasure_path.sql
@@ -19,6 +19,24 @@ alter table public.ai_credit_ledger
   add constraint ai_credit_ledger_user_id_fkey
     foreign key (user_id) references auth.users (id) on delete set null;
 
+-- Dropping NOT NULL to make SET NULL possible costs the guarantee that every
+-- row is attributable, and null now *means* something ("erased"), so a stray
+-- insert with a null user_id would mint a row that reads as anonymized
+-- evidence while having never belonged to anyone. Recording the erasure as a
+-- fact rather than inferring it from a null closes that: `anonymized_at` says
+-- which reading applies, and the check below rejects rows that claim neither.
+--
+-- Deliberately a CHECK and not a BEFORE INSERT trigger — this is the hot path
+-- (a row per AI generation), and a declarative constraint costs a null test
+-- where a PL/pgSQL trigger costs a function call. The timestamp is also worth
+-- having on its own: Art. 17 compliance is easier to demonstrate with the date
+-- of erasure on the record than with an absence.
+alter table public.ai_credit_ledger add column anonymized_at timestamptz;
+
+alter table public.ai_credit_ledger
+  add constraint ai_credit_ledger_attributable_or_anonymized
+  check (user_id is not null or anonymized_at is not null);
+
 -- The append-only guard (20260804000005) unconditionally blocks UPDATE
 -- because, at the time it was written, no code path ever updated a ledger
 -- row. Account erasure introduces exactly one legitimate UPDATE: the
@@ -37,8 +55,16 @@ begin
   -- Sanctioned exception: the ON DELETE SET NULL write fired by account
   -- erasure (prepare_user_erasure / auth.users delete cascade). Comparing
   -- via to_jsonb minus user_id keeps this robust as columns are added.
+  --
+  -- `anonymized_at` is subtracted alongside it because this trigger is what
+  -- stamps it — it is an output of the sanctioned transition, not part of the
+  -- "nothing else changed" evidence. Stamped after the comparison so a row
+  -- cannot smuggle a value in, and coalesced so a replay keeps the first
+  -- erasure date rather than sliding it forward.
   if new.user_id is null and old.user_id is not null
-     and (to_jsonb(new) - 'user_id') = (to_jsonb(old) - 'user_id') then
+     and (to_jsonb(new) - 'user_id' - 'anonymized_at')
+       = (to_jsonb(old) - 'user_id' - 'anonymized_at') then
+    new.anonymized_at := coalesce(old.anonymized_at, now());
     return new;
   end if;
 
@@ -84,7 +110,123 @@ alter table public.purchase_consents
   add constraint purchase_consents_user_id_fkey
     foreign key (user_id) references auth.users (id) on delete set null;
 
--- ── 3. prepare_user_erasure: the rows no FK cascade/set-null can reach ──────
+alter table public.purchase_consents add column anonymized_at timestamptz;
+
+alter table public.purchase_consents
+  add constraint purchase_consents_attributable_or_anonymized
+  check (user_id is not null or anonymized_at is not null);
+
+-- The ledger stamps `anonymized_at` from its existing append-only guard; this
+-- table has no UPDATE trigger to extend, so it gets a stamp-only one. It is
+-- deliberately not a second append-only guard: making consents immutable is a
+-- behaviour change this migration has no mandate for, and the check above is
+-- what the erasure path actually needs satisfied.
+create or replace function public.purchase_consents_stamp_anonymized()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.user_id is null and old.user_id is not null then
+    new.anonymized_at := coalesce(old.anonymized_at, now());
+  end if;
+  return new;
+end;
+$$;
+
+revoke execute on function public.purchase_consents_stamp_anonymized() from public, anon, authenticated;
+
+create trigger purchase_consents_stamp_anonymized
+  before update on public.purchase_consents
+  for each row execute procedure public.purchase_consents_stamp_anonymized();
+
+-- ── 3a. admin_audit_log ─────────────────────────────────────────────────────
+-- Anonymizing the evidence answers "is this row still personal data"; it does
+-- not answer "who erased this account". Without that second record an admin can
+-- permanently destroy any account and leave no trace — a privileged destructive
+-- action with no audit trail — and nothing satisfies the Art. 5(2) duty to
+-- *demonstrate* that an erasure request was honoured.
+--
+-- This is the table #642 specifies, created here rather than invented as an
+-- erasure-only register: account deletion is simply the most destructive of the
+-- admin actions that ticket enumerates (ban/unban, refunds, credit grants, plan
+-- changes), and a second parallel log would have to be merged away later. #642
+-- keeps the remaining writers and the admin viewer tab; only the table and the
+-- erasure entry land here.
+--
+-- Deliberate departures from the table conventions in CLAUDE.md, because this is
+-- an append-only log rather than user-owned content:
+--   * No `updated_at` column or trigger — a row that may never change has no
+--     meaningful modification time.
+--   * SELECT is admin-only, and there is no INSERT/UPDATE/DELETE policy at all,
+--     so PostgREST exposes no way to write or edit the log. The only writers are
+--     SECURITY DEFINER functions, which bypass RLS.
+--   * `target_user_id` is NOT an FK — for an erasure it names a row that is
+--     about to stop existing, which is the whole point. It is the only
+--     identifier kept: no email, no name. Every row that referred to it has been
+--     nulled, so it is a receipt, not a re-identification route.
+create table public.admin_audit_log (
+  id uuid primary key default gen_random_uuid(),
+  -- Null once the actor is themselves erased; the log outlives its actors. For a
+  -- self-serve deletion the actor *is* the target, so this nulls out and
+  -- `details->>'actor_kind' = 'self'` is what records that.
+  admin_user_id uuid references auth.users (id) on delete set null,
+  action text not null,
+  target_user_id uuid,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index admin_audit_log_target_idx on public.admin_audit_log (target_user_id);
+create index admin_audit_log_created_at_idx on public.admin_audit_log (created_at desc);
+
+alter table public.admin_audit_log enable row level security;
+
+create policy "admin_audit_log_select" on public.admin_audit_log
+  for select using (private.is_app_admin());
+
+-- Append-only, same shape as the ledger guards in 20260804000005: an audit log
+-- an admin can edit is not an audit log.
+create or replace function public.admin_audit_log_guard_write()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Sanctioned exception, and the one that is easy to miss: `admin_user_id` is
+  -- ON DELETE SET NULL, so erasing the actor's own account issues an UPDATE
+  -- here. For a self-serve deletion that lands on the entry written moments
+  -- earlier in the same transaction, so refusing it would make self-serve
+  -- erasure impossible — the same deadlock between an append-only guard and a
+  -- referential action that this migration exists to undo for the ledger.
+  --
+  -- Nested rather than one `and` chain because NEW is unassigned in a DELETE
+  -- trigger and SQL does not promise to short-circuit.
+  if tg_op = 'UPDATE' then
+    if new.admin_user_id is null and old.admin_user_id is not null
+       and (to_jsonb(new) - 'admin_user_id') = (to_jsonb(old) - 'admin_user_id') then
+      return new;
+    end if;
+  end if;
+
+  raise exception 'admin_audit_log is append-only — % on row % is not permitted',
+    tg_op, old.id;
+end;
+$$;
+
+revoke execute on function public.admin_audit_log_guard_write() from public, anon, authenticated;
+
+create trigger admin_audit_log_guard_update
+  before update on public.admin_audit_log
+  for each row execute procedure public.admin_audit_log_guard_write();
+
+create trigger admin_audit_log_guard_delete
+  before delete on public.admin_audit_log
+  for each row execute procedure public.admin_audit_log_guard_write();
+
+-- ── 3b. prepare_user_erasure: the rows no FK cascade/set-null can reach ─────
 -- rate_limit_events has no FK to auth.users at all (by design — it's a
 -- high-volume append-only log, see 20260621000008) so it needs an explicit
 -- delete. storage.objects.owner/owner_id reference the uploader but are not
@@ -97,17 +239,56 @@ alter table public.purchase_consents
 -- runs with elevated privilege and does destructive, unscoped-by-RLS work,
 -- so only service_role (the delete-account edge function, after it has
 -- already verified the caller is the account owner or an admin) may invoke
--- it — never a client-supplied identity.
-create or replace function public.prepare_user_erasure(p_user_id uuid)
+-- it — never a client-supplied identity. The actor arguments are trusted for
+-- the same reason and only that reason: service_role is the edge function,
+-- which derives them from the verified JWT, never from the request body.
+create or replace function public.prepare_user_erasure(
+  p_user_id uuid,
+  p_actor_id uuid,
+  p_actor_kind text
+)
 returns void
 language plpgsql
 security definer
 set search_path = public
 as $$
+declare
+  v_ledger_rows integer;
+  v_consent_rows integer;
 begin
   if coalesce(auth.jwt() ->> 'role', '') <> 'service_role' then
     raise exception 'prepare_user_erasure can only be called by service_role';
   end if;
+
+  if p_actor_kind not in ('self', 'admin') then
+    raise exception 'prepare_user_erasure: actor_kind must be self or admin, got %', p_actor_kind;
+  end if;
+
+  if p_actor_kind = 'self' and p_actor_id is distinct from p_user_id then
+    raise exception 'prepare_user_erasure: a self erasure must be performed by its own account';
+  end if;
+
+  -- Counted before the auth delete, which is what actually nulls them.
+  select count(*) into v_ledger_rows
+  from public.ai_credit_ledger where user_id = p_user_id;
+
+  select count(*) into v_consent_rows
+  from public.purchase_consents where user_id = p_user_id;
+
+  -- Written before the destructive work, not after: if anything below fails the
+  -- transaction unwinds and no log row survives, whereas logging afterwards
+  -- would lose the record of a partial erasure.
+  insert into public.admin_audit_log (admin_user_id, action, target_user_id, details)
+  values (
+    p_actor_id,
+    'account_erasure',
+    p_user_id,
+    jsonb_build_object(
+      'actor_kind', p_actor_kind,
+      'ledger_rows_anonymized', v_ledger_rows,
+      'consent_rows_anonymized', v_consent_rows
+    )
+  );
 
   delete from public.rate_limit_events where user_id = p_user_id;
 
@@ -117,8 +298,8 @@ begin
 end;
 $$;
 
-revoke execute on function public.prepare_user_erasure(uuid) from public, anon, authenticated;
-grant  execute on function public.prepare_user_erasure(uuid) to service_role;
+revoke execute on function public.prepare_user_erasure(uuid, uuid, text) from public, anon, authenticated;
+grant  execute on function public.prepare_user_erasure(uuid, uuid, text) to service_role;
 
 -- ── 4. Defensive check: no FK to auth.users left that would block a delete ──
 -- Fails the push (rather than failing silently at the next real account

--- a/supabase/migrations/20260808000001_account_deletion_erasure_path.sql
+++ b/supabase/migrations/20260808000001_account_deletion_erasure_path.sql
@@ -1,0 +1,142 @@
+-- Migration: account_deletion_erasure_path
+-- Unblocks GDPR account erasure (#631): billing evidence is anonymized instead
+-- of blocking the delete, and a service-role helper handles the rows no FK
+-- cascade can reach.
+--
+-- ── 1. ai_credit_ledger: retain, anonymize (Art. 17(3)(b) GDPR + Dutch 7-year
+--       bookkeeping duty) ───────────────────────────────────────────────────
+-- The ledger is billing/tax evidence, not personal-preference data — Art.
+-- 17(3)(b) exempts erasure where retention is needed for legal obligations,
+-- and Dutch bookkeeping law (Belastingdienst, art. 52 AWR) requires 7 years.
+-- So deleting the account must not delete these rows: user_id becomes
+-- nullable and the FK moves from CASCADE to SET NULL. All other columns
+-- (delta, reason, amounts, timestamps) are untouched — the row keeps its
+-- evidentiary value, just stripped of the identifying link.
+alter table public.ai_credit_ledger alter column user_id drop not null;
+
+alter table public.ai_credit_ledger
+  drop constraint ai_credit_ledger_user_id_fkey,
+  add constraint ai_credit_ledger_user_id_fkey
+    foreign key (user_id) references auth.users (id) on delete set null;
+
+-- The append-only guard (20260804000005) unconditionally blocks UPDATE
+-- because, at the time it was written, no code path ever updated a ledger
+-- row. Account erasure introduces exactly one legitimate UPDATE: the
+-- ON DELETE SET NULL write above nulling user_id on a settled row. Widen the
+-- guard to sanction that one transition and nothing else — every other
+-- column must be byte-for-byte identical, which the to_jsonb diff enforces
+-- and keeps correct as columns are added later. The DELETE guard is
+-- untouched: settled rows still can never be removed, only anonymized.
+create or replace function public.ai_credit_ledger_guard_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Sanctioned exception: the ON DELETE SET NULL write fired by account
+  -- erasure (prepare_user_erasure / auth.users delete cascade). Comparing
+  -- via to_jsonb minus user_id keeps this robust as columns are added.
+  if new.user_id is null and old.user_id is not null
+     and (to_jsonb(new) - 'user_id') = (to_jsonb(old) - 'user_id') then
+    return new;
+  end if;
+
+  raise exception 'ai_credit_ledger is append-only — row % cannot be updated', old.id;
+end;
+$$;
+
+-- 20260804000009 let account deletion through the DELETE guard by exempting
+-- rows whose parent auth row is already gone (the ON DELETE CASCADE case).
+-- With the FK now SET NULL, erasure no longer deletes ledger rows at all —
+-- and that exemption would make every anonymized row (user_id null ⇒ "parent
+-- absent") freely deletable afterwards, quietly un-doing the append-only
+-- guarantee for exactly the rows we retain as evidence. Restore the strict
+-- guard: only pending reservation holds may ever be deleted.
+create or replace function public.ai_credit_ledger_guard_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Sanctioned exception: releasing a still-pending reservation hold
+  -- (reserve_credits/release_credits, the release-stale-credit-holds cron —
+  -- both delete only `pending = true` rows). A settled row must never be
+  -- removed, only anonymized via the SET NULL erasure path above.
+  if old.pending then
+    return old;
+  end if;
+  raise exception 'ai_credit_ledger is append-only — settled row % cannot be deleted', old.id;
+end;
+$$;
+
+revoke execute on function public.ai_credit_ledger_guard_delete() from public, anon, authenticated;
+
+-- ── 2. purchase_consents: retain, anonymize ─────────────────────────────────
+-- Same rationale as the ledger: this table's entire purpose is dispute
+-- evidence for a purchase (the stripe_session_id keeps the evidentiary link
+-- to Stripe), so erasure anonymizes rather than deletes.
+alter table public.purchase_consents alter column user_id drop not null;
+
+alter table public.purchase_consents
+  drop constraint purchase_consents_user_id_fkey,
+  add constraint purchase_consents_user_id_fkey
+    foreign key (user_id) references auth.users (id) on delete set null;
+
+-- ── 3. prepare_user_erasure: the rows no FK cascade/set-null can reach ──────
+-- rate_limit_events has no FK to auth.users at all (by design — it's a
+-- high-volume append-only log, see 20260621000008) so it needs an explicit
+-- delete. storage.objects.owner/owner_id reference the uploader but are not
+-- enforced FKs to auth.users either; any row still pointing at the deleted
+-- user after the storage purge (e.g. this account made an admin upload under
+-- the shared srd/ prefix) would otherwise dangle and could block reasoning
+-- about the delete, so it's nulled defensively.
+--
+-- SECURITY DEFINER rule (CLAUDE.md): first act is authorization. This RPC
+-- runs with elevated privilege and does destructive, unscoped-by-RLS work,
+-- so only service_role (the delete-account edge function, after it has
+-- already verified the caller is the account owner or an admin) may invoke
+-- it — never a client-supplied identity.
+create or replace function public.prepare_user_erasure(p_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if coalesce(auth.jwt() ->> 'role', '') <> 'service_role' then
+    raise exception 'prepare_user_erasure can only be called by service_role';
+  end if;
+
+  delete from public.rate_limit_events where user_id = p_user_id;
+
+  update storage.objects
+  set owner = null, owner_id = null
+  where owner = p_user_id or owner_id = p_user_id::text;
+end;
+$$;
+
+revoke execute on function public.prepare_user_erasure(uuid) from public, anon, authenticated;
+grant  execute on function public.prepare_user_erasure(uuid) to service_role;
+
+-- ── 4. Defensive check: no FK to auth.users left that would block a delete ──
+-- Fails the push (rather than failing silently at the next real account
+-- deletion) if a future migration adds a FK to auth.users without CASCADE or
+-- SET NULL. Scoped to public — Supabase-managed schemas (auth, storage) are
+-- not ours to police here, version-drift in them must not brick a deploy, and
+-- the one that matters (storage.objects.owner) is already handled by
+-- prepare_user_erasure nulling it before the delete.
+do $$
+declare bad text;
+begin
+  select string_agg(conrelid::regclass::text || '.' || conname, ', ') into bad
+  from pg_constraint
+  where contype = 'f' and confrelid = 'auth.users'::regclass
+    and confdeltype not in ('c', 'n')
+    and conrelid in (select oid from pg_class where relnamespace = 'public'::regnamespace);
+
+  if bad is not null then
+    raise exception 'FKs to auth.users would block account deletion: %', bad;
+  end if;
+end $$;

--- a/supabase/tests/ai_compliance_regressions.test.sql
+++ b/supabase/tests/ai_compliance_regressions.test.sql
@@ -1,7 +1,7 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(8);
+select plan(9);
 
 insert into auth.users (id, instance_id, aud, role, email, encrypted_password, raw_app_meta_data, raw_user_meta_data)
 values
@@ -55,7 +55,7 @@ $$, 'P0001', null, 'settled ledger rows remain protected from direct deletion');
 select lives_ok($$
   delete from auth.users
   where id = '68000000-0000-4000-8000-000000000003'
-$$, 'account deletion may cascade through settled ledger rows');
+$$, 'account deletion may proceed despite settled ledger rows');
 
 select is(
   (select count(*)::integer from auth.users where id = '68000000-0000-4000-8000-000000000003'),
@@ -66,7 +66,14 @@ select is(
 select is(
   (select count(*)::integer from public.ai_credit_ledger where user_id = '68000000-0000-4000-8000-000000000003'),
   0,
-  'the account cascade removes its ledger rows'
+  'no ledger row remains linked to the deleted account'
+);
+
+select is(
+  (select count(*)::integer from public.ai_credit_ledger
+   where id = '68000000-0000-4000-8000-000000000030' and user_id is null and delta = 10),
+  1,
+  'the settled row survives erasure anonymized — billing evidence is retained, not cascaded away'
 );
 
 select * from finish();

--- a/supabase/tests/ai_compliance_regressions.test.sql
+++ b/supabase/tests/ai_compliance_regressions.test.sql
@@ -1,13 +1,14 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(9);
+select plan(20);
 
 insert into auth.users (id, instance_id, aud, role, email, encrypted_password, raw_app_meta_data, raw_user_meta_data)
 values
   ('68000000-0000-4000-8000-000000000001', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'ai-fix-owner@example.invalid', '', '{}'::jsonb, '{}'::jsonb),
   ('68000000-0000-4000-8000-000000000002', '00000000-0000-0000-8000-000000000000', 'authenticated', 'authenticated', 'ai-fix-player@example.invalid', '', '{}'::jsonb, '{}'::jsonb),
-  ('68000000-0000-4000-8000-000000000003', '00000000-0000-0000-8000-000000000000', 'authenticated', 'authenticated', 'ai-fix-ledger@example.invalid', '', '{}'::jsonb, '{}'::jsonb);
+  ('68000000-0000-4000-8000-000000000003', '00000000-0000-0000-8000-000000000000', 'authenticated', 'authenticated', 'ai-fix-ledger@example.invalid', '', '{}'::jsonb, '{}'::jsonb),
+  ('68000000-0000-4000-8000-000000000004', '00000000-0000-0000-8000-000000000000', 'authenticated', 'authenticated', 'ai-fix-selfserve@example.invalid', '', '{}'::jsonb, '{}'::jsonb);
 
 insert into public.campaigns (id, user_id, name)
 values ('68000000-0000-4000-8000-000000000010', '68000000-0000-4000-8000-000000000001', 'AI compliance regression test');
@@ -52,6 +53,30 @@ select throws_ok($$
   where id = '68000000-0000-4000-8000-000000000030'
 $$, 'P0001', null, 'settled ledger rows remain protected from direct deletion');
 
+-- auth.jwt() reads the whole claims blob, not the per-claim GUCs the RLS tests
+-- above use, so the service_role gate needs `request.jwt.claims` set as JSON.
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+-- The actor is the only record of who erased an account, so "self" must really
+-- mean self — an admin cannot file their deletion as the user's own request.
+select throws_ok($$
+  select public.prepare_user_erasure(
+    '68000000-0000-4000-8000-000000000003',
+    '68000000-0000-4000-8000-000000000001',
+    'self'
+  )
+$$, 'P0001', null, 'a self erasure attributed to a different account is refused');
+
+select lives_ok($$
+  select public.prepare_user_erasure(
+    '68000000-0000-4000-8000-000000000003',
+    '68000000-0000-4000-8000-000000000001',
+    'admin'
+  )
+$$, 'an admin may prepare another account for erasure');
+
+select set_config('request.jwt.claims', '', true);
+
 select lives_ok($$
   delete from auth.users
   where id = '68000000-0000-4000-8000-000000000003'
@@ -74,6 +99,87 @@ select is(
    where id = '68000000-0000-4000-8000-000000000030' and user_id is null and delta = 10),
   1,
   'the settled row survives erasure anonymized — billing evidence is retained, not cascaded away'
+);
+
+-- Erasure is a recorded fact, not an inference from a null: without the stamp
+-- an unattributable row and an erased one are indistinguishable.
+select isnt(
+  (select anonymized_at from public.ai_credit_ledger
+   where id = '68000000-0000-4000-8000-000000000030'),
+  null,
+  'the anonymized row records when it was erased'
+);
+
+-- The other half of that guarantee: nothing may enter the table already
+-- looking erased. This is what dropping NOT NULL would otherwise have allowed.
+select throws_ok($$
+  insert into public.ai_credit_ledger (user_id, delta, reason, pending)
+  values (null, 5, 'orphan_grant', false)
+$$, '23514', null, 'a ledger row that is neither attributable nor anonymized is rejected');
+
+select throws_ok($$
+  insert into public.purchase_consents (user_id, purpose, consent_version, stripe_session_id)
+  values (null, 'credit_pack', 'v1', 'cs_test_orphan')
+$$, '23514', null, 'a consent row that is neither attributable nor anonymized is rejected');
+
+-- Who erased the account (#642). The admin survives the deletion, so their id is
+-- still on the entry; the target's is kept deliberately, as the receipt.
+select is(
+  (select count(*)::integer from public.admin_audit_log
+   where action = 'account_erasure'
+     and target_user_id = '68000000-0000-4000-8000-000000000003'
+     and admin_user_id = '68000000-0000-4000-8000-000000000001'
+     and details ->> 'actor_kind' = 'admin'
+     and (details ->> 'ledger_rows_anonymized')::integer = 1),
+  1,
+  'the erasure is recorded against the admin who performed it'
+);
+
+-- An audit log an admin can edit is not an audit log.
+select throws_ok($$
+  update public.admin_audit_log set action = 'something_else'
+  where target_user_id = '68000000-0000-4000-8000-000000000003'
+$$, 'P0001', null, 'audit entries cannot be rewritten');
+
+select throws_ok($$
+  delete from public.admin_audit_log
+  where target_user_id = '68000000-0000-4000-8000-000000000003'
+$$, 'P0001', null, 'audit entries cannot be deleted');
+
+-- ── Self-serve erasure ──────────────────────────────────────────────────────
+-- The actor is the target here, so deleting them fires ON DELETE SET NULL on
+-- the audit entry written moments earlier — an UPDATE, straight into the
+-- append-only guard. If that transition is not sanctioned, self-serve account
+-- deletion fails outright, so this covers the guard's exception rather than
+-- just its refusal.
+insert into public.ai_credit_ledger (id, user_id, delta, reason, pending)
+values ('68000000-0000-4000-8000-000000000031', '68000000-0000-4000-8000-000000000004', 4, 'test_grant', false);
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+select lives_ok($$
+  select public.prepare_user_erasure(
+    '68000000-0000-4000-8000-000000000004',
+    '68000000-0000-4000-8000-000000000004',
+    'self'
+  )
+$$, 'an account may prepare its own erasure');
+
+select set_config('request.jwt.claims', '', true);
+
+select lives_ok($$
+  delete from auth.users
+  where id = '68000000-0000-4000-8000-000000000004'
+$$, 'self-serve deletion survives the audit entry naming the deleted account as actor');
+
+select is(
+  (select count(*)::integer from public.admin_audit_log
+   where action = 'account_erasure'
+     and target_user_id = '68000000-0000-4000-8000-000000000004'
+     and admin_user_id is null
+     and details ->> 'actor_kind' = 'self'),
+  1,
+  'the entry outlives its actor — actor_kind is what still says who did it'
 );
 
 select * from finish();


### PR DESCRIPTION
Implements #631 (part of epic #646): self-serve and admin account deletion, with billing evidence retained **anonymized** instead of either blocking the delete or cascading the evidence away.

## The design decision

`20260804000005` made the credit ledger append-only, which blocked the `auth.users` cascade; `20260804000009` unblocked it by exempting rows whose parent auth row is gone — which meant an account deletion would silently **destroy** the settled billing rows #609 decided are kept indefinitely as dispute evidence. This PR supersedes both readings with the shape GDPR actually wants (Art. 17(3)(b) + Dutch 7-year bookkeeping): `ai_credit_ledger` and `purchase_consents` move to `ON DELETE SET NULL`, the UPDATE guard sanctions exactly that anonymization transition (via a `to_jsonb` minus-`user_id` diff, robust to future columns), and the DELETE guard is restored to strict pending-only — the `20260804000009` parent-absent exemption would otherwise have made every anonymized row freely deletable.

## What's in here

**Migration `20260808000001_account_deletion_erasure_path.sql`**
- FK + guard changes above, for both evidence tables
- `prepare_user_erasure(uuid)` (service-role only, per the CLAUDE.md SECURITY DEFINER rules): deletes `rate_limit_events` rows (no FK) and nulls `storage.objects.owner/owner_id` remnants
- A push-time assertion that no `public` FK to `auth.users` lacks CASCADE/SET NULL — a future migration that would re-block deletion fails its own deploy instead of failing at the next erasure request

**Edge function `delete-account`**
- Self-serve (caller deletes self) and admin (`targetUserId` + `requireAdmin`) paths; `confirm: "DELETE"` gate; admin accounts refused (`cannot_delete_admin` — de-privilege first)
- Purges the user's storage in **both** stores (every Supabase bucket via recursive listing + chunked `remove()`; every R2-backed bucket via prefix list + chunked deletes) **before** touching the auth user — a half-purged account is never deleted
- Then `prepare_user_erasure` → `auth.admin.deleteUser` (cascades/set-nulls do the rest)

**UI — universal `/account` page**
- Account settings are account-level, not role-level (every user holds the free DM plan from signup), so the deletion UI lives on a new **`/account` route** (`requiresAuth`, no role gate — same pattern as `/billing`): email, Billing & Subscription link, and the danger zone (type-DELETE confirm via `ConfirmByNameInput`, which gained a `disabled` prop; destructive `AppButton`; honest copy about owned campaigns being deleted and billing records kept anonymized)
- DM sidebar account popover gains an **Account** link; Player Settings keeps an email row and links through with "Manage account & billing →" — the deletion UI has exactly one owner
- Admin users tab: Delete action with confirm dialog; errors surfaced inline
- Shared `useAccountDeletion` composable + 8 unit tests

**Tests**
- `supabase/tests/ai_compliance_regressions.test.sql` updated to pin the new invariant: auth delete succeeds, no ledger row stays linked, and the settled row **survives anonymized** (plan 8 → 9)
- New `_shared/storage-purge` helper with colocated vitest coverage

## Checks

- `npm run lint` ✅ · `npx vue-tsc -b` ✅ · `npx vitest run` ✅ 224 files / 2565 tests · `npx vite build` ✅

## Post-merge steps (can't be done from this session — no supabase CLI/MCP here)

- [ ] `supabase db push` applies the migration (CI's `supabase test db` exercises it on this PR)
- [ ] Run `get_advisors({ type: "security" })` and resolve any new findings (new SECURITY DEFINER function `prepare_user_erasure`)

Closes #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pv5Ckn8UXa2go7cSjcmgu

---
_Generated by [Claude Code](https://claude.ai/code/session_011pv5Ckn8UXa2go7cSjcmgu)_